### PR TITLE
feat(github-mcp): GITHUB_DEFAULT_LABELS env var for auto-applied labels

### DIFF
--- a/apps/github-mcp/src/server.ts
+++ b/apps/github-mcp/src/server.ts
@@ -12,6 +12,20 @@ export interface Env {
    * Optional — without it, every tool call must pass `repo`.
    */
   GITHUB_DEFAULT_REPO?: string;
+  /**
+   * Comma-separated label names automatically applied to every issue created
+   * via `github_create_issue`. Merged with caller-supplied labels (deduped).
+   * Optional — empty/unset means no default labels.
+   */
+  GITHUB_DEFAULT_LABELS?: string;
+}
+
+function parseDefaultLabels(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 export function buildServer(env: Env): McpServer {
@@ -21,7 +35,7 @@ export function buildServer(env: Env): McpServer {
   });
 
   const client = new GitHubClient(env.GITHUB_TOKEN);
-  registerAllTools(server, client, env.GITHUB_DEFAULT_REPO);
+  registerAllTools(server, client, env.GITHUB_DEFAULT_REPO, parseDefaultLabels(env.GITHUB_DEFAULT_LABELS));
 
   return server;
 }

--- a/apps/github-mcp/src/tools/index.ts
+++ b/apps/github-mcp/src/tools/index.ts
@@ -10,8 +10,9 @@ export function registerAllTools(
   server: McpServer,
   client: GitHubClient,
   defaultRepo: string | undefined,
+  defaultLabels: string[],
 ): void {
-  registerIssueTools(server, client, defaultRepo);
+  registerIssueTools(server, client, defaultRepo, defaultLabels);
   registerCommentTools(server, client, defaultRepo);
   registerLabelTools(server, client, defaultRepo);
   registerAssigneeTools(server, client, defaultRepo);

--- a/apps/github-mcp/src/tools/issues.ts
+++ b/apps/github-mcp/src/tools/issues.ts
@@ -12,7 +12,13 @@ export function registerIssueTools(
   server: McpServer,
   client: GitHubClient,
   defaultRepo: string | undefined,
+  defaultLabels: string[],
 ): void {
+  const createIssueLabelsDesc =
+    defaultLabels.length > 0
+      ? `Label names to apply. Merged with deployment defaults [${defaultLabels.join(", ")}] (deduped).`
+      : "Label names to apply.";
+
   server.tool(
     "github_create_issue",
     "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional.",
@@ -20,18 +26,19 @@ export function registerIssueTools(
       repo: repoArg,
       title: z.string().min(1).describe("Issue title."),
       body: z.string().optional().describe("Markdown body."),
-      labels: z.array(z.string()).optional().describe("Label names to apply."),
+      labels: z.array(z.string()).optional().describe(createIssueLabelsDesc),
       assignees: z.array(z.string()).optional().describe("GitHub usernames to assign."),
       milestone: z.number().int().optional().describe("Milestone number (not title)."),
     },
     async ({ repo, title, body, labels, assignees, milestone }) => {
       const r = resolveRepo(repo, defaultRepo);
       if ("error" in r) return r.error;
+      const mergedLabels = Array.from(new Set([...defaultLabels, ...(labels ?? [])]));
       try {
         const issue = await client.post<unknown>(`/repos/${r.owner}/${r.repo}/issues`, {
           title,
           ...(body !== undefined ? { body } : {}),
-          ...(labels ? { labels } : {}),
+          ...(mergedLabels.length > 0 ? { labels: mergedLabels } : {}),
           ...(assignees ? { assignees } : {}),
           ...(milestone !== undefined ? { milestone } : {}),
         });


### PR DESCRIPTION
## Summary
- Adds optional \`GITHUB_DEFAULT_LABELS\` env var to \`github-mcp\` (comma-separated label names).
- \`github_create_issue\` merges the env-configured defaults with caller-supplied labels and dedupes.
- Tool description for the \`labels\` arg surfaces the active defaults so callers know what's being applied.

## Why
Per \`CLAUDE.md\`, \`claude-task\` is the queue-filter label for Claude.ai-filed issues, but Claude.ai was not consistently adding it (all 8 current oura-mcp issues are missing it). Pushing the default into the Worker's env makes the queue convention enforceable at the deployment layer rather than the model's discretion.

## Deployment step (user)
After merge, set the secret on the deployed Worker:
\`\`\`
cd apps/github-mcp
echo -n "claude-task" | pnpm wrangler secret put GITHUB_DEFAULT_LABELS
pnpm wrangler deploy
\`\`\`

## Test plan
- [x] \`pnpm -r type-check\` passes
- [x] \`claude-task\` label created on repo and backfilled on issues #1–#8
- [ ] After deploy, confirm a new \`github_create_issue\` call (no \`labels\` arg) produces an issue tagged \`claude-task\`
- [ ] Confirm passing explicit \`labels: ["bug"]\` produces an issue tagged \`claude-task, bug\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)