### PR TITLE
[oura-mcp] add 3 illness/respiratory analytical tools

### DIFF
--- a/apps/oura-mcp/src/tools/illness_signals.ts
+++ b/apps/oura-mcp/src/tools/illness_signals.ts
@@ -1,0 +1,267 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OuraClient } from "../oura/client.js";
+import { OuraApiError } from "../oura/client.js";
+import { getDailyReadiness } from "../oura/endpoints.js";
+import { addDays, fetchMetricByDay } from "../oura/metrics.js";
+import {
+  defined,
+  mean,
+  stddev,
+  zScore,
+  percentileFromZ,
+} from "../oura/stats.js";
+import { textContent, errorContent, todayInTz } from "./utils.js";
+
+type TempStatus = "normal" | "elevated" | "febrile";
+type ExertionCeiling = "rest" | "zone_2_only" | "moderate" | "unrestricted";
+
+interface MetricVsBaseline {
+  value: number | null;
+  baseline_mean: number | null;
+  delta_pct: number | null;
+}
+
+/**
+ * Resolve the most recent date <= target with a non-null value in `series`.
+ * Returns null when nothing in series is present.
+ */
+function resolveLatest(
+  series: Map<string, number | null>,
+  target: string,
+): { date: string; value: number } | null {
+  const sortedDays = [...series.keys()].sort();
+  for (let i = sortedDays.length - 1; i >= 0; i--) {
+    const day = sortedDays[i] as string;
+    if (day > target) continue;
+    const v = series.get(day);
+    if (v !== null && v !== undefined && Number.isFinite(v)) {
+      return { date: day, value: v };
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute baseline mean over a window ending the day BEFORE refDate, looking
+ * back `windowDays` days. Excludes refDate itself.
+ */
+async function rawWithBaseline(
+  client: OuraClient,
+  metric: "hrv" | "rhr" | "respiratory_rate",
+  refDate: string,
+  baselineWindowDays: number,
+  fallback: "strict" | "latest",
+): Promise<MetricVsBaseline> {
+  const baselineStart = addDays(refDate, -baselineWindowDays);
+  const baselineEnd = addDays(refDate, -1);
+
+  const baselineSeries = await fetchMetricByDay(client, metric, baselineStart, baselineEnd);
+  const todaySeries = await fetchMetricByDay(client, metric, refDate, refDate);
+
+  let value: number | null = todaySeries.get(refDate) ?? null;
+  if (value === null && fallback === "latest") {
+    // Fall back to the most recent baseline day with data.
+    const latest = resolveLatest(baselineSeries, refDate);
+    if (latest) value = latest.value;
+  }
+
+  const baselineVals = defined([...baselineSeries.values()]);
+  const baselineMean = baselineVals.length > 0 ? mean(baselineVals) : null;
+  let deltaPct: number | null = null;
+  if (value !== null && baselineMean !== null && baselineMean !== 0) {
+    deltaPct = ((value - baselineMean) / baselineMean) * 100;
+  }
+  return { value, baseline_mean: baselineMean, delta_pct: deltaPct };
+}
+
+function classifyTemp(dev: number | null): TempStatus | null {
+  if (dev === null) return null;
+  const abs = Math.abs(dev);
+  if (dev > 0.8) return "febrile";
+  if (dev > 0.3) return "elevated";
+  if (abs <= 0.3) return "normal";
+  // dev <= -0.3 (cold deviation) — treat as normal status (no illness signal).
+  return "normal";
+}
+
+function decideExertionCeiling(
+  tempStatus: TempStatus | null,
+  respDeltaPct: number | null,
+  hrvDeltaPct: number | null,
+  rhrDeltaPct: number | null,
+  readinessScore: number | null,
+): { ceiling: ExertionCeiling; signals: string[] } {
+  const signals: string[] = [];
+
+  if (tempStatus === "febrile") signals.push("temperature_febrile");
+  if (respDeltaPct !== null && respDeltaPct > 20) signals.push("respiratory_rate_high_+20pct");
+  const restTrigger = tempStatus === "febrile" || (respDeltaPct !== null && respDeltaPct > 20);
+
+  if (tempStatus === "elevated") signals.push("temperature_elevated");
+  if (respDeltaPct !== null && respDeltaPct > 10 && respDeltaPct <= 20) {
+    signals.push("respiratory_rate_high_+10pct");
+  }
+  if (readinessScore !== null && readinessScore < 50) signals.push("readiness_low");
+  const zone2Trigger =
+    tempStatus === "elevated" ||
+    (respDeltaPct !== null && respDeltaPct > 10) ||
+    (readinessScore !== null && readinessScore < 50);
+
+  if (hrvDeltaPct !== null && hrvDeltaPct < -25) signals.push("hrv_drop_-25pct");
+  if (rhrDeltaPct !== null && rhrDeltaPct > 10) signals.push("rhr_high_+10pct");
+  const moderateTrigger =
+    (hrvDeltaPct !== null && hrvDeltaPct < -25) ||
+    (rhrDeltaPct !== null && rhrDeltaPct > 10);
+
+  let ceiling: ExertionCeiling;
+  if (restTrigger) ceiling = "rest";
+  else if (zone2Trigger) ceiling = "zone_2_only";
+  else if (moderateTrigger) ceiling = "moderate";
+  else ceiling = "unrestricted";
+
+  return { ceiling, signals };
+}
+
+export function registerIllnessSignalsTool(server: McpServer, client: OuraClient): void {
+  server.tool(
+    "oura_illness_signals",
+    "Composite illness/recovery signal report for a single day. Aggregates body " +
+      "temperature deviation, respiratory rate, HRV, RHR, and readiness score (each " +
+      "compared to a 30-day rolling baseline that excludes the target date itself) " +
+      "and emits a recommended exertion ceiling. " +
+      "Temperature thresholds: |dev| <= 0.3°C => normal; dev > 0.3°C => elevated; " +
+      "dev > 0.8°C => febrile. " +
+      "Exertion ceiling rules: " +
+      "(1) febrile temperature OR respiratory rate >+20% vs baseline => rest; " +
+      "(2) elevated temperature OR respiratory rate >+10% OR readiness_score < 50 => zone_2_only; " +
+      "(3) HRV < -25% vs baseline OR RHR > +10% vs baseline => moderate; " +
+      "(4) otherwise => unrestricted. " +
+      "fallback='latest' (default) reuses the most recent prior day with data when the target date is missing; fallback='strict' returns nulls for missing data.",
+    {
+      date: z
+        .string()
+        .optional()
+        .describe("YYYY-MM-DD target date. Default: today (America/Los_Angeles)."),
+      fallback: z
+        .enum(["strict", "latest"])
+        .optional()
+        .describe(
+          "How to handle a target date with no data. 'latest' (default) reuses the most recent baseline-window day with data; 'strict' reports nulls.",
+        ),
+      baseline_window_days: z
+        .number()
+        .int()
+        .min(7)
+        .max(180)
+        .optional()
+        .describe("Rolling baseline length, excluding the target date. Default 30."),
+    },
+    async ({ date, fallback, baseline_window_days }) => {
+      const target = date ?? todayInTz();
+      const fb: "strict" | "latest" = fallback ?? "latest";
+      const windowDays = baseline_window_days ?? 30;
+
+      try {
+        // Pull daily readiness across baseline + target to get temperature_deviation,
+        // readiness score, and 30d readiness percentile.
+        const baselineStart = addDays(target, -windowDays);
+        const baselineEnd = addDays(target, -1);
+        const readinessAll = await getDailyReadiness(client, {
+          start_date: baselineStart,
+          end_date: target,
+        });
+
+        // Build per-day maps for readiness score + temperature_deviation.
+        const scoreByDay = new Map<string, number | null>();
+        const tempDevByDay = new Map<string, number | null>();
+        for (const r of readinessAll) {
+          scoreByDay.set(r.day, r.score);
+          tempDevByDay.set(r.day, r.temperature_deviation);
+        }
+
+        // Resolve target-day values, with optional fallback.
+        let targetReadiness = scoreByDay.get(target) ?? null;
+        let resolvedDate = target;
+        if (targetReadiness === null && fb === "latest") {
+          const latest = resolveLatest(scoreByDay, target);
+          if (latest) {
+            targetReadiness = latest.value;
+            resolvedDate = latest.date;
+          }
+        }
+        let tempDev = tempDevByDay.get(resolvedDate) ?? null;
+        if (tempDev === null && fb === "latest") {
+          const latest = resolveLatest(tempDevByDay, target);
+          if (latest) tempDev = latest.value;
+        }
+
+        // 30d readiness percentile: z-score of target's score against baseline scores.
+        const baselineScores: number[] = [];
+        for (const [day, val] of scoreByDay) {
+          if (day >= target) continue;
+          if (val !== null && Number.isFinite(val)) baselineScores.push(val);
+        }
+        let readinessPercentile30d: number | null = null;
+        if (targetReadiness !== null && baselineScores.length >= 2) {
+          const mu = mean(baselineScores);
+          const sigma = stddev(baselineScores, mu);
+          if (sigma > 0) {
+            readinessPercentile30d = percentileFromZ(zScore(targetReadiness, mu, sigma));
+          }
+        }
+
+        // Raw + baseline for HRV / RHR / respiratory rate.
+        const [resp, hrv, rhr] = await Promise.all([
+          rawWithBaseline(client, "respiratory_rate", target, windowDays, fb),
+          rawWithBaseline(client, "hrv", target, windowDays, fb),
+          rawWithBaseline(client, "rhr", target, windowDays, fb),
+        ]);
+
+        const tempStatus = classifyTemp(tempDev);
+        const { ceiling, signals } = decideExertionCeiling(
+          tempStatus,
+          resp.delta_pct,
+          hrv.delta_pct,
+          rhr.delta_pct,
+          targetReadiness,
+        );
+
+        const result: Record<string, unknown> = {
+          date: target,
+          resolved_date: resolvedDate !== target ? resolvedDate : undefined,
+          fallback: fb,
+          body_temperature_deviation_c: tempDev,
+          temperature_status: tempStatus,
+          respiratory_rate: {
+            value: resp.value,
+            baseline_mean: resp.baseline_mean,
+            delta_pct: resp.delta_pct,
+          },
+          hrv_ms: {
+            value: hrv.value,
+            baseline_mean: hrv.baseline_mean,
+            delta_pct: hrv.delta_pct,
+          },
+          rhr_bpm: {
+            value: rhr.value,
+            baseline_mean: rhr.baseline_mean,
+            delta_pct: rhr.delta_pct,
+          },
+          readiness_score: targetReadiness,
+          readiness_percentile_30d: readinessPercentile30d,
+          exertion_ceiling: ceiling,
+          signals_triggered: signals,
+          baseline_window_days: windowDays,
+        };
+        // Strip undefined resolved_date for cleanliness when no fallback used.
+        if (result["resolved_date"] === undefined) delete result["resolved_date"];
+
+        return textContent(result);
+      } catch (e) {
+        if (e instanceof OuraApiError) return errorContent(e.message);
+        throw e;
+      }
+    },
+  );
+}

--- a/apps/oura-mcp/src/tools/index.ts
+++ b/apps/oura-mcp/src/tools/index.ts
@@ -22,6 +22,9 @@ import { registerAnomalyDetectTool } from "./anomaly_detect.js";
 import { registerRecoveryForecastTool } from "./recovery_forecast.js";
 import { registerAlcoholImpactTool } from "./alcohol_impact.js";
 import { registerWeeklyDigestTool } from "./weekly_digest.js";
+import { registerRespiratoryTrendTool } from "./respiratory_trend.js";
+import { registerIllnessSignalsTool } from "./illness_signals.js";
+import { registerSymptomOnsetDetectTool } from "./symptom_onset_detect.js";
 
 export function registerAllTools(server: McpServer, client: OuraClient): void {
   registerPersonalTools(server, client);
@@ -46,4 +49,7 @@ export function registerAllTools(server: McpServer, client: OuraClient): void {
   registerRecoveryForecastTool(server, client);
   registerAlcoholImpactTool(server, client);
   registerWeeklyDigestTool(server, client);
+  registerRespiratoryTrendTool(server, client);
+  registerIllnessSignalsTool(server, client);
+  registerSymptomOnsetDetectTool(server, client);
 }

--- a/apps/oura-mcp/src/tools/respiratory_trend.ts
+++ b/apps/oura-mcp/src/tools/respiratory_trend.ts
@@ -1,0 +1,99 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OuraClient } from "../oura/client.js";
+import { OuraApiError } from "../oura/client.js";
+import { getSleepPeriods } from "../oura/endpoints.js";
+import type { SleepPeriod } from "../oura/types.js";
+import {
+  textContent,
+  errorContent,
+  resolveDateRange,
+  validateDateRange,
+} from "./utils.js";
+
+interface RespiratoryTrendEntry {
+  date: string;
+  average_respiratory_rate: number | null;
+  breath_samples_count?: number;
+  respiratory_rate_min?: number;
+  respiratory_rate_max?: number;
+}
+
+/**
+ * Pick one sleep period per date. Prefer the longest-duration period whose
+ * average_breath is non-null. If all longest candidates have null
+ * average_breath, fall back to the next-longest. Skips deleted periods.
+ */
+function pickPeriodForRespiratory(periods: SleepPeriod[]): SleepPeriod | undefined {
+  const usable = periods.filter((p) => p.type !== "deleted");
+  if (usable.length === 0) return undefined;
+  // Sort by total_sleep_duration descending (nulls treated as -1).
+  const sorted = [...usable].sort(
+    (a, b) => (b.total_sleep_duration ?? -1) - (a.total_sleep_duration ?? -1),
+  );
+  // Prefer longest with non-null average_breath; otherwise return the longest.
+  const withResp = sorted.find((p) => p.average_breath !== null);
+  return withResp ?? sorted[0];
+}
+
+export function registerRespiratoryTrendTool(server: McpServer, client: OuraClient): void {
+  server.tool(
+    "oura_respiratory_trend",
+    "Derived tool: fetches detailed sleep periods and returns a clean date-indexed " +
+      "respiratory-rate series. One entry per date — when Oura reports multiple sleep " +
+      "periods for a night, the longest period wins (with fallback to the next-longest " +
+      "if the longest has no respiratory data). Fields per entry: date, " +
+      "average_respiratory_rate (breaths/min), and (when available) breath_samples_count, " +
+      "respiratory_rate_min, respiratory_rate_max from the per-night breath time series. " +
+      "null average_respiratory_rate means the ring did not record breath rate that night. " +
+      "Use this tool for respiratory-rate trends and elevated-breathing-rate analysis.",
+    {
+      start_date: z
+        .string()
+        .optional()
+        .describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
+      end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
+    },
+    async ({ start_date, end_date }) => {
+      const range = resolveDateRange(start_date, end_date);
+      const err = validateDateRange(range.start_date, range.end_date);
+      if (err) return errorContent(err);
+      try {
+        const periods = await getSleepPeriods(client, range);
+
+        // Group by day, then pick one per day.
+        const byDay = new Map<string, SleepPeriod[]>();
+        for (const p of periods) {
+          const arr = byDay.get(p.day) ?? [];
+          arr.push(p);
+          byDay.set(p.day, arr);
+        }
+
+        const trend: RespiratoryTrendEntry[] = [];
+        for (const [day, dayPeriods] of byDay) {
+          const main = pickPeriodForRespiratory(dayPeriods);
+          if (!main) continue;
+          const entry: RespiratoryTrendEntry = {
+            date: day,
+            average_respiratory_rate: main.average_breath,
+          };
+          // Derive min/max/sample count from breath samples (sleep period
+          // exposes hrv/heart_rate time series; Oura does not currently
+          // ship a public breath time series, so we only populate when
+          // available on the payload). Guard defensively.
+          // Note: SleepPeriod type does not include a breath samples array,
+          // so we omit these fields rather than fabricating them.
+          trend.push(entry);
+        }
+
+        // Sort by date ascending for consumer convenience.
+        trend.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+        return textContent(trend);
+      } catch (e) {
+        if (e instanceof OuraApiError) return errorContent(e.message);
+        throw e;
+      }
+    },
+  );
+}

--- a/apps/oura-mcp/src/tools/symptom_onset_detect.ts
+++ b/apps/oura-mcp/src/tools/symptom_onset_detect.ts
@@ -1,0 +1,179 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OuraClient } from "../oura/client.js";
+import { OuraApiError } from "../oura/client.js";
+import { getDailyReadiness } from "../oura/endpoints.js";
+import { addDays, eachDay, fetchMetricByDay } from "../oura/metrics.js";
+import { mean, stddev, zScore } from "../oura/stats.js";
+import {
+  textContent,
+  errorContent,
+  todayInTz,
+  daysAgoInTz,
+  validateDateRange,
+} from "./utils.js";
+
+const BASELINE_WINDOW = 28;
+const MIN_BASELINE_SAMPLES = 7;
+
+interface OnsetDay {
+  date: string;
+  signals: string[];
+  z_scores: {
+    body_temperature_deviation: number | null;
+    respiratory_rate: number | null;
+    rhr: number | null;
+    hrv: number | null;
+  };
+  confidence: number;
+}
+
+function zForDay(
+  series: Map<string, number | null>,
+  date: string,
+): number | null {
+  const value = series.get(date);
+  if (value === null || value === undefined || !Number.isFinite(value)) return null;
+  // Baseline = 28 days ending the day BEFORE `date`.
+  const start = addDays(date, -BASELINE_WINDOW);
+  const end = addDays(date, -1);
+  const vals: number[] = [];
+  for (const d of eachDay(start, end)) {
+    const v = series.get(d);
+    if (v !== null && v !== undefined && Number.isFinite(v)) vals.push(v);
+  }
+  if (vals.length < MIN_BASELINE_SAMPLES) return null;
+  const mu = mean(vals);
+  const sigma = stddev(vals, mu);
+  if (sigma === 0) return null;
+  return zScore(value, mu, sigma);
+}
+
+export function registerSymptomOnsetDetectTool(server: McpServer, client: OuraClient): void {
+  server.tool(
+    "oura_symptom_onset_detect",
+    "Scans a date window for clusters of biometric anomalies indicative of illness " +
+      "onset. For each day, computes z-scores for body temperature deviation, respiratory " +
+      "rate, resting heart rate, and HRV using a 28-day rolling baseline ending the day " +
+      "BEFORE the candidate date (so the anomaly itself does not contaminate the baseline). " +
+      "Default thresholds: temp z > +1.5, resp z > +1.0, RHR z > +1.0, HRV z < -1.0. " +
+      "A day is flagged when at least `min_signals` (default 3) of the four signals trip. " +
+      "Returns an array of { date, signals, z_scores, confidence } where " +
+      "confidence = signals_count / 4. Returns an empty array when no onset days detected. " +
+      "Requires at least 7 valid baseline samples per metric; days lacking sufficient " +
+      "baseline data report null z-scores and contribute no signals.",
+    {
+      start_date: z
+        .string()
+        .optional()
+        .describe("Start of scan window YYYY-MM-DD. Defaults to 30 days ago."),
+      end_date: z
+        .string()
+        .optional()
+        .describe("End of scan window YYYY-MM-DD. Defaults to today."),
+      temp_z_threshold: z.number().optional().describe("Default +1.5. Trips when z > threshold."),
+      resp_z_threshold: z.number().optional().describe("Default +1.0. Trips when z > threshold."),
+      rhr_z_threshold: z.number().optional().describe("Default +1.0. Trips when z > threshold."),
+      hrv_z_threshold: z
+        .number()
+        .optional()
+        .describe("Default -1.0. Trips when z < threshold (HRV drop is the illness signal)."),
+      min_signals: z
+        .number()
+        .int()
+        .min(1)
+        .max(4)
+        .optional()
+        .describe("Minimum tripped signals to flag a day. Default 3."),
+    },
+    async ({
+      start_date,
+      end_date,
+      temp_z_threshold,
+      resp_z_threshold,
+      rhr_z_threshold,
+      hrv_z_threshold,
+      min_signals,
+    }) => {
+      const end = end_date ?? todayInTz();
+      const start = start_date ?? daysAgoInTz(30);
+      const err = validateDateRange(start, end);
+      if (err) return errorContent(err);
+
+      const tempT = temp_z_threshold ?? 1.5;
+      const respT = resp_z_threshold ?? 1.0;
+      const rhrT = rhr_z_threshold ?? 1.0;
+      const hrvT = hrv_z_threshold ?? -1.0;
+      const minSig = min_signals ?? 3;
+
+      // Need to fetch BASELINE_WINDOW extra days before `start` so the earliest
+      // scan dates have access to their baseline.
+      const fetchStart = addDays(start, -BASELINE_WINDOW);
+      const fetchEnd = end;
+
+      try {
+        const [readiness, respSeries, rhrSeries, hrvSeries] = await Promise.all([
+          getDailyReadiness(client, { start_date: fetchStart, end_date: fetchEnd }),
+          fetchMetricByDay(client, "respiratory_rate", fetchStart, fetchEnd),
+          fetchMetricByDay(client, "rhr", fetchStart, fetchEnd),
+          fetchMetricByDay(client, "hrv", fetchStart, fetchEnd),
+        ]);
+
+        // Build temperature-deviation series from daily_readiness.
+        const tempSeries = new Map<string, number | null>();
+        for (const d of eachDay(fetchStart, fetchEnd)) tempSeries.set(d, null);
+        for (const r of readiness) {
+          tempSeries.set(r.day, r.temperature_deviation);
+        }
+
+        const scanDates = eachDay(start, end);
+        const onsets: OnsetDay[] = [];
+
+        for (const date of scanDates) {
+          const tempZ = zForDay(tempSeries, date);
+          const respZ = zForDay(respSeries, date);
+          const rhrZ = zForDay(rhrSeries, date);
+          const hrvZ = zForDay(hrvSeries, date);
+
+          const signals: string[] = [];
+          if (tempZ !== null && tempZ > tempT) signals.push("body_temperature_deviation");
+          if (respZ !== null && respZ > respT) signals.push("respiratory_rate");
+          if (rhrZ !== null && rhrZ > rhrT) signals.push("rhr");
+          if (hrvZ !== null && hrvZ < hrvT) signals.push("hrv");
+
+          if (signals.length >= minSig) {
+            const round2 = (x: number | null): number | null =>
+              x === null ? null : Math.round(x * 100) / 100;
+            onsets.push({
+              date,
+              signals,
+              z_scores: {
+                body_temperature_deviation: round2(tempZ),
+                respiratory_rate: round2(respZ),
+                rhr: round2(rhrZ),
+                hrv: round2(hrvZ),
+              },
+              confidence: Math.round((signals.length / 4) * 100) / 100,
+            });
+          }
+        }
+
+        return textContent({
+          date_range: { start, end },
+          baseline_window_days: BASELINE_WINDOW,
+          thresholds: {
+            temp_z: tempT,
+            resp_z: respT,
+            rhr_z: rhrT,
+            hrv_z: hrvT,
+            min_signals: minSig,
+          },
+          onsets,
+        });
+      } catch (e) {
+        if (e instanceof OuraApiError) return errorContent(e.message);
+        throw e;
+      }
+    },
+  );
+}


### PR DESCRIPTION
Closes #4
Closes #5
Closes #8

## Summary
- `oura_respiratory_trend` — mirror of `oura_hrv_trend` for respiratory rate. Returns one entry per date with `average_respiratory_rate`. Dedups multiple sleep periods per night by picking the longest-duration period whose `average_breath` is non-null, falling back to next-longest if needed.
- `oura_illness_signals` — composite single-day report combining body temperature deviation, respiratory rate, HRV, RHR, and readiness against a 30-day rolling baseline (excluding the target date). Emits a categorical `exertion_ceiling` (`rest` / `zone_2_only` / `moderate` / `unrestricted`) per the thresholds documented in the tool description, plus a `signals_triggered` audit array. Supports `fallback: "strict" | "latest"` (default `"latest"`).
- `oura_symptom_onset_detect` — scans a window (default last 30 days) for clusters of biometric anomalies. Per-day z-scores for temp, resp, RHR, HRV use a 28-day baseline ending the day BEFORE the candidate (so the anomaly cannot contaminate its own baseline). Defaults: temp z > +1.5, resp z > +1.0, RHR z > +1.0, HRV z < -1.0; flags a day when >=3 of 4 signals trip. Returns empty array when no onsets.

Implementation notes:
- All three tools reuse the existing `fetchMetricByDay` (in `oura/metrics.ts`) and the shared stats helpers (`mean`/`stddev`/`zScore`/`percentileFromZ`/`defined`), matching the baseline semantics of `oura_baseline_compare` and `oura_anomaly_detect`. No new shared helper introduced — duplication across the three new tools stayed under the 10-line threshold called out in the brief.
- Body-temperature deviation pulled from `DailyReadiness.temperature_deviation` (the only public field for it). Respiratory rate, HRV, RHR pulled via the `respiratory_rate` / `hrv` / `rhr` metric entries in `fetchMetricByDay`, which picks the longest sleep period per night to match the rest of the analytics suite.
- For `respiratory_trend`, `SleepPeriod` does not expose a public per-night breath time series, so optional fields like `breath_samples_count`/min/max are omitted (not fabricated) per the "gracefully omit" constraint.

## Test plan
- [x] `pnpm -r type-check` passes across the whole workspace.
- [ ] Smoke test `oura_respiratory_trend` for a 7-day window and a multi-period night.
- [ ] Smoke test `oura_illness_signals` for today (latest fallback) and for a known-missing date in strict mode.
- [ ] Smoke test `oura_symptom_onset_detect` over the last 30 days; verify empty array when no triggers and that flagged days look plausible.

Generated with [Claude Code](https://claude.com/claude-code)