### PR TITLE
[oura-mcp] integrate user tag overlay into analytical tools

### DIFF
--- a/apps/oura-mcp/src/oura/metrics.ts
+++ b/apps/oura-mcp/src/oura/metrics.ts
@@ -26,8 +26,75 @@ import {
   getDailyActivity,
   getDailySpo2,
   getSleepPeriods,
+  getEnhancedTags,
 } from "./endpoints.js";
 import type { SleepPeriod } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Tag overlay helper (shared by readiness / hrv_trend / respiratory_trend)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lightweight tag projection attached to per-date trend rows when callers
+ * pass `overlay_tags`. Matches the field shape exposed by `oura_tags`: name,
+ * optional comment, optional timestamp. Comment/timestamp are omitted (not
+ * nulled) when Oura did not record them.
+ */
+export interface TagEntry {
+  name: string;
+  comment?: string;
+  timestamp?: string;
+}
+
+/**
+ * `overlay_tags` parameter accepts:
+ *   - true       → attach every tag falling on each date
+ *   - string[]   → attach only tags whose name matches one of the listed
+ *                  names (exact, case-insensitive)
+ *   - false/undef → no tags, no extra API call (handled by callers)
+ */
+export type OverlayTagsFilter = boolean | string[];
+
+/**
+ * Display name for a tag. Oura's enhanced_tag endpoint exposes a
+ * `tag_type_code` (e.g. "tag_generic_alcohol") and an optional
+ * `custom_name`. We prefer `custom_name` when set, otherwise fall back to
+ * the type code. Mirrors the shape callers see from `oura_tags`.
+ */
+function tagDisplayName(t: { tag_type_code: string; custom_name: string | null }): string {
+  return t.custom_name ?? t.tag_type_code;
+}
+
+/**
+ * Fetch all tags overlapping `[start, end]` in a SINGLE paginated call and
+ * return a date-keyed map. When `filter` is a string[], only tags whose
+ * display name matches one of the entries (case-insensitive) are kept.
+ */
+export async function fetchTagsByDay(
+  client: OuraClient,
+  start: string,
+  end: string,
+  filter: OverlayTagsFilter,
+): Promise<Map<string, TagEntry[]>> {
+  const out = new Map<string, TagEntry[]>();
+  if (filter === false) return out;
+  const names =
+    Array.isArray(filter)
+      ? new Set(filter.map((n) => n.toLowerCase()))
+      : null;
+  const tags = await getEnhancedTags(client, { start_date: start, end_date: end });
+  for (const t of tags) {
+    const name = tagDisplayName(t);
+    if (names && !names.has(name.toLowerCase())) continue;
+    const entry: TagEntry = { name };
+    if (t.comment) entry.comment = t.comment;
+    if (t.start_time) entry.timestamp = t.start_time;
+    const list = out.get(t.start_day) ?? [];
+    list.push(entry);
+    out.set(t.start_day, list);
+  }
+  return out;
+}
 
 export const METRIC_NAMES = [
   "readiness",

--- a/apps/oura-mcp/src/tools/intervention_analysis.ts
+++ b/apps/oura-mcp/src/tools/intervention_analysis.ts
@@ -8,6 +8,7 @@ import {
   fetchMetricByDay,
   type Metric,
 } from "../oura/metrics.js";
+import { getEnhancedTags } from "../oura/endpoints.js";
 import { defined, mean, median, stddev } from "../oura/stats.js";
 import { textContent, errorContent } from "./utils.js";
 
@@ -41,11 +42,19 @@ export function registerInterventionAnalysisTool(
     "Compares metric values in a window before vs after an intervention date " +
       "(e.g. dietary change, new medication, schedule shift). An exclusion window " +
       "around the intervention date is dropped to avoid washout effects. " +
-      "`meaningfully_different` flag is rough: |delta| > 1 stddev of the BEFORE period.",
+      "`meaningfully_different` flag is rough: |delta| > 1 stddev of the BEFORE period. " +
+      "Specify the intervention either by explicit `intervention_date` OR by `tag_name` " +
+      "(uses the FIRST occurrence of that user tag, exact-match case-insensitive, as the date). " +
+      "Provide exactly one.",
     {
       intervention_date: z
         .string()
-        .describe("YYYY-MM-DD. The day the intervention took effect."),
+        .optional()
+        .describe("YYYY-MM-DD. The day the intervention took effect. Mutually exclusive with tag_name."),
+      tag_name: z
+        .string()
+        .optional()
+        .describe("User tag name (exact, case-insensitive). The earliest occurrence in your tag history is used as the intervention date. Mutually exclusive with intervention_date."),
       intervention_label: z
         .string()
         .describe("Free-text label describing the intervention (echoed in output)."),
@@ -69,16 +78,55 @@ export function registerInterventionAnalysisTool(
         .optional()
         .describe("Days adjacent to intervention_date to drop on each side. Default 7."),
     },
-    async ({ intervention_date, intervention_label, metrics, window_days, exclusion_days }) => {
+    async ({ intervention_date, tag_name, intervention_label, metrics, window_days, exclusion_days }) => {
+      if (intervention_date && tag_name) {
+        return errorContent(
+          "Provide either `intervention_date` or `tag_name`, not both.",
+        );
+      }
+      if (!intervention_date && !tag_name) {
+        return errorContent(
+          "Provide one of `intervention_date` (YYYY-MM-DD) or `tag_name`.",
+        );
+      }
+
       const win = window_days ?? 30;
       const excl = exclusion_days ?? 7;
 
-      const beforeStart = addDays(intervention_date, -excl - win);
-      const beforeEnd = addDays(intervention_date, -excl - 1);
-      const afterStart = addDays(intervention_date, excl);
-      const afterEnd = addDays(intervention_date, excl + win - 1);
-
       try {
+        // Resolve intervention_date from tag_name if needed. Scan a wide
+        // history window (5y back from today) and pick the earliest matching
+        // tag occurrence.
+        let resolvedDate: string;
+        if (tag_name) {
+          const today = new Date().toISOString().slice(0, 10);
+          const scanStart = addDays(today, -365 * 5);
+          const tags = await getEnhancedTags(
+            client,
+            { start_date: scanStart, end_date: today },
+            20,
+          );
+          const needle = tag_name.toLowerCase();
+          const matches = tags.filter((t) => {
+            const name = (t.custom_name ?? t.tag_type_code).toLowerCase();
+            return name === needle;
+          });
+          if (matches.length === 0) {
+            return errorContent(
+              `No tag found matching "${tag_name}" in the last 5 years of tag history.`,
+            );
+          }
+          matches.sort((a, b) => a.start_day.localeCompare(b.start_day));
+          resolvedDate = matches[0]!.start_day;
+        } else {
+          resolvedDate = intervention_date!;
+        }
+
+        const beforeStart = addDays(resolvedDate, -excl - win);
+        const beforeEnd = addDays(resolvedDate, -excl - 1);
+        const afterStart = addDays(resolvedDate, excl);
+        const afterEnd = addDays(resolvedDate, excl + win - 1);
+
         const out: Record<string, unknown> = {};
         for (const metric of metrics as Metric[]) {
           const beforeSeries = await fetchMetricByDay(client, metric, beforeStart, beforeEnd);
@@ -114,7 +162,8 @@ export function registerInterventionAnalysisTool(
         }
 
         return textContent({
-          intervention_date,
+          intervention_date: resolvedDate,
+          ...(tag_name ? { resolved_from_tag: tag_name } : {}),
           intervention_label,
           exclusion_days: excl,
           window_days: win,

--- a/apps/oura-mcp/src/tools/readiness.ts
+++ b/apps/oura-mcp/src/tools/readiness.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyReadiness, getSleepPeriods } from "../oura/endpoints.js";
-import { addDays } from "../oura/metrics.js";
+import { addDays, fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 import { defined, mean } from "../oura/stats.js";
 import type { DailyReadiness, SleepPeriod } from "../oura/types.js";
 import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
@@ -70,13 +70,22 @@ export function registerReadinessTools(server: McpServer, client: OuraClient): v
       "biometrics (rhr_bpm, hrv_ms, body_temperature_deviation_c, resp_rate) " +
       "sourced from the main overnight sleep period, plus rolling 14-day " +
       "baselines (rhr_baseline, hrv_baseline, resp_rate_baseline). Fields " +
-      "are omitted when the underlying data is unavailable.",
+      "are omitted when the underlying data is unavailable. " +
+      "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
+      "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (exact, case-insensitive). " +
+      "When set, each row gets a `tags` array of {name, comment?, timestamp?}.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
       max_pages: z.number().int().min(1).max(20).optional().describe("Max pagination pages (default 5)."),
+      overlay_tags: z
+        .union([z.boolean(), z.array(z.string()).min(1)])
+        .optional()
+        .describe(
+          "Attach user tags to each row. `true` = all tags; string[] = filter by tag name (case-insensitive exact match). Omit/false = no tags.",
+        ),
     },
-    async ({ start_date, end_date, max_pages }) => {
+    async ({ start_date, end_date, max_pages, overlay_tags }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
@@ -130,6 +139,20 @@ export function registerReadinessTools(server: McpServer, client: OuraClient): v
 
           return { ...r, raw_values: raw };
         });
+
+        if (overlay_tags) {
+          const tagsByDay = await fetchTagsByDay(
+            client,
+            range.start_date,
+            range.end_date,
+            overlay_tags,
+          );
+          const withTags = enriched.map((r) => ({
+            ...r,
+            tags: (tagsByDay.get(r.day) ?? []) as TagEntry[],
+          }));
+          return textContent(withTags);
+        }
 
         return textContent(enriched);
       } catch (e) {

--- a/apps/oura-mcp/src/tools/respiratory_trend.ts
+++ b/apps/oura-mcp/src/tools/respiratory_trend.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getSleepPeriods } from "../oura/endpoints.js";
+import { fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 import type { SleepPeriod } from "../oura/types.js";
 import {
   textContent,
@@ -46,15 +47,24 @@ export function registerRespiratoryTrendTool(server: McpServer, client: OuraClie
       "average_respiratory_rate (breaths/min), and (when available) breath_samples_count, " +
       "respiratory_rate_min, respiratory_rate_max from the per-night breath time series. " +
       "null average_respiratory_rate means the ring did not record breath rate that night. " +
-      "Use this tool for respiratory-rate trends and elevated-breathing-rate analysis.",
+      "Use this tool for respiratory-rate trends and elevated-breathing-rate analysis. " +
+      "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
+      "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (case-insensitive). " +
+      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}.",
     {
       start_date: z
         .string()
         .optional()
         .describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
+      overlay_tags: z
+        .union([z.boolean(), z.array(z.string()).min(1)])
+        .optional()
+        .describe(
+          "Attach user tags to each row. `true` = all tags; string[] = filter by tag name (case-insensitive exact match). Omit/false = no tags.",
+        ),
     },
-    async ({ start_date, end_date }) => {
+    async ({ start_date, end_date, overlay_tags }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
@@ -88,6 +98,20 @@ export function registerRespiratoryTrendTool(server: McpServer, client: OuraClie
 
         // Sort by date ascending for consumer convenience.
         trend.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+        if (overlay_tags) {
+          const tagsByDay = await fetchTagsByDay(
+            client,
+            range.start_date,
+            range.end_date,
+            overlay_tags,
+          );
+          const withTags = trend.map((e) => ({
+            ...e,
+            tags: (tagsByDay.get(e.date) ?? []) as TagEntry[],
+          }));
+          return textContent(withTags);
+        }
 
         return textContent(trend);
       } catch (e) {

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -14,6 +14,7 @@ import {
   errorContent,
 } from "./utils.js";
 import type { HrvTrendEntry } from "../oura/types.js";
+import { fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 
 const dateRangeSchema = {
   start_date: z
@@ -104,12 +105,21 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
       "Fields per entry: date, average_hrv (ms RMSSD), lowest_hrv (ms RMSSD), " +
       "average_heart_rate (bpm), lowest_heart_rate (bpm). " +
       "null values mean the ring did not record HRV that night. " +
-      "This is the best tool for HRV trends and cardiovascular recovery analysis.",
+      "This is the best tool for HRV trends and cardiovascular recovery analysis. " +
+      "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
+      "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (case-insensitive). " +
+      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
+      overlay_tags: z
+        .union([z.boolean(), z.array(z.string()).min(1)])
+        .optional()
+        .describe(
+          "Attach user tags to each row. `true` = all tags; string[] = filter by tag name (case-insensitive exact match). Omit/false = no tags.",
+        ),
     },
-    async ({ start_date, end_date }) => {
+    async ({ start_date, end_date, overlay_tags }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
@@ -148,6 +158,19 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
           });
         }
         trend.sort((a, b) => a.date.localeCompare(b.date));
+        if (overlay_tags) {
+          const tagsByDay = await fetchTagsByDay(
+            client,
+            range.start_date,
+            range.end_date,
+            overlay_tags,
+          );
+          const withTags = trend.map((e) => ({
+            ...e,
+            tags: (tagsByDay.get(e.date) ?? []) as TagEntry[],
+          }));
+          return textContent(withTags);
+        }
         return textContent(trend);
       } catch (e) {
         if (e instanceof OuraApiError) return errorContent(e.message);


### PR DESCRIPTION
Closes #6

## Summary
- Adds `overlay_tags` (boolean | string[]) parameter to `oura_daily_readiness`, `oura_hrv_trend`, and `oura_respiratory_trend`. When set, each per-date row gets a `tags` array of `{name, comment?, timestamp?}`. Omitted/false leaves response shape unchanged (backward-compatible).
- Adds `tag_name` as an alternative to `intervention_date` on `oura_intervention_analysis`. Resolves to the earliest matching tag occurrence (scans 5y of tag history, exact-match case-insensitive). Errors clearly when both or neither are provided, and when the tag is not found.
- New shared helper `fetchTagsByDay(client, start, end, filter)` in `apps/oura-mcp/src/oura/metrics.ts` builds a `Map<date, TagEntry[]>` from a single `/enhanced_tag` call per tool invocation.

## Test plan
- [x] `pnpm -r type-check` passes
- [ ] Smoke-test `oura_daily_readiness` without `overlay_tags` (existing response shape, no extra API call)
- [ ] Smoke-test `oura_daily_readiness` with `overlay_tags: true` (each row gains `tags` array)
- [ ] Smoke-test `oura_hrv_trend` with `overlay_tags: ["alcohol"]` (only matching tag names attached)
- [ ] Smoke-test `oura_respiratory_trend` with `overlay_tags: true`
- [ ] Smoke-test `oura_intervention_analysis` with `tag_name: "<known tag>"` and verify the resolved date matches the earliest occurrence
- [ ] Verify error responses for: both `intervention_date` + `tag_name`, neither, and unknown `tag_name`