### PR TITLE
[oura-mcp] clarify date semantics across tool descriptions

### DIFF
--- a/apps/oura-mcp/src/tools/activity.ts
+++ b/apps/oura-mcp/src/tools/activity.ts
@@ -10,7 +10,8 @@ export function registerActivityTools(server: McpServer, client: OuraClient): vo
     "oura_daily_activity",
     "Returns daily activity scores (0-100), step count, active calories, total calories, " +
       "MET minutes by intensity, and time breakdowns. " +
-      "All time fields (high_activity_time, sedentary_time, etc.) are in SECONDS.",
+      "All time fields (high_activity_time, sedentary_time, etc.) are in SECONDS. " +
+      "Dates: \"day\" is the calendar day the activity occurred.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/alcohol_impact.ts
+++ b/apps/oura-mcp/src/tools/alcohol_impact.ts
@@ -68,7 +68,8 @@ export function registerAlcoholImpactTool(server: McpServer, client: OuraClient)
     "Compares biometrics (HRV, deep sleep, RHR, readiness, sleep latency) between " +
       "alcohol-tagged days and non-alcohol days. Also estimates how many days HRV " +
       "takes to recover after an alcohol day. Tag is auto-discovered by name match " +
-      "unless alcohol_tag_name is provided.",
+      "unless alcohol_tag_name is provided. " +
+      "Dates: alcohol days are identified by tag start_day; biometrics (HRV, deep_sleep, RHR, sleep_latency) are bucketed by sleep-period-start date; readiness is bucketed by morning-of-report date. These conventions can shift the same physiological night by a day across categories — interpret recovery_pattern (offset days) as approximate.",
     {
       date_range: z
         .object({ start: z.string(), end: z.string() })

--- a/apps/oura-mcp/src/tools/anomaly_detect.ts
+++ b/apps/oura-mcp/src/tools/anomaly_detect.ts
@@ -212,7 +212,8 @@ export function registerAnomalyDetectTool(server: McpServer, client: OuraClient)
     "Flags days where a metric deviates from its rolling baseline by more than " +
       "z_threshold standard deviations. Scans each day in date_range against the " +
       "preceding baseline_window_days for each metric. Skips metrics with fewer than " +
-      "7 valid baseline samples. Use this to surface unusual readings worth investigating.",
+      "7 valid baseline samples. Use this to surface unusual readings worth investigating. " +
+      "Dates: each anomaly's \"date\" follows the source metric's convention — sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, respiratory_rate) use the sleep-period-start date, while readiness/sleep_score/activity_score use the morning-of-report date. Within a single result, anomalies for the same night may appear under different dates depending on the metric.",
     {
       date_range: z.object({ start: z.string(), end: z.string() }),
       baseline_window_days: z

--- a/apps/oura-mcp/src/tools/baseline_compare.ts
+++ b/apps/oura-mcp/src/tools/baseline_compare.ts
@@ -27,7 +27,8 @@ export function registerBaselineCompareTool(server: McpServer, client: OuraClien
       "backward up to 7 days for the most recent reading and returns it (with " +
       "`actual_date_used` and `days_lag` in the response). The baseline window itself " +
       "remains anchored to the requested date. Default `fallback: \"strict\"` preserves " +
-      "the no-data error behavior.",
+      "the no-data error behavior. " +
+      "Dates: \"date\" indexes the underlying metric — for sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, sleep_total, respiratory_rate) this is the date the sleep period started; for daily-report metrics (readiness, sleep_score, activity_score, spo2) this is the morning the score is reported on. The two conventions can refer to the same physiological night but different calendar dates.",
     {
       metric: z.enum(METRIC_NAMES).describe("Metric to compare against personal baseline."),
       date: z

--- a/apps/oura-mcp/src/tools/correlation.ts
+++ b/apps/oura-mcp/src/tools/correlation.ts
@@ -70,7 +70,8 @@ export function registerCorrelationTool(server: McpServer, client: OuraClient): 
       "deep_sleep, rem_sleep, respiratory_rate, spo2, activity_score) or a tag (prefix " +
       "with `tag:`, matched against tag_type_code or custom_name). " +
       "Optional `lag_days` shifts B forward relative to A: tests whether A on day d " +
-      "predicts B on day d+lag.",
+      "predicts B on day d+lag. " +
+      "Dates: each series is keyed by its source's native date convention — sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, respiratory_rate, sleep_total) use the sleep-period-start date; daily-report metrics (readiness, sleep_score, activity_score, spo2) use the morning-of-report date; tag series use tag start_day. When correlating a sleep-derived metric with a daily-report metric at lag_days=0, pairs may be off by one calendar day from the same physiological night — consider lag_days=1 if the relationship looks weaker than expected.",
     {
       metric_a: z
         .string()

--- a/apps/oura-mcp/src/tools/heartrate.ts
+++ b/apps/oura-mcp/src/tools/heartrate.ts
@@ -11,7 +11,8 @@ export function registerHeartrateTools(server: McpServer, client: OuraClient): v
     "Returns time-series heart rate samples as { bpm, source, timestamp } objects. " +
       "source is one of: awake, rest, sleep, session, live, workout. " +
       "Timestamps are ISO 8601. Samples are ~5-minute intervals during rest/sleep. " +
-      "Default cap: 24-hour window. To query longer windows, set max_pages explicitly.",
+      "Default cap: 24-hour window. To query longer windows, set max_pages explicitly. " +
+      "Timestamps: each sample's `timestamp` is the wall-clock instant the reading was taken (ISO 8601 with offset); no per-sample date field — derive a date from the timestamp if needed.",
     {
       start_datetime: z
         .string()

--- a/apps/oura-mcp/src/tools/illness_signals.ts
+++ b/apps/oura-mcp/src/tools/illness_signals.ts
@@ -137,7 +137,8 @@ export function registerIllnessSignalsTool(server: McpServer, client: OuraClient
       "(2) elevated temperature OR respiratory rate >+10% OR readiness_score < 50 => zone_2_only; " +
       "(3) HRV < -25% vs baseline OR RHR > +10% vs baseline => moderate; " +
       "(4) otherwise => unrestricted. " +
-      "fallback='latest' (default) reuses the most recent prior day with data when the target date is missing; fallback='strict' returns nulls for missing data.",
+      "fallback='latest' (default) reuses the most recent prior day with data when the target date is missing; fallback='strict' returns nulls for missing data. " +
+      "Dates: \"date\" is interpreted against each underlying metric's native convention — body temperature deviation and readiness score use the morning-of-report date; HRV, RHR, and respiratory rate are sourced from the sleep period whose `day` matches that date (sleep-period-start convention). Pick whichever date aligns with how you mentally label the night in question; off-by-one across conventions is possible.",
     {
       date: z
         .string()

--- a/apps/oura-mcp/src/tools/intervention_analysis.ts
+++ b/apps/oura-mcp/src/tools/intervention_analysis.ts
@@ -45,7 +45,8 @@ export function registerInterventionAnalysisTool(
       "`meaningfully_different` flag is rough: |delta| > 1 stddev of the BEFORE period. " +
       "Specify the intervention either by explicit `intervention_date` OR by `tag_name` " +
       "(uses the FIRST occurrence of that user tag, exact-match case-insensitive, as the date). " +
-      "Provide exactly one.",
+      "Provide exactly one. " +
+      "Dates: intervention_date and the before/after windows are matched against each metric's native date convention — sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, respiratory_rate, sleep_total) use the sleep-period-start date; daily-report metrics (readiness, sleep_score, activity_score, spo2) use the morning-of-report date. If precise alignment to the intervention day matters, prefer the daily-report convention.",
     {
       intervention_date: z
         .string()

--- a/apps/oura-mcp/src/tools/period_compare.ts
+++ b/apps/oura-mcp/src/tools/period_compare.ts
@@ -37,7 +37,8 @@ export function registerPeriodCompareTool(server: McpServer, client: OuraClient)
     "Side-by-side comparison of two arbitrary date ranges across one or more metrics. " +
       "Returns mean/median/stddev for each period plus delta_mean (b-a), delta_pct, " +
       "and a rough `meaningfully_different` flag (|delta| > 1 stddev of period A — " +
-      "intentionally crude, treat as a heuristic rather than statistical inference).",
+      "intentionally crude, treat as a heuristic rather than statistical inference). " +
+      "Dates: period_a/period_b ranges are matched against each metric's native date convention — sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, respiratory_rate, sleep_total) use the sleep-period-start date; daily-report metrics (readiness, sleep_score, activity_score, spo2) use the morning-of-report date.",
     {
       metrics: z
         .array(z.enum(METRIC_NAMES))

--- a/apps/oura-mcp/src/tools/readiness.ts
+++ b/apps/oura-mcp/src/tools/readiness.ts
@@ -73,7 +73,8 @@ export function registerReadinessTools(server: McpServer, client: OuraClient): v
       "are omitted when the underlying data is unavailable. " +
       "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
       "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (exact, case-insensitive). " +
-      "When set, each row gets a `tags` array of {name, comment?, timestamp?}.",
+      "When set, each row gets a `tags` array of {name, comment?, timestamp?}. " +
+      "Dates: \"day\" is the morning the readiness score is reported on (reflecting the overnight sleep ending that morning). Note: raw_values pulls from the sleep period whose `day` matches this date, which uses a different convention in oura_sleep_detail/oura_hrv_trend (sleep-period-start date) — within this tool the alignment is handled internally, but be aware when cross-referencing.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/recovery_forecast.ts
+++ b/apps/oura-mcp/src/tools/recovery_forecast.ts
@@ -23,7 +23,8 @@ export function registerRecoveryForecastTool(server: McpServer, client: OuraClie
     "Forecasts a single day's readiness score using recent trend plus regression " +
       "toward a 30-day mean. Returns predicted_readiness with a confidence band " +
       "(±1 stddev of recent values, clamped 0-100), trend label, and basis string. " +
-      "Defaults to predicting tomorrow.",
+      "Defaults to predicting tomorrow. " +
+      "Dates: \"target_date\" is the morning the predicted readiness score would be reported on (same convention as oura_daily_readiness — the morning following the overnight sleep being predicted).",
     {
       target_date: z
         .string()

--- a/apps/oura-mcp/src/tools/resilience.ts
+++ b/apps/oura-mcp/src/tools/resilience.ts
@@ -9,7 +9,8 @@ export function registerResilienceTools(server: McpServer, client: OuraClient): 
   server.tool(
     "oura_daily_resilience",
     "Returns daily resilience level (exceptional/strong/adequate/limited/poor) " +
-      "and contributor scores for sleep recovery, daytime recovery, and stress.",
+      "and contributor scores for sleep recovery, daytime recovery, and stress. " +
+      "Dates: \"day\" is the morning the resilience level is reported on (reflecting sleep ending that morning and the trailing recent period).",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/respiratory_trend.ts
+++ b/apps/oura-mcp/src/tools/respiratory_trend.ts
@@ -50,7 +50,8 @@ export function registerRespiratoryTrendTool(server: McpServer, client: OuraClie
       "Use this tool for respiratory-rate trends and elevated-breathing-rate analysis. " +
       "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
       "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (case-insensitive). " +
-      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}.",
+      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}. " +
+      "Dates: \"date\" is the date the sleep period started (sourced from the sleep period's `day` field), NOT the morning the metric is reported on. This matches oura_hrv_trend's convention but differs from oura_daily_readiness/oura_daily_sleep — beware of off-by-one alignment when correlating across tools.",
     {
       start_date: z
         .string()

--- a/apps/oura-mcp/src/tools/session.ts
+++ b/apps/oura-mcp/src/tools/session.ts
@@ -9,7 +9,8 @@ export function registerSessionTools(server: McpServer, client: OuraClient): voi
   server.tool(
     "oura_sessions",
     "Returns mindfulness and rest sessions: meditation, breathing, nap, relaxation, rest. " +
-      "Includes type, start/end datetime, mood rating, and HRV/HR sample arrays.",
+      "Includes type, start/end datetime, mood rating, and HRV/HR sample arrays. " +
+      "Dates: \"day\" is the calendar day the session occurred (derived from start_datetime).",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -39,7 +39,8 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     "oura_daily_sleep",
     "Returns daily sleep scores and contributor breakdown for a date range. " +
       "Score is 0-100. Contributor values are 0-100. " +
-      "Does NOT include raw stage durations — use oura_sleep_detail for that.",
+      "Does NOT include raw stage durations — use oura_sleep_detail for that. " +
+      "Dates: \"day\" is the morning the sleep score is reported on (i.e. the sleep period ending that morning).",
     dateRangeSchema,
     async ({ start_date, end_date, max_pages }) => {
       const range = resolveDateRange(start_date, end_date);
@@ -60,7 +61,8 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     "Returns detailed per-period sleep data including stage durations (seconds), " +
       "average and lowest heart rate (bpm), average HRV (ms RMSSD), sleep latency (seconds), " +
       "efficiency (0-100), and bedtime start/end. " +
-      "All duration fields are in SECONDS, not minutes.",
+      "All duration fields are in SECONDS, not minutes. " +
+      "Dates: \"day\" is the date the sleep period started (the evening you went to bed); the sleep period ends the following morning.",
     dateRangeSchema,
     async ({ start_date, end_date, max_pages }) => {
       const range = resolveDateRange(start_date, end_date);
@@ -79,7 +81,8 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
   server.tool(
     "oura_sleep_time_recommendation",
     "Returns Oura's recommended sleep time window and status for each day. " +
-      "Includes optimal_bedtime offsets (minutes from midnight) and recommendation label.",
+      "Includes optimal_bedtime offsets (minutes from midnight) and recommendation label. " +
+      "Dates: \"day\" is the date the recommendation applies to (the evening of that calendar day).",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
@@ -108,7 +111,8 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
       "This is the best tool for HRV trends and cardiovascular recovery analysis. " +
       "Pass `overlay_tags: true` to attach all user tags falling on each date, " +
       "or `overlay_tags: [\"sick\", \"alcohol\"]` to filter by tag name (case-insensitive). " +
-      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}.",
+      "When set, each entry gets a `tags` array of {name, comment?, timestamp?}. " +
+      "Dates: \"date\" is the date the sleep period started (sourced from the underlying sleep period's `day` field), NOT the morning the score is reported on. This differs from oura_daily_readiness/oura_daily_sleep, which key on the morning-of-report date — beware of off-by-one alignment when correlating across tools.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/spo2.ts
+++ b/apps/oura-mcp/src/tools/spo2.ts
@@ -10,7 +10,8 @@ export function registerSpo2Tools(server: McpServer, client: OuraClient): void {
     "oura_daily_spo2",
     "Returns average blood oxygen saturation (SpO2) percentage per night. " +
       "spo2_percentage.average is a percentage value (e.g. 97.3). " +
-      "null means insufficient data for that night.",
+      "null means insufficient data for that night. " +
+      "Dates: \"day\" is the morning the nightly SpO2 average is reported on (reflecting the overnight sleep ending that morning).",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/stress.ts
+++ b/apps/oura-mcp/src/tools/stress.ts
@@ -10,7 +10,8 @@ export function registerStressTools(server: McpServer, client: OuraClient): void
     "oura_daily_stress",
     "Returns daily stress metrics: stress_high (seconds in high-stress state), " +
       "recovery_high (seconds in high-recovery state), and day_summary label " +
-      "(restored/normal/stressful/unknown). Both time fields are in SECONDS.",
+      "(restored/normal/stressful/unknown). Both time fields are in SECONDS. " +
+      "Dates: \"day\" is the calendar day the stress measurements were taken on.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/summary.ts
+++ b/apps/oura-mcp/src/tools/summary.ts
@@ -14,7 +14,8 @@ export function registerSummaryTools(server: McpServer, client: OuraClient): voi
     "Convenience tool: fetches today's and yesterday's sleep score, readiness score, " +
       "and activity score in parallel. Returns a compact merged object keyed by date. " +
       "Use this as the first tool when the user asks 'how am I doing?' or wants a daily overview. " +
-      "Timezone: America/Los_Angeles.",
+      "Timezone: America/Los_Angeles. " +
+      "Dates: keys in `dates` are morning-of-report dates (sleep score, readiness score, activity score all use this convention).",
     {},
     async () => {
       const today = todayInTz();

--- a/apps/oura-mcp/src/tools/symptom_onset_detect.ts
+++ b/apps/oura-mcp/src/tools/symptom_onset_detect.ts
@@ -61,7 +61,8 @@ export function registerSymptomOnsetDetectTool(server: McpServer, client: OuraCl
       "Returns an array of { date, signals, z_scores, confidence } where " +
       "confidence = signals_count / 4. Returns an empty array when no onset days detected. " +
       "Requires at least 7 valid baseline samples per metric; days lacking sufficient " +
-      "baseline data report null z-scores and contribute no signals.",
+      "baseline data report null z-scores and contribute no signals. " +
+      "Dates: each onset \"date\" indexes a mix of conventions — body temperature deviation uses the morning-of-report date (from daily_readiness), while respiratory rate, RHR, and HRV use the sleep-period-start date (from /sleep). For a given physiological night the same date string may refer to slightly different calendar days across signals; treat the flagged date as the night being scrutinized rather than a precise event timestamp.",
     {
       start_date: z
         .string()

--- a/apps/oura-mcp/src/tools/tag.ts
+++ b/apps/oura-mcp/src/tools/tag.ts
@@ -10,7 +10,8 @@ export function registerTagTools(server: McpServer, client: OuraClient): void {
     "oura_tags",
     "Returns user-created tags (enhanced format). " +
       "Each tag has a start_day, tag_type_code, optional comment text, " +
-      "optional custom_name, and start/end times.",
+      "optional custom_name, and start/end times. " +
+      "Dates: \"start_day\"/\"end_day\" are the calendar days the tag covers (when the user logged the event); the date-range filter matches against start_day.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/vo2max.ts
+++ b/apps/oura-mcp/src/tools/vo2max.ts
@@ -9,7 +9,8 @@ export function registerVo2MaxTools(server: McpServer, client: OuraClient): void
   server.tool(
     "oura_vo2_max",
     "Returns VO2 max estimates (mL/kg/min) as calculated by Oura. " +
-      "Updates infrequently — monthly or after significant training changes.",
+      "Updates infrequently — monthly or after significant training changes. " +
+      "Dates: \"day\" is the calendar day the VO2 max estimate was computed/reported on.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),

--- a/apps/oura-mcp/src/tools/weekly_digest.ts
+++ b/apps/oura-mcp/src/tools/weekly_digest.ts
@@ -59,7 +59,8 @@ export function registerWeeklyDigestTool(server: McpServer, client: OuraClient):
     "Composite weekly summary across sleep, readiness, HRV, activity, anomalies, " +
       "and tags. Returns area-by-area numbers plus highlights (positive things) " +
       "and watch_outs (concerns). Default window is the 7 days ending the most " +
-      "recent Sunday in the user's TZ. Plain factual summary; agent layers narrative.",
+      "recent Sunday in the user's TZ. Plain factual summary; agent layers narrative. " +
+      "Dates: week_start/week_ending bracket a calendar window, but the metrics inside mix conventions — sleep-period-derived stats (HRV, RHR, deep/REM sleep, total sleep) bucket by sleep-period-start date, while readiness/sleep score/activity score bucket by morning-of-report date. Tag bucketing uses tag start_day. Differences are usually within ±1 day for any given night.",
     {
       week_ending: z
         .string()

--- a/apps/oura-mcp/src/tools/workout.ts
+++ b/apps/oura-mcp/src/tools/workout.ts
@@ -10,7 +10,8 @@ export function registerWorkoutTools(server: McpServer, client: OuraClient): voi
     "oura_workouts",
     "Returns logged and auto-detected workouts. " +
       "Fields include: activity type, start/end datetime, calories, distance (meters), " +
-      "intensity (easy/moderate/hard), source (manual/confirmed/detected), and steps.",
+      "intensity (easy/moderate/hard), source (manual/confirmed/detected), and steps. " +
+      "Dates: \"day\" is the calendar day the workout occurred (derived from start_datetime).",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),


### PR DESCRIPTION
Closes #7

## Summary

Documents (does not rename) the date conventions each Oura tool uses, so callers correlating across tools stop hitting silent off-by-one errors. No code paths or field names changed — descriptions only.

### Date conventions in this repo

Three distinct conventions are in use; the tools below now say which one they use.

**Sleep-period-start date** (`SleepPeriod.day` from `/sleep` — the evening you went to bed):
- `oura_sleep_detail`
- `oura_hrv_trend`
- `oura_respiratory_trend`
- Sleep-derived metrics (`hrv`, `rhr`, `deep_sleep`, `rem_sleep`, `respiratory_rate`, `sleep_total`) wherever they appear in composite tools

**Morning-of-report date** (the calendar morning the score is reported on — sleep period ending that morning):
- `oura_daily_sleep`
- `oura_daily_readiness`
- `oura_daily_resilience`
- `oura_daily_spo2`
- `oura_sleep_time_recommendation`
- `oura_recovery_forecast` (target_date)
- `oura_summary_today`

**Calendar day of event** (the date the thing happened on):
- `oura_daily_activity`
- `oura_daily_stress`
- `oura_vo2_max`
- `oura_workouts`
- `oura_sessions`
- `oura_tags` (start_day/end_day)

**Mixed convention** (called out explicitly in description):
- `oura_weekly_digest`
- `oura_alcohol_impact`
- `oura_illness_signals`
- `oura_symptom_onset_detect`
- `oura_anomaly_detect`
- `oura_baseline_compare`
- `oura_period_compare`
- `oura_correlation`
- `oura_intervention_analysis`

**No date field** (untouched): `oura_personal_info`, `oura_ring_configuration`. `oura_heartrate` has sample timestamps only; clarified that no per-sample date is present.

### Notable

- The biggest gap was that `oura_daily_readiness` was already enriching `raw_values` from sleep periods keyed on its own day field — i.e. matching a morning-of-report date against the sleep period that has the same `day`. Within the tool the alignment is consistent, but cross-tool comparison with `oura_hrv_trend` (which exposes the sleep-period-start date) can be off by one calendar day for the same physiological night. Description now flags this.
- Composite tools (`weekly_digest`, `alcohol_impact`, `illness_signals`, `symptom_onset_detect`, `anomaly_detect`) silently mix conventions inside a single response. Their descriptions now say so explicitly rather than papering over with vague language.

## Test plan

- [x] `pnpm -r type-check` passes
- [ ] Smoke-deploy the worker and inspect a tool description via the connector to confirm new sentences surface
- [ ] Spot-check `oura_hrv_trend` vs `oura_daily_readiness` on the same date range to confirm the date-shift caveat matches observed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)