### PR TITLE
[oura-mcp] fix baseline_compare null current_value for hrv/respiratory_rate

### DIFF
--- a/apps/oura-mcp/src/oura/metrics.ts
+++ b/apps/oura-mcp/src/oura/metrics.ts
@@ -130,22 +130,6 @@ export function addDays(date: string, n: number): string {
   return d.toISOString().slice(0, 10);
 }
 
-/**
- * Pick the longest-duration sleep period per day, ignoring deleted entries.
- * Returns Map<day, SleepPeriod>.
- */
-function mainSleepPerDay(periods: SleepPeriod[]): Map<string, SleepPeriod> {
-  const byDay = new Map<string, SleepPeriod>();
-  for (const p of periods) {
-    if (p.type === "deleted") continue;
-    const existing = byDay.get(p.day);
-    const existingDur = existing?.total_sleep_duration ?? -1;
-    const candidateDur = p.total_sleep_duration ?? -1;
-    if (!existing || candidateDur > existingDur) byDay.set(p.day, p);
-  }
-  return byDay;
-}
-
 /** Build a Map of YYYY-MM-DD → value for every day in [start, end]. */
 function buildSeries(
   start: string,
@@ -200,32 +184,55 @@ export async function fetchMetricByDay(
     case "deep_sleep":
     case "rem_sleep":
     case "respiratory_rate": {
-      const periods = await getSleepPeriods(client, range);
-      const main = mainSleepPerDay(periods);
-      const source = new Map<string, number | null>();
-      for (const [day, p] of main) {
-        let v: number | null;
+      // Oura's /sleep endpoint filters by `bedtime_start` (or similar), not
+      // by the `day` field we key on. A sleep period with `day = D` can have
+      // `bedtime_start` on D-1 (evening) and so be excluded from a tight
+      // `start=end=D` query. Pad the API window by one day on each side so
+      // single-day callers like baseline_compare see the same periods that
+      // wider-window callers (hrv_trend, daily_readiness) see. We then
+      // restrict the returned series back to [start, end] via buildSeries.
+      const paddedRange = {
+        start_date: addDays(start, -1),
+        end_date: addDays(end, 1),
+      };
+      const periods = await getSleepPeriods(client, paddedRange);
+
+      // Group periods by p.day and, for the requested metric, pick the
+      // longest-duration period whose value for that metric is non-null
+      // (falling back to the longest period overall if every value is
+      // null). Mirrors oura_hrv_trend's PR #10 dedup logic so cross-tool
+      // results agree on dates with multiple sleep periods (main + nap).
+      const valueFor = (p: SleepPeriod): number | null => {
         switch (metric) {
           case "hrv":
-            v = p.average_hrv;
-            break;
+            return p.average_hrv;
           case "rhr":
-            v = p.lowest_heart_rate;
-            break;
+            return p.lowest_heart_rate;
           case "sleep_total":
-            v = p.total_sleep_duration;
-            break;
+            return p.total_sleep_duration;
           case "deep_sleep":
-            v = p.deep_sleep_duration;
-            break;
+            return p.deep_sleep_duration;
           case "rem_sleep":
-            v = p.rem_sleep_duration;
-            break;
+            return p.rem_sleep_duration;
           case "respiratory_rate":
-            v = p.average_breath;
-            break;
+            return p.average_breath;
         }
-        source.set(day, v);
+      };
+      const byDay = new Map<string, SleepPeriod[]>();
+      for (const p of periods) {
+        if (p.type === "deleted") continue;
+        const list = byDay.get(p.day) ?? [];
+        list.push(p);
+        byDay.set(p.day, list);
+      }
+      const source = new Map<string, number | null>();
+      for (const [day, group] of byDay) {
+        const sorted = [...group].sort(
+          (a, b) => (b.total_sleep_duration ?? 0) - (a.total_sleep_duration ?? 0),
+        );
+        const chosen = sorted.find((p) => valueFor(p) !== null) ?? sorted[0];
+        if (!chosen) continue;
+        source.set(day, valueFor(chosen));
       }
       return buildSeries(start, end, source);
     }


### PR DESCRIPTION
Closes #16

## Summary

- `oura_baseline_compare` returned `current_value: null` for sleep-derived metrics (`hrv`, `respiratory_rate`, etc.) on dates where data clearly existed (per `oura_hrv_trend` / `oura_daily_readiness.raw_values`).
- Two compounding defects in `fetchMetricByDay` (apps/oura-mcp/src/oura/metrics.ts):
  1. The sleep-derived branch queried `/sleep` with `start=end=compareDate`. Oura's `/sleep` filters by `bedtime_start`, so periods with `p.day = D` but `bedtime_start` on D-1 evening were excluded. Fix: pad the API window to `[start-1, end+1]` and let `buildSeries` scope the returned map back to `[start, end]`.
  2. The dedup picked the longest period regardless of whether the chosen period's value for the requested metric was null. `oura_hrv_trend` (post-PR #10) picks the longest period whose `average_hrv` is non-null. Fix: replicate that logic, parameterized by the requested metric, so cross-tool results agree on multi-period dates.
- `baseline_compare.ts` is unchanged. The helper `mainSleepPerDay` in `metrics.ts` was inlined into the sleep-derived branch (only caller) and removed; `readiness.ts` has its own local copy and is unaffected.
- `fallback: "latest"` now works end-to-end for sleep-derived metrics — previously the backward scan reused the same broken fetch and returned null on every prior day.

## Test plan

- [x] `pnpm -r type-check` passes.
- [ ] Deploy and verify `oura_baseline_compare` `metric: "hrv"`, `date: "2026-05-14"` returns `current_value: 48` (matching `oura_hrv_trend` for the same date).
- [ ] Same for `metric: "respiratory_rate"` on 2026-05-10 / 14 / 15.
- [ ] Verify day-keyed metrics (`readiness`, `sleep_score`, `activity_score`, `spo2`) still return the same values they did pre-fix.
- [ ] Verify `fallback: "latest"` for `metric: "hrv"` on a stale-sync morning returns a non-null `current_value` with `actual_date_used` and `days_lag` populated.

## Follow-ups (not in this PR)

- PR #15's documentation note saying `baseline_compare` uses "sleep-period-start date" for sleep metrics is technically still accurate (we still key on `p.day`), but the more important point is that callers can now query a single date and get the value they'd see in `hrv_trend`/`raw_values` for that same calendar date — so the "mixed convention" framing in #15 may warrant a follow-up doc tweak.
- `oura_hrv_trend` itself likely has the same single-day-window blind spot if called with `start=end=D`; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)