### PR TITLE
[oura-mcp] fix overlay_tags dropping tags whose start_time crosses UTC day

### DIFF
--- a/apps/oura-mcp/src/oura/metrics.ts
+++ b/apps/oura-mcp/src/oura/metrics.ts
@@ -69,6 +69,17 @@ function tagDisplayName(t: { tag_type_code: string; custom_name: string | null }
  * Fetch all tags overlapping `[start, end]` in a SINGLE paginated call and
  * return a date-keyed map. When `filter` is a string[], only tags whose
  * display name matches one of the entries (case-insensitive) are kept.
+ *
+ * The Oura `/enhanced_tag` endpoint filters server-side using a UTC-derived
+ * comparison on `start_time`, not on the tag's `start_day` field. A tag
+ * whose `start_day` falls inside `[start, end]` can still be dropped from
+ * the response if its `start_time`, converted to UTC, lands on the next
+ * (or previous) calendar day — e.g. an evening 2026-04-11 tag in -07:00
+ * with UTC `start_time` of 2026-04-12T03:17:54Z disappears from a query
+ * ending on 2026-04-12. To recover these tz-crossing tags we widen the
+ * API window by one day on each side; bucketing still uses the tag's own
+ * `start_day` below, so tags from the padding days bucket under their
+ * own `start_day` keys and are simply never looked up by callers.
  */
 export async function fetchTagsByDay(
   client: OuraClient,
@@ -82,7 +93,10 @@ export async function fetchTagsByDay(
     Array.isArray(filter)
       ? new Set(filter.map((n) => n.toLowerCase()))
       : null;
-  const tags = await getEnhancedTags(client, { start_date: start, end_date: end });
+  const tags = await getEnhancedTags(client, {
+    start_date: addDays(start, -1),
+    end_date: addDays(end, 1),
+  });
   for (const t of tags) {
     const name = tagDisplayName(t);
     if (names && !names.has(name.toLowerCase())) continue;


### PR DESCRIPTION
Closes #18

## Summary

- The bucketing logic in `fetchTagsByDay` already keyed by `t.start_day`, so the dropped tags weren't a keying bug — they were never in the response at all.
- Oura's `/enhanced_tag` endpoint filters server-side using a UTC-derived comparison on `start_time`, not on `start_day`. A tag with `start_day: "2026-04-11"` and `start_time: "2026-04-11T20:17:54-07:00"` (UTC: 2026-04-12T03:17:54Z) is excluded from a query whose `end_date` is 2026-04-12, because the UTC cutoff is 2026-04-12T00:00:00Z.
- Fix: pad the `/enhanced_tag` window by ±1 day inside `fetchTagsByDay`. Bucketing by `t.start_day` (unchanged) keeps padding-day tags from leaking onto user-requested rows.

## Trace

- April 11 case (window 2026-04-04 to 2026-04-12 from issue): padded query [2026-04-03, 2026-04-13]; Oura UTC cutoff is 2026-04-13T00:00Z which now covers the airplane/travel tag at 2026-04-12T03:17:54Z. All 3 tags bucket under key `"2026-04-11"` and attach to the April 11 readiness row.
- April 4 case (same window): all 3 source-day-matches-UTC-day tags were already returned; they still bucket under `"2026-04-04"`. No regression.
- Same single helper feeds `oura_daily_readiness`, `oura_hrv_trend`, `oura_respiratory_trend`, so all three benefit.

## Test plan

- [x] `pnpm -r type-check` clean
- [ ] Manual smoke after deploy: `oura_daily_readiness` with `start_date=2026-04-04`, `end_date=2026-04-12`, `overlay_tags: true` returns 3 tags on the April 11 row and 3 tags on the April 4 row.
- [ ] Same call on `oura_hrv_trend` and `oura_respiratory_trend` shows the same April 11 attachment.