### PR TITLE
[oura-mcp] exclude late_nap/rest from sleep-derived analytical metrics

### DIFF
--- a/apps/oura-mcp/src/oura/metrics.ts
+++ b/apps/oura-mcp/src/oura/metrics.ts
@@ -234,7 +234,7 @@ export async function fetchMetricByDay(
       };
       const byDay = new Map<string, SleepPeriod[]>();
       for (const p of periods) {
-        if (p.type === "deleted") continue;
+        if (p.type !== "sleep" && p.type !== "long_sleep") continue;
         const list = byDay.get(p.day) ?? [];
         list.push(p);
         byDay.set(p.day, list);

--- a/apps/oura-mcp/src/tools/readiness.ts
+++ b/apps/oura-mcp/src/tools/readiness.ts
@@ -36,7 +36,7 @@ interface ReadinessWithRawValues extends DailyReadiness {
 function mainSleepPerDay(periods: SleepPeriod[]): Map<string, SleepPeriod> {
   const byDay = new Map<string, SleepPeriod>();
   for (const p of periods) {
-    if (p.type === "deleted") continue;
+    if (p.type !== "sleep" && p.type !== "long_sleep") continue;
     const existing = byDay.get(p.day);
     const existingDur = existing?.total_sleep_duration ?? -1;
     const candidateDur = p.total_sleep_duration ?? -1;

--- a/apps/oura-mcp/src/tools/respiratory_trend.ts
+++ b/apps/oura-mcp/src/tools/respiratory_trend.ts
@@ -26,7 +26,7 @@ interface RespiratoryTrendEntry {
  * average_breath, fall back to the next-longest. Skips deleted periods.
  */
 function pickPeriodForRespiratory(periods: SleepPeriod[]): SleepPeriod | undefined {
-  const usable = periods.filter((p) => p.type !== "deleted");
+  const usable = periods.filter((p) => p.type === "sleep" || p.type === "long_sleep");
   if (usable.length === 0) return undefined;
   // Sort by total_sleep_duration descending (nulls treated as -1).
   const sorted = [...usable].sort(

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -134,7 +134,7 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
         // the date has null HRV, keep the longest period anyway (so the date is still represented).
         const byDate = new Map<string, typeof periods>();
         for (const p of periods) {
-          if (p.type === "deleted") continue;
+          if (p.type !== "sleep" && p.type !== "long_sleep") continue;
           const list = byDate.get(p.day) ?? [];
           list.push(p);
           byDate.set(p.day, list);


### PR DESCRIPTION
Closes #19

## Summary

The sleep-period dedup loops in `metrics.ts`, `sleep.ts` (oura_hrv_trend), `respiratory_trend.ts`, and `readiness.ts` were byte-identical and all filtered only `type === "deleted"`. This allowed `late_nap` and `rest` periods to be picked as the "main sleep" for a date when no overnight sleep landed on that `p.day`. Filter narrowed to the allow-list `{sleep, long_sleep}`.

Behavioral implications:
- `oura_hrv_trend` no longer returns a row for dates where the user took a daytime nap but no overnight main sleep landed on that `p.day`. That's correct — those days don't have a "main sleep" reading.
- `oura_baseline_compare(metric: "hrv")` for the May 16 case now returns `null current_value` (no main sleep for `p.day === "2026-05-16"`) — which is precisely when `fallback: "latest"` is meant to surface the prior night's main-sleep value (41) instead of the bogus 60. This restores the design intent of PR #11's fallback.
- `oura_illness_signals` on the May 16 case will now correctly use the prior night's main-sleep HRV (41) via its default `fallback: "latest"`, yielding an `exertion_ceiling` informed by HRV 41 rather than nap-skewed 60.

`oura_sleep_detail` (the raw-detail tool) is intentionally NOT filtered — its job is to surface ALL periods including naps so callers can inspect them.

## Test plan

- [x] `pnpm -r type-check` passes
- [ ] Smoke: `oura_hrv_trend` over a window containing May 16 omits the 5/16 row (or carries the nap's hrv=60 → confirms it's filtered out)
- [ ] Smoke: `oura_baseline_compare(metric: "hrv", date: "2026-05-16", fallback: "strict")` returns `current_value: null`
- [ ] Smoke: `oura_baseline_compare(metric: "hrv", date: "2026-05-16", fallback: "latest")` returns May 15's main-sleep HRV (41)
- [ ] Smoke: `oura_illness_signals` for May 16 uses HRV 41, not 60

🤖 Generated with [Claude Code](https://claude.com/claude-code)