### PR TITLE
[github-mcp] Add label management tools (create/update/delete)

### DIFF
--- a/apps/github-mcp/README.md
+++ b/apps/github-mcp/README.md
@@ -29,8 +29,11 @@ for one-shot "open an issue" workflows.
 |---|---|
 | `github_add_labels` | Additive — keeps existing labels. |
 | `github_set_labels` | Replaces the full label set. |
-| `github_remove_label` | Remove a single label. |
+| `github_remove_label` | Remove a single label from one issue. |
 | `github_list_repo_labels` | List labels defined on a repo. |
+| `github_create_label` | Create a repo-level label (name + hex color, optional description). |
+| `github_update_label` | Rename / recolor / re-describe an existing repo label. |
+| `github_delete_label` | Delete a repo label. Cascades: also removes it from every issue using it. |
 
 ### Assignees
 | Tool | What it does |

--- a/apps/github-mcp/src/tools/labels.ts
+++ b/apps/github-mcp/src/tools/labels.ts
@@ -8,6 +8,15 @@ const repoArg = z
   .optional()
   .describe("Target repo as 'owner/name'. Falls back to GITHUB_DEFAULT_REPO when omitted.");
 
+const colorArg = z
+  .string()
+  .regex(/^#?[0-9a-fA-F]{6}$/, "color must be a 6-digit hex string (leading # optional)")
+  .describe("6-digit hex color, e.g. 'ededed' (leading # accepted but stripped).");
+
+function normalizeColor(c: string): string {
+  return c.startsWith("#") ? c.slice(1) : c;
+}
+
 export function registerLabelTools(
   server: McpServer,
   client: GitHubClient,
@@ -75,6 +84,79 @@ export function registerLabelTools(
           `/repos/${r.owner}/${r.repo}/issues/${issue_number}/labels/${encodeURIComponent(label)}`,
         );
         return textContent(result ?? { ok: true, removed: label });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+  );
+
+  server.tool(
+    "github_create_label",
+    "Create a new label on a repo. 'color' is required by the GitHub API (6-digit hex, no leading #). Fails with a 422 error if a label with the same name already exists — use github_update_label to change an existing one.",
+    {
+      repo: repoArg,
+      name: z.string().min(1).describe("Label name, e.g. 'bug' or 'app:github-mcp'."),
+      color: colorArg,
+      description: z.string().max(100).optional(),
+    },
+    async ({ repo, name, color, description }) => {
+      const r = resolveRepo(repo, defaultRepo);
+      if ("error" in r) return r.error;
+      try {
+        const body: Record<string, unknown> = { name, color: normalizeColor(color) };
+        if (description !== undefined) body.description = description;
+        const result = await client.post<unknown>(`/repos/${r.owner}/${r.repo}/labels`, body);
+        return textContent(result);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+  );
+
+  server.tool(
+    "github_update_label",
+    "Update an existing repo label by its current name. Can rename (new_name), recolor (color), or change description. Only provided fields are sent.",
+    {
+      repo: repoArg,
+      name: z.string().min(1).describe("Current label name (used to locate the label)."),
+      new_name: z.string().min(1).optional().describe("New label name. Omit to keep current name."),
+      color: colorArg.optional(),
+      description: z.string().max(100).optional(),
+    },
+    async ({ repo, name, new_name, color, description }) => {
+      const r = resolveRepo(repo, defaultRepo);
+      if ("error" in r) return r.error;
+      try {
+        const body: Record<string, unknown> = {};
+        if (new_name !== undefined) body.new_name = new_name;
+        if (color !== undefined) body.color = normalizeColor(color);
+        if (description !== undefined) body.description = description;
+        const result = await client.patch<unknown>(
+          `/repos/${r.owner}/${r.repo}/labels/${encodeURIComponent(name)}`,
+          body,
+        );
+        return textContent(result);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+  );
+
+  server.tool(
+    "github_delete_label",
+    "Delete a label from a repo by name. CASCADE WARNING: this also removes the label from every issue and pull request currently using it. Use with care — to merely take a label off one issue, use github_remove_label instead.",
+    {
+      repo: repoArg,
+      name: z.string().min(1).describe("Label name to delete."),
+    },
+    async ({ repo, name }) => {
+      const r = resolveRepo(repo, defaultRepo);
+      if ("error" in r) return r.error;
+      try {
+        const result = await client.delete<unknown>(
+          `/repos/${r.owner}/${r.repo}/labels/${encodeURIComponent(name)}`,
+        );
+        return textContent(result ?? { ok: true, deleted: name });
       } catch (e) {
         return handleError(e);
       }


### PR DESCRIPTION
Closes #23

## Summary

Adds three new tools to `apps/github-mcp` for repo-level label management:

- `github_create_label` — creates a label with `name` + `color` (required, hex) and optional `description`. Duplicate names surface as a GitHub 422 error (via the existing `GitHubApiError` flow) rather than silently no-op'ing.
- `github_update_label` — `PATCH /repos/{owner}/{repo}/labels/{name}` with any of `new_name`, `color`, `description`. Only provided fields are sent.
- `github_delete_label` — deletes a repo label by name. Tool description explicitly warns about the cascade: GitHub removes the label from every issue/PR using it, so the LLM doesn't nuke the vocabulary by mistake.

`github_list_repo_labels` is untouched.

## Decisions

- **Color format:** accept 6-digit hex with optional leading `#` (zod regex `^#?[0-9a-fA-F]{6}$`), then strip `#` before sending. Less friction for users who paste from a color picker.
- **No new tests added.** `apps/github-mcp` has no existing test suite; the tools follow the established `resolveRepo` / `handleError` / `textContent` pattern of the other label tools.

## Verification

- `pnpm -r type-check` — all 12 projects pass
- `pnpm -r test` — all suites pass (github-mcp has no test files; `--passWithNoTests`)

## Test plan
- [ ] Deploy and confirm `github_create_label` creates a label, returns the created object
- [ ] Try creating a duplicate name; confirm the 422 surfaces with a readable message
- [ ] `github_update_label` renames a label and updates color
- [ ] `github_delete_label` removes the label (verify cascade off an issue)