### PR TITLE
[github-mcp] repo allowlist + README hardening

### DIFF
--- a/apps/github-mcp/README.md
+++ b/apps/github-mcp/README.md
@@ -62,7 +62,13 @@ pnpm wrangler secret put MCP_PATH_SECRET
 # Optional but recommended: default repo for tools called without 'repo' arg
 pnpm wrangler secret put GITHUB_DEFAULT_REPO   # e.g. tusensii/mcp-stack
 
-pnpm deploy
+# Strongly recommended when the PAT can reach more repos than this Worker
+# should touch: comma-separated owner/repo allowlist. GITHUB_DEFAULT_REPO
+# is implicitly included. Tool calls targeting any other repo are rejected
+# before hitting the GitHub API.
+pnpm wrangler secret put GITHUB_ALLOWED_REPOS  # e.g. tusensii/mcp-stack,tusensii/mcp-stack-private
+
+pnpm run deploy
 ```
 
 ## Connect from Claude.ai
@@ -89,9 +95,17 @@ to file an issue. Without an explicit `repo` arg it'll target
 
 ## Security notes
 
-The PAT is broad by design (Christopher's full account) so this MCP can
-review or act on any of his repos. The Worker is gated behind a
-URL-path secret, CORS-locked to `https://claude.ai`, and only ever
-holds the token in the Wrangler secret store. If the path secret leaks,
-rotate it via `pnpm wrangler secret put MCP_PATH_SECRET`; if the PAT
-leaks, revoke at https://github.com/settings/tokens and re-issue.
+The deploying user's PAT determines which repos this Worker can reach.
+A classic `repo`-scope PAT grants access to every repo the user owns or
+collaborates on, so prefer a fine-grained PAT scoped to just the repos
+this Worker needs. As a second line of defense, set `GITHUB_ALLOWED_REPOS`
+to an explicit allowlist — tool calls targeting any other repo are
+rejected at the Worker before the PAT is used. The Worker is also gated
+by a URL-path secret and only holds the token in the Wrangler secret
+store. The `corsOptions.origin = https://claude.ai` setting only affects
+browser preflights; non-browser clients are gated by the path secret, not
+by CORS.
+
+Rotation: if the path secret leaks, replace it via
+`pnpm wrangler secret put MCP_PATH_SECRET`. If the PAT leaks, revoke at
+https://github.com/settings/tokens and re-issue.

--- a/apps/github-mcp/src/server.ts
+++ b/apps/github-mcp/src/server.ts
@@ -18,14 +18,31 @@ export interface Env {
    * Optional — empty/unset means no default labels.
    */
   GITHUB_DEFAULT_LABELS?: string;
+  /**
+   * Comma-separated `owner/repo` allowlist. When set, tool calls targeting
+   * any other repo are rejected before hitting the GitHub API.
+   * `GITHUB_DEFAULT_REPO`, if set, is implicitly included. Optional — unset
+   * means no Worker-level restriction (the PAT scope is the only gate).
+   */
+  GITHUB_ALLOWED_REPOS?: string;
 }
 
-function parseDefaultLabels(raw: string | undefined): string[] {
+function parseCsv(raw: string | undefined): string[] {
   if (!raw) return [];
   return raw
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+}
+
+function parseAllowedRepos(
+  raw: string | undefined,
+  defaultRepo: string | undefined,
+): Set<string> | undefined {
+  const list = parseCsv(raw).map((s) => s.toLowerCase());
+  if (defaultRepo) list.push(defaultRepo.toLowerCase());
+  if (list.length === 0) return undefined;
+  return new Set(list);
 }
 
 export function buildServer(env: Env): McpServer {
@@ -35,7 +52,13 @@ export function buildServer(env: Env): McpServer {
   });
 
   const client = new GitHubClient(env.GITHUB_TOKEN);
-  registerAllTools(server, client, env.GITHUB_DEFAULT_REPO, parseDefaultLabels(env.GITHUB_DEFAULT_LABELS));
+  registerAllTools(
+    server,
+    client,
+    env.GITHUB_DEFAULT_REPO,
+    parseCsv(env.GITHUB_DEFAULT_LABELS),
+    parseAllowedRepos(env.GITHUB_ALLOWED_REPOS, env.GITHUB_DEFAULT_REPO),
+  );
 
   return server;
 }

--- a/apps/github-mcp/src/tools/assignees.ts
+++ b/apps/github-mcp/src/tools/assignees.ts
@@ -12,6 +12,7 @@ export function registerAssigneeTools(
   server: McpServer,
   client: GitHubClient,
   defaultRepo: string | undefined,
+  allowedRepos: Set<string> | undefined,
 ): void {
   server.tool(
     "github_add_assignees",
@@ -22,7 +23,7 @@ export function registerAssigneeTools(
       assignees: z.array(z.string().min(1)).min(1),
     },
     async ({ repo, issue_number, assignees }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const issue = await client.post<unknown>(
@@ -45,7 +46,7 @@ export function registerAssigneeTools(
       assignees: z.array(z.string().min(1)).min(1),
     },
     async ({ repo, issue_number, assignees }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const issue = await client.delete<unknown>(

--- a/apps/github-mcp/src/tools/comments.ts
+++ b/apps/github-mcp/src/tools/comments.ts
@@ -12,6 +12,7 @@ export function registerCommentTools(
   server: McpServer,
   client: GitHubClient,
   defaultRepo: string | undefined,
+  allowedRepos: Set<string> | undefined,
 ): void {
   server.tool(
     "github_add_issue_comment",
@@ -22,7 +23,7 @@ export function registerCommentTools(
       body: z.string().min(1).describe("Markdown body."),
     },
     async ({ repo, issue_number, body }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const comment = await client.post<unknown>(
@@ -47,7 +48,7 @@ export function registerCommentTools(
       page: z.number().int().min(1).optional(),
     },
     async ({ repo, issue_number, ...params }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const comments = await client.get<unknown>(
@@ -70,7 +71,7 @@ export function registerCommentTools(
       body: z.string().min(1),
     },
     async ({ repo, comment_id, body }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const comment = await client.patch<unknown>(
@@ -92,7 +93,7 @@ export function registerCommentTools(
       comment_id: z.number().int().min(1),
     },
     async ({ repo, comment_id }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         await client.delete<void>(`/repos/${r.owner}/${r.repo}/issues/comments/${comment_id}`);

--- a/apps/github-mcp/src/tools/index.ts
+++ b/apps/github-mcp/src/tools/index.ts
@@ -11,10 +11,11 @@ export function registerAllTools(
   client: GitHubClient,
   defaultRepo: string | undefined,
   defaultLabels: string[],
+  allowedRepos: Set<string> | undefined,
 ): void {
-  registerIssueTools(server, client, defaultRepo, defaultLabels);
-  registerCommentTools(server, client, defaultRepo);
-  registerLabelTools(server, client, defaultRepo);
-  registerAssigneeTools(server, client, defaultRepo);
+  registerIssueTools(server, client, defaultRepo, defaultLabels, allowedRepos);
+  registerCommentTools(server, client, defaultRepo, allowedRepos);
+  registerLabelTools(server, client, defaultRepo, allowedRepos);
+  registerAssigneeTools(server, client, defaultRepo, allowedRepos);
   registerSearchTools(server, client);
 }

--- a/apps/github-mcp/src/tools/issues.ts
+++ b/apps/github-mcp/src/tools/issues.ts
@@ -13,6 +13,7 @@ export function registerIssueTools(
   client: GitHubClient,
   defaultRepo: string | undefined,
   defaultLabels: string[],
+  allowedRepos: Set<string> | undefined,
 ): void {
   const createIssueLabelsDesc =
     defaultLabels.length > 0
@@ -31,7 +32,7 @@ export function registerIssueTools(
       milestone: z.number().int().optional().describe("Milestone number (not title)."),
     },
     async ({ repo, title, body, labels, assignees, milestone }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       const mergedLabels = Array.from(new Set([...defaultLabels, ...(labels ?? [])]));
       try {
@@ -57,7 +58,7 @@ export function registerIssueTools(
       issue_number: z.number().int().min(1),
     },
     async ({ repo, issue_number }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const issue = await client.get<unknown>(`/repos/${r.owner}/${r.repo}/issues/${issue_number}`);
@@ -87,7 +88,7 @@ export function registerIssueTools(
       page: z.number().int().min(1).optional(),
     },
     async ({ repo, ...params }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const issues = await client.get<unknown>(`/repos/${r.owner}/${r.repo}/issues`, params);
@@ -114,7 +115,7 @@ export function registerIssueTools(
       milestone: z.number().int().nullable().optional().describe("Pass null to clear."),
     },
     async ({ repo, issue_number, ...patch }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       const body: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(patch)) {
@@ -144,7 +145,7 @@ export function registerIssueTools(
       lock_reason: z.enum(["off-topic", "too heated", "resolved", "spam"]).optional(),
     },
     async ({ repo, issue_number, lock_reason }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         await client.put<void>(
@@ -166,7 +167,7 @@ export function registerIssueTools(
       issue_number: z.number().int().min(1),
     },
     async ({ repo, issue_number }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         await client.delete<void>(`/repos/${r.owner}/${r.repo}/issues/${issue_number}/lock`);

--- a/apps/github-mcp/src/tools/labels.ts
+++ b/apps/github-mcp/src/tools/labels.ts
@@ -21,6 +21,7 @@ export function registerLabelTools(
   server: McpServer,
   client: GitHubClient,
   defaultRepo: string | undefined,
+  allowedRepos: Set<string> | undefined,
 ): void {
   server.tool(
     "github_add_labels",
@@ -31,7 +32,7 @@ export function registerLabelTools(
       labels: z.array(z.string().min(1)).min(1),
     },
     async ({ repo, issue_number, labels }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const result = await client.post<unknown>(
@@ -54,7 +55,7 @@ export function registerLabelTools(
       labels: z.array(z.string()).describe("Full replacement set."),
     },
     async ({ repo, issue_number, labels }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const result = await client.put<unknown>(
@@ -77,7 +78,7 @@ export function registerLabelTools(
       label: z.string().min(1),
     },
     async ({ repo, issue_number, label }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const result = await client.delete<unknown>(
@@ -100,7 +101,7 @@ export function registerLabelTools(
       description: z.string().max(100).optional(),
     },
     async ({ repo, name, color, description }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const body: Record<string, unknown> = { name, color: normalizeColor(color) };
@@ -124,7 +125,7 @@ export function registerLabelTools(
       description: z.string().max(100).optional(),
     },
     async ({ repo, name, new_name, color, description }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const body: Record<string, unknown> = {};
@@ -150,7 +151,7 @@ export function registerLabelTools(
       name: z.string().min(1).describe("Label name to delete."),
     },
     async ({ repo, name }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const result = await client.delete<unknown>(
@@ -172,7 +173,7 @@ export function registerLabelTools(
       page: z.number().int().min(1).optional(),
     },
     async ({ repo, ...params }) => {
-      const r = resolveRepo(repo, defaultRepo);
+      const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
         const labels = await client.get<unknown>(`/repos/${r.owner}/${r.repo}/labels`, params);

--- a/apps/github-mcp/src/tools/utils.ts
+++ b/apps/github-mcp/src/tools/utils.ts
@@ -12,6 +12,7 @@ const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 export function resolveRepo(
   arg: string | undefined,
   defaultRepo: string | undefined,
+  allowedRepos?: Set<string>,
 ): { owner: string; repo: string } | { error: McpToolResponse } {
   const value = arg ?? defaultRepo;
   if (!value) {
@@ -23,6 +24,13 @@ export function resolveRepo(
   }
   if (!REPO_RE.test(value)) {
     return { error: errorContent(`Invalid repo '${value}'. Expected 'owner/name'.`) };
+  }
+  if (allowedRepos && !allowedRepos.has(value.toLowerCase())) {
+    return {
+      error: errorContent(
+        `Repo '${value}' is not in the GITHUB_ALLOWED_REPOS allowlist for this Worker.`,
+      ),
+    };
   }
   const [owner, repo] = value.split("/") as [string, string];
   return { owner, repo };


### PR DESCRIPTION
Fixes from a public-repo review pass — three concrete items spotted in the github-mcp Worker after the public split.

## Summary
- **Repo allowlist (`GITHUB_ALLOWED_REPOS`)** — optional, comma-separated `owner/repo` list. When set, `resolveRepo()` rejects any other repo before the PAT is used. `GITHUB_DEFAULT_REPO` is implicitly included. Defense-in-depth for the case where the PAT is broader than the Worker should be. Unset = previous behavior.
- **README: `pnpm deploy` → `pnpm run deploy`** — `pnpm deploy` is pnpm's built-in workspace-deploy command, not the wrangler script. Following the README as written would not run `wrangler deploy`.
- **README: tighten Security notes** — drop the first-name reference, clarify that `corsOptions.origin = https://claude.ai` only affects browser preflights (non-browser clients are gated by the path secret, not by CORS), and document the new allowlist.

No behavior change when `GITHUB_ALLOWED_REPOS` is unset. `pnpm -r type-check` and `pnpm -r test` both green.

## Test plan
- [x] `pnpm -r type-check`
- [x] `pnpm -r test`
- [ ] After merge: set `GITHUB_ALLOWED_REPOS` via `pnpm wrangler secret put` on the deployed Worker, then confirm a tool call against a repo outside the allowlist returns the rejection error.