### PR TITLE
[github-mcp] Handle missing labels gracefully on issue/label tools

### DIFF
--- a/apps/github-mcp/src/tools/issues.ts
+++ b/apps/github-mcp/src/tools/issues.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
 import { resolveRepo, handleError, textContent, errorContent } from "./utils.js";
+import { preflightLabels } from "./labels.js";
 
 const repoArg = z
   .string()
@@ -22,7 +23,11 @@ export function registerIssueTools(
 
   server.tool(
     "github_create_issue",
-    "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional.",
+    "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional. " +
+      "By default, fails with a structured error if any requested label does not exist " +
+      "on the repo (GitHub itself silently drops unknown labels, which we treat as a bug). " +
+      "Pass create_missing_labels: true to auto-create unknown labels first, with a color " +
+      "heuristic (app:* → purple, area:* → green, other prefix → yellow, no prefix → grey).",
     {
       repo: repoArg,
       title: z.string().min(1).describe("Issue title."),
@@ -30,12 +35,26 @@ export function registerIssueTools(
       labels: z.array(z.string()).optional().describe(createIssueLabelsDesc),
       assignees: z.array(z.string()).optional().describe("GitHub usernames to assign."),
       milestone: z.number().int().optional().describe("Milestone number (not title)."),
+      create_missing_labels: z
+        .boolean()
+        .optional()
+        .describe("If true, auto-create any labels that don't exist on the repo. Default false."),
     },
-    async ({ repo, title, body, labels, assignees, milestone }) => {
+    async ({ repo, title, body, labels, assignees, milestone, create_missing_labels }) => {
       const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       const mergedLabels = Array.from(new Set([...defaultLabels, ...(labels ?? [])]));
       try {
+        if (mergedLabels.length > 0) {
+          const pf = await preflightLabels(
+            client,
+            r.owner,
+            r.repo,
+            mergedLabels,
+            create_missing_labels ?? false,
+          );
+          if ("error" in pf) return pf.error;
+        }
         const issue = await client.post<unknown>(`/repos/${r.owner}/${r.repo}/issues`, {
           title,
           ...(body !== undefined ? { body } : {}),

--- a/apps/github-mcp/src/tools/labels.test.ts
+++ b/apps/github-mcp/src/tools/labels.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import type { GitHubClient } from "../github/client.js";
+import { ensureLabelsExist, pickAutoLabelColor, preflightLabels } from "./labels.js";
+
+interface PostCall {
+  path: string;
+  body: unknown;
+}
+
+function makeMockClient(existing: string[]): {
+  client: GitHubClient;
+  posts: PostCall[];
+} {
+  const posts: PostCall[] = [];
+  const repoLabels = existing.map((name) => ({ name }));
+  const mock = {
+    async get<T>(_path: string, _params?: unknown): Promise<T> {
+      // Single page, less than 100 → ensureLabelsExist's loop exits after one iteration.
+      return repoLabels as unknown as T;
+    },
+    async post<T>(path: string, body: unknown): Promise<T> {
+      posts.push({ path, body });
+      return (body as { name: string }) as unknown as T;
+    },
+  };
+  return {
+    client: mock as unknown as GitHubClient,
+    posts,
+  };
+}
+
+describe("pickAutoLabelColor", () => {
+  it("app:* prefix → purple", () => {
+    expect(pickAutoLabelColor("app:github-mcp")).toBe("5319e7");
+    expect(pickAutoLabelColor("app:foo")).toBe("5319e7");
+  });
+
+  it("area:* prefix → green", () => {
+    expect(pickAutoLabelColor("area:auth")).toBe("0e8a16");
+  });
+
+  it("other recognized prefix → yellow", () => {
+    expect(pickAutoLabelColor("kind:cleanup")).toBe("fbca04");
+    expect(pickAutoLabelColor("priority:high")).toBe("fbca04");
+  });
+
+  it("no prefix → neutral grey", () => {
+    expect(pickAutoLabelColor("bug")).toBe("ededed");
+    expect(pickAutoLabelColor("enhancement")).toBe("ededed");
+    expect(pickAutoLabelColor("random")).toBe("ededed");
+  });
+});
+
+describe("ensureLabelsExist", () => {
+  it("returns empty missing when all labels exist", async () => {
+    const { client, posts } = makeMockClient(["bug", "enhancement", "claude-task"]);
+    const result = await ensureLabelsExist(
+      client,
+      "owner",
+      "repo",
+      ["bug", "claude-task"],
+      { create: false },
+    );
+    expect(result.missing).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(posts).toHaveLength(0);
+  });
+
+  it("returns missing names when create=false and labels are absent", async () => {
+    const { client, posts } = makeMockClient(["bug"]);
+    const result = await ensureLabelsExist(
+      client,
+      "owner",
+      "repo",
+      ["bug", "app:new-app", "random-missing"],
+      { create: false },
+    );
+    expect(result.missing).toEqual(["app:new-app", "random-missing"]);
+    expect(result.created).toEqual([]);
+    expect(posts).toHaveLength(0);
+  });
+
+  it("auto-creates missing labels with color heuristic when create=true", async () => {
+    const { client, posts } = makeMockClient(["bug"]);
+    const result = await ensureLabelsExist(
+      client,
+      "owner",
+      "repo",
+      ["bug", "app:foo", "area:bar", "random"],
+      { create: true },
+    );
+    expect(result.missing).toEqual([]);
+    expect(result.created).toEqual(["app:foo", "area:bar", "random"]);
+    expect(posts).toHaveLength(3);
+    expect(posts[0]).toEqual({
+      path: "/repos/owner/repo/labels",
+      body: {
+        name: "app:foo",
+        color: "5319e7",
+        description: "Auto-created by github-mcp.",
+      },
+    });
+    expect(posts[1]?.body).toMatchObject({ name: "area:bar", color: "0e8a16" });
+    expect(posts[2]?.body).toMatchObject({ name: "random", color: "ededed" });
+  });
+
+  it("no-ops when label list is empty (does not even fetch)", async () => {
+    const { client, posts } = makeMockClient(["bug"]);
+    const result = await ensureLabelsExist(client, "owner", "repo", [], { create: true });
+    expect(result.missing).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(posts).toHaveLength(0);
+  });
+});
+
+describe("preflightLabels", () => {
+  it("returns ok when all labels exist", async () => {
+    const { client } = makeMockClient(["bug", "claude-task"]);
+    const result = await preflightLabels(client, "o", "r", ["bug", "claude-task"], false);
+    expect("ok" in result && result.ok).toBe(true);
+  });
+
+  it("returns structured error naming missing labels when create_missing_labels=false", async () => {
+    const { client } = makeMockClient(["bug"]);
+    const result = await preflightLabels(
+      client,
+      "o",
+      "r",
+      ["bug", "app:ghost", "lost"],
+      false,
+    );
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.isError).toBe(true);
+      const text = result.error.content[0]?.text ?? "";
+      expect(text).toContain("app:ghost");
+      expect(text).toContain("lost");
+      expect(text).toContain("create_missing_labels");
+    }
+  });
+
+  it("returns ok and creates labels when create_missing_labels=true", async () => {
+    const { client, posts } = makeMockClient([]);
+    const result = await preflightLabels(client, "o", "r", ["app:foo"], true);
+    expect("ok" in result && result.ok).toBe(true);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.body).toMatchObject({ name: "app:foo", color: "5319e7" });
+  });
+
+  it("returns ok with empty created list when labels array is empty", async () => {
+    const { client, posts } = makeMockClient(["bug"]);
+    const result = await preflightLabels(client, "o", "r", [], false);
+    expect("ok" in result && result.ok).toBe(true);
+    if ("ok" in result) expect(result.created).toEqual([]);
+    expect(posts).toHaveLength(0);
+  });
+});

--- a/apps/github-mcp/src/tools/labels.ts
+++ b/apps/github-mcp/src/tools/labels.ts
@@ -1,7 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { resolveRepo, handleError, textContent } from "./utils.js";
+import { resolveRepo, handleError, textContent, errorContent } from "./utils.js";
+import type { McpToolResponse } from "@mcp-stack/mcp-core";
 
 const repoArg = z
   .string()
@@ -17,6 +18,98 @@ function normalizeColor(c: string): string {
   return c.startsWith("#") ? c.slice(1) : c;
 }
 
+/**
+ * Color heuristic for auto-created labels. The `app:*` prefix is the
+ * established convention for app-scoping labels in this repo and gets
+ * the canonical purple. Other recognized prefixes get a sensible default;
+ * unprefixed labels get neutral grey.
+ */
+export function pickAutoLabelColor(name: string): string {
+  if (name.startsWith("app:")) return "5319e7"; // purple
+  if (name.startsWith("area:")) return "0e8a16"; // green
+  // any other prefix (e.g. `kind:`, `priority:`, …)
+  if (/^[a-z0-9_-]+:/i.test(name)) return "fbca04"; // yellow
+  return "ededed"; // neutral grey
+}
+
+const AUTO_LABEL_DESCRIPTION = "Auto-created by github-mcp.";
+
+interface RepoLabel {
+  name: string;
+}
+
+/**
+ * Ensure every name in `labels` exists on the target repo. Returns the
+ * subset that was missing at the time of the check. When `create` is true,
+ * missing labels are POSTed before returning (with the color heuristic
+ * and a generic auto-created description).
+ */
+export async function ensureLabelsExist(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  labels: readonly string[],
+  opts: { create: boolean },
+): Promise<{ missing: string[]; created: string[] }> {
+  if (labels.length === 0) return { missing: [], created: [] };
+
+  // Page through repo labels. 100/page is the API max.
+  const existing = new Set<string>();
+  for (let page = 1; ; page++) {
+    const batch = await client.get<RepoLabel[]>(`/repos/${owner}/${repo}/labels`, {
+      per_page: 100,
+      page,
+    });
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    for (const l of batch) existing.add(l.name);
+    if (batch.length < 100) break;
+  }
+
+  const missing = labels.filter((n) => !existing.has(n));
+  if (missing.length === 0 || !opts.create) {
+    return { missing, created: [] };
+  }
+
+  const created: string[] = [];
+  for (const name of missing) {
+    await client.post<unknown>(`/repos/${owner}/${repo}/labels`, {
+      name,
+      color: pickAutoLabelColor(name),
+      description: AUTO_LABEL_DESCRIPTION,
+    });
+    created.push(name);
+  }
+  return { missing: [], created };
+}
+
+/**
+ * Shared pre-flight for tools that send a `labels` array to GitHub.
+ * Returns `{ ok: true }` if all labels exist (or were just created);
+ * otherwise returns a tool-shaped error response naming the missing labels.
+ */
+export async function preflightLabels(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  labels: readonly string[],
+  createMissing: boolean,
+): Promise<{ ok: true; created: string[] } | { error: McpToolResponse }> {
+  if (labels.length === 0) return { ok: true, created: [] };
+  const { missing, created } = await ensureLabelsExist(client, owner, repo, labels, {
+    create: createMissing,
+  });
+  if (missing.length > 0) {
+    return {
+      error: errorContent(
+        `Label(s) do not exist on ${owner}/${repo}: ${missing.join(", ")}. ` +
+          `Pass create_missing_labels: true to auto-create them, or create them ` +
+          `first with github_create_label.`,
+      ),
+    };
+  }
+  return { ok: true, created };
+}
+
 export function registerLabelTools(
   server: McpServer,
   client: GitHubClient,
@@ -25,16 +118,32 @@ export function registerLabelTools(
 ): void {
   server.tool(
     "github_add_labels",
-    "Add labels to an issue (additive; existing labels kept).",
+    "Add labels to an issue (additive; existing labels kept). " +
+      "By default, fails with a structured error if any label does not exist " +
+      "on the repo (GitHub itself silently drops unknown labels, which we treat as a bug). " +
+      "Pass create_missing_labels: true to auto-create unknown labels with a color heuristic " +
+      "(app:* → purple, area:* → green, other prefix → yellow, no prefix → grey).",
     {
       repo: repoArg,
       issue_number: z.number().int().min(1),
       labels: z.array(z.string().min(1)).min(1),
+      create_missing_labels: z
+        .boolean()
+        .optional()
+        .describe("If true, auto-create any labels that don't exist on the repo. Default false."),
     },
-    async ({ repo, issue_number, labels }) => {
+    async ({ repo, issue_number, labels, create_missing_labels }) => {
       const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
+        const pf = await preflightLabels(
+          client,
+          r.owner,
+          r.repo,
+          labels,
+          create_missing_labels ?? false,
+        );
+        if ("error" in pf) return pf.error;
         const result = await client.post<unknown>(
           `/repos/${r.owner}/${r.repo}/issues/${issue_number}/labels`,
           { labels },
@@ -48,16 +157,32 @@ export function registerLabelTools(
 
   server.tool(
     "github_set_labels",
-    "Replace all labels on an issue with the provided set. Pass empty array to clear.",
+    "Replace all labels on an issue with the provided set. Pass empty array to clear. " +
+      "By default, fails with a structured error if any label does not exist on the repo " +
+      "(GitHub itself silently drops unknown labels, which we treat as a bug). " +
+      "Pass create_missing_labels: true to auto-create unknown labels with a color heuristic " +
+      "(app:* → purple, area:* → green, other prefix → yellow, no prefix → grey).",
     {
       repo: repoArg,
       issue_number: z.number().int().min(1),
       labels: z.array(z.string()).describe("Full replacement set."),
+      create_missing_labels: z
+        .boolean()
+        .optional()
+        .describe("If true, auto-create any labels that don't exist on the repo. Default false."),
     },
-    async ({ repo, issue_number, labels }) => {
+    async ({ repo, issue_number, labels, create_missing_labels }) => {
       const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
+        const pf = await preflightLabels(
+          client,
+          r.owner,
+          r.repo,
+          labels,
+          create_missing_labels ?? false,
+        );
+        if ("error" in pf) return pf.error;
         const result = await client.put<unknown>(
           `/repos/${r.owner}/${r.repo}/issues/${issue_number}/labels`,
           { labels },


### PR DESCRIPTION
Closes #31

## Summary
- Default behavior of `github_create_issue`, `github_add_labels`, and `github_set_labels` changes from silently dropping unknown labels (GitHub's native behavior) to returning a structured error naming every label that doesn't exist on the target repo.
- New optional `create_missing_labels: boolean` flag (default `false`) on each of those three tools. When `true`, missing labels are auto-created via the GitHub API before the issue/label apply proceeds.
- Color heuristic for auto-created labels:
  - `app:*` -> `5319e7` (purple, matches the established `app:github-mcp` convention)
  - `area:*` -> `0e8a16` (green)
  - any other `prefix:*` -> `fbca04` (yellow)
  - no prefix -> `ededed` (neutral grey)
  - description: `Auto-created by github-mcp.`
- Tool descriptions updated to document the new default and the flag.

## Implementation notes
- Pre-flight logic lives in `apps/github-mcp/src/tools/labels.ts` as exported helpers `pickAutoLabelColor`, `ensureLabelsExist`, and `preflightLabels`. `issues.ts` imports `preflightLabels` so the check happens before POSTing the issue (no half-applied issues).
- Repo labels are fetched paginated at 100/page.

## Breaking change
The issue explicitly calls out the previous silent-drop behavior as "the worst option and must change," so the new default is a loud structured error. Callers that want the old auto-tolerant path opt in with `create_missing_labels: true`.

## Test plan
- [x] `pnpm -r type-check` passes
- [x] `pnpm -r test` passes (12 new tests in `apps/github-mcp/src/tools/labels.test.ts`)
- [ ] After merge / deploy, smoke-test by filing a test issue with a brand-new `app:foo` label and `create_missing_labels: true`, then with `create_missing_labels: false` against an unknown label to confirm the error path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>