### PR TITLE
[oura-mcp] Fix sleep_detail/sessions docstrings, single-day bug, add naps/night_summary tools, timeseries stripping, type filter, baseline_compare staleness flag

### DIFF
--- a/apps/oura-mcp/src/oura/metrics.test.ts
+++ b/apps/oura-mcp/src/oura/metrics.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { selectMainPeriodPerDay, sleepMetricValue, isSleepDerivedMetric } from "./metrics.js";
+import type { SleepPeriod, TimeSeriesSamples } from "./types.js";
+
+function makePeriod(overrides: Partial<SleepPeriod>): SleepPeriod {
+  const ts: TimeSeriesSamples = { interval: 300, items: [1, 2, 3], timestamp: "2026-05-25T00:00:00Z" };
+  return {
+    id: "id",
+    average_breath: 14,
+    average_heart_rate: 60,
+    average_hrv: 50,
+    awake_time: null,
+    bedtime_end: "2026-05-25T08:00:00-07:00",
+    bedtime_start: "2026-05-24T23:00:00-07:00",
+    day: "2026-05-25",
+    deep_sleep_duration: 5400,
+    efficiency: 90,
+    heart_rate: ts,
+    hrv: ts,
+    latency: 600,
+    light_sleep_duration: 10000,
+    low_battery_alert: false,
+    lowest_heart_rate: 55,
+    movement_30_sec: "0000111",
+    period: 1,
+    readiness: null,
+    readiness_score_delta: null,
+    rem_sleep_duration: 6000,
+    restless_periods: null,
+    sleep_algorithm_version: null,
+    sleep_analysis_reason: null,
+    sleep_phase_30_sec: "1234",
+    sleep_phase_5_min: "12",
+    sleep_score_delta: null,
+    time_in_bed: null,
+    total_sleep_duration: 28800,
+    type: "long_sleep",
+    ring_id: null,
+    app_sleep_phase_5_min: "12",
+    ...overrides,
+  };
+}
+
+describe("isSleepDerivedMetric", () => {
+  it("is true for hrv/rhr/sleep_total/deep_sleep/rem_sleep/respiratory_rate", () => {
+    expect(isSleepDerivedMetric("hrv")).toBe(true);
+    expect(isSleepDerivedMetric("rhr")).toBe(true);
+    expect(isSleepDerivedMetric("sleep_total")).toBe(true);
+    expect(isSleepDerivedMetric("deep_sleep")).toBe(true);
+    expect(isSleepDerivedMetric("rem_sleep")).toBe(true);
+    expect(isSleepDerivedMetric("respiratory_rate")).toBe(true);
+  });
+
+  it("is false for daily-report metrics", () => {
+    expect(isSleepDerivedMetric("readiness")).toBe(false);
+    expect(isSleepDerivedMetric("sleep_score")).toBe(false);
+    expect(isSleepDerivedMetric("activity_score")).toBe(false);
+    expect(isSleepDerivedMetric("spo2")).toBe(false);
+  });
+});
+
+describe("sleepMetricValue", () => {
+  it("reads the right field per metric", () => {
+    const p = makePeriod({});
+    expect(sleepMetricValue("hrv", p)).toBe(50);
+    expect(sleepMetricValue("rhr", p)).toBe(55);
+    expect(sleepMetricValue("sleep_total", p)).toBe(28800);
+    expect(sleepMetricValue("deep_sleep", p)).toBe(5400);
+    expect(sleepMetricValue("rem_sleep", p)).toBe(6000);
+    expect(sleepMetricValue("respiratory_rate", p)).toBe(14);
+  });
+});
+
+describe("selectMainPeriodPerDay", () => {
+  it("excludes nap/late_nap/rest/deleted types", () => {
+    const periods = [
+      makePeriod({ id: "night", day: "2026-05-25", type: "long_sleep" }),
+      makePeriod({ id: "nap", day: "2026-05-25", type: "nap" }),
+      makePeriod({ id: "rest", day: "2026-05-25", type: "rest" }),
+      makePeriod({ id: "gone", day: "2026-05-25", type: "deleted" }),
+    ];
+    const chosen = selectMainPeriodPerDay(periods, "hrv");
+    expect(chosen.get("2026-05-25")?.id).toBe("night");
+  });
+
+  it("picks the longest-duration period with a non-null value for the metric", () => {
+    const periods = [
+      makePeriod({ id: "short", day: "2026-05-25", type: "sleep", total_sleep_duration: 1000, average_hrv: null }),
+      makePeriod({ id: "long_null_hrv", day: "2026-05-25", type: "long_sleep", total_sleep_duration: 28800, average_hrv: null }),
+      makePeriod({ id: "medium_has_hrv", day: "2026-05-25", type: "sleep", total_sleep_duration: 5000, average_hrv: 42 }),
+    ];
+    const chosen = selectMainPeriodPerDay(periods, "hrv");
+    // The longest period (long_null_hrv) has null HRV, so the next-longest
+    // with a non-null value (medium_has_hrv) should be picked.
+    expect(chosen.get("2026-05-25")?.id).toBe("medium_has_hrv");
+  });
+
+  it("falls back to the longest period overall if every candidate is null for the metric", () => {
+    const periods = [
+      makePeriod({ id: "short", day: "2026-05-25", type: "sleep", total_sleep_duration: 1000, average_hrv: null }),
+      makePeriod({ id: "long", day: "2026-05-25", type: "long_sleep", total_sleep_duration: 28800, average_hrv: null }),
+    ];
+    const chosen = selectMainPeriodPerDay(periods, "hrv");
+    expect(chosen.get("2026-05-25")?.id).toBe("long");
+  });
+
+  it("groups independently per day", () => {
+    const periods = [
+      makePeriod({ id: "d1", day: "2026-05-24", type: "long_sleep" }),
+      makePeriod({ id: "d2", day: "2026-05-25", type: "long_sleep" }),
+    ];
+    const chosen = selectMainPeriodPerDay(periods, "hrv");
+    expect(chosen.get("2026-05-24")?.id).toBe("d1");
+    expect(chosen.get("2026-05-25")?.id).toBe("d2");
+  });
+});

--- a/apps/oura-mcp/src/oura/metrics.ts
+++ b/apps/oura-mcp/src/oura/metrics.ts
@@ -110,6 +110,104 @@ export async function fetchTagsByDay(
   return out;
 }
 
+/**
+ * Metrics sourced from `/sleep` (as opposed to a daily-report endpoint).
+ * Used by baseline_compare (#46) to decide when it needs to resolve and
+ * expose the underlying SleepPeriod (bedtime_start/bedtime_end) alongside
+ * the scalar value, since these metrics are vulnerable to the sync-boundary
+ * "wrong night" confusion documented in that issue.
+ */
+export const SLEEP_DERIVED_METRICS: ReadonlySet<Metric> = new Set([
+  "hrv",
+  "rhr",
+  "sleep_total",
+  "deep_sleep",
+  "rem_sleep",
+  "respiratory_rate",
+]);
+
+export function isSleepDerivedMetric(metric: Metric): metric is
+  | "hrv"
+  | "rhr"
+  | "sleep_total"
+  | "deep_sleep"
+  | "rem_sleep"
+  | "respiratory_rate" {
+  return SLEEP_DERIVED_METRICS.has(metric);
+}
+
+/** Extracts the scalar value a sleep-derived metric reads off a SleepPeriod. */
+export function sleepMetricValue(metric: Metric, p: SleepPeriod): number | null {
+  switch (metric) {
+    case "hrv":
+      return p.average_hrv;
+    case "rhr":
+      return p.lowest_heart_rate;
+    case "sleep_total":
+      return p.total_sleep_duration;
+    case "deep_sleep":
+      return p.deep_sleep_duration;
+    case "rem_sleep":
+      return p.rem_sleep_duration;
+    case "respiratory_rate":
+      return p.average_breath;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Groups `sleep`/`long_sleep` periods by `p.day` and picks, for each day,
+ * the longest-duration period with a non-null value for `metric` (falling
+ * back to the longest period overall if every candidate is null). Pure
+ * function extracted from fetchMetricByDay's inline logic so it can be
+ * reused (and unit-tested) independently of any network call — see
+ * fetchMainSleepPeriodsByDay below and #46.
+ */
+export function selectMainPeriodPerDay(
+  periods: SleepPeriod[],
+  metric: Metric,
+): Map<string, SleepPeriod> {
+  const byDay = new Map<string, SleepPeriod[]>();
+  for (const p of periods) {
+    if (p.type !== "sleep" && p.type !== "long_sleep") continue;
+    const list = byDay.get(p.day) ?? [];
+    list.push(p);
+    byDay.set(p.day, list);
+  }
+  const chosen = new Map<string, SleepPeriod>();
+  for (const [day, group] of byDay) {
+    const sorted = [...group].sort(
+      (a, b) => (b.total_sleep_duration ?? 0) - (a.total_sleep_duration ?? 0),
+    );
+    const picked = sorted.find((p) => sleepMetricValue(metric, p) !== null) ?? sorted[0];
+    if (picked) chosen.set(day, picked);
+  }
+  return chosen;
+}
+
+/**
+ * Like `fetchMetricByDay` for sleep-derived metrics, but returns the chosen
+ * SleepPeriod per day instead of just the scalar value. Used by
+ * `oura_baseline_compare` (#46) to surface `bedtime_start`/`bedtime_end` for
+ * the night backing a given day's value, so a caller can tell which physical
+ * night was actually matched — important near the Oura sync boundary where
+ * a requested date's `day` may resolve to an older, already-synced night
+ * rather than the most recent (possibly still-unsynced) one.
+ */
+export async function fetchMainSleepPeriodsByDay(
+  client: OuraClient,
+  metric: Metric,
+  start: string,
+  end: string,
+): Promise<Map<string, SleepPeriod>> {
+  // Same ±1 day padding as fetchMetricByDay, for the same reason (Oura
+  // filters /sleep by bedtime_start, not by `day`).
+  const paddedRange = { start_date: addDays(start, -1), end_date: addDays(end, 1) };
+  const periods = await getSleepPeriods(client, paddedRange);
+  return selectMainPeriodPerDay(periods, metric);
+}
+
 export const METRIC_NAMES = [
   "readiness",
   "sleep_score",
@@ -205,48 +303,14 @@ export async function fetchMetricByDay(
       // single-day callers like baseline_compare see the same periods that
       // wider-window callers (hrv_trend, daily_readiness) see. We then
       // restrict the returned series back to [start, end] via buildSeries.
-      const paddedRange = {
-        start_date: addDays(start, -1),
-        end_date: addDays(end, 1),
-      };
-      const periods = await getSleepPeriods(client, paddedRange);
-
-      // Group periods by p.day and, for the requested metric, pick the
-      // longest-duration period whose value for that metric is non-null
-      // (falling back to the longest period overall if every value is
-      // null). Mirrors oura_hrv_trend's PR #10 dedup logic so cross-tool
-      // results agree on dates with multiple sleep periods (main + nap).
-      const valueFor = (p: SleepPeriod): number | null => {
-        switch (metric) {
-          case "hrv":
-            return p.average_hrv;
-          case "rhr":
-            return p.lowest_heart_rate;
-          case "sleep_total":
-            return p.total_sleep_duration;
-          case "deep_sleep":
-            return p.deep_sleep_duration;
-          case "rem_sleep":
-            return p.rem_sleep_duration;
-          case "respiratory_rate":
-            return p.average_breath;
-        }
-      };
-      const byDay = new Map<string, SleepPeriod[]>();
-      for (const p of periods) {
-        if (p.type !== "sleep" && p.type !== "long_sleep") continue;
-        const list = byDay.get(p.day) ?? [];
-        list.push(p);
-        byDay.set(p.day, list);
-      }
+      // Mirrors oura_hrv_trend's PR #10 dedup logic (via selectMainPeriodPerDay)
+      // so cross-tool results agree on dates with multiple sleep periods
+      // (main + nap). See fetchMainSleepPeriodsByDay for the period-level
+      // equivalent used by baseline_compare (#46).
+      const chosenByDay = await fetchMainSleepPeriodsByDay(client, metric, start, end);
       const source = new Map<string, number | null>();
-      for (const [day, group] of byDay) {
-        const sorted = [...group].sort(
-          (a, b) => (b.total_sleep_duration ?? 0) - (a.total_sleep_duration ?? 0),
-        );
-        const chosen = sorted.find((p) => valueFor(p) !== null) ?? sorted[0];
-        if (!chosen) continue;
-        source.set(day, valueFor(chosen));
+      for (const [day, chosen] of chosenByDay) {
+        source.set(day, sleepMetricValue(metric, chosen));
       }
       return buildSeries(start, end, source);
     }

--- a/apps/oura-mcp/src/oura/types.ts
+++ b/apps/oura-mcp/src/oura/types.ts
@@ -106,7 +106,7 @@ export interface SleepPeriod {
   sleep_score_delta: number | null;
   time_in_bed: number | null; // seconds
   total_sleep_duration: number | null; // seconds
-  type: "deleted" | "sleep" | "long_sleep" | "late_nap" | "rest";
+  type: "deleted" | "sleep" | "long_sleep" | "nap" | "late_nap" | "rest";
   ring_id: string | null;
   app_sleep_phase_5_min: string | null;
 }

--- a/apps/oura-mcp/src/tools/activity.test.ts
+++ b/apps/oura-mcp/src/tools/activity.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { stripActivityTimeSeries } from "./activity.js";
+import type { DailyActivity } from "../oura/types.js";
+
+function makeActivity(overrides: Partial<DailyActivity>): DailyActivity {
+  return {
+    id: "id",
+    active_calories: 500,
+    average_met_minutes: 1.5,
+    class_5_min: "1122330011223300",
+    contributors: {
+      meet_daily_targets: 80,
+      move_every_hour: 90,
+      recovery_time: 100,
+      stay_active: 70,
+      training_frequency: 60,
+      training_volume: 65,
+    },
+    day: "2026-07-25",
+    equivalent_walking_distance: 4000,
+    high_activity_met_minutes: 20,
+    high_activity_time: 600,
+    inactivity_alerts: 2,
+    low_activity_met_minutes: 100,
+    low_activity_time: 3600,
+    medium_activity_met_minutes: 50,
+    medium_activity_time: 1800,
+    met: { interval: 60, items: [1, 1.2, 1.5, 2], timestamp: "2026-07-25T00:00:00Z" },
+    meters_to_target: null,
+    non_wear_time: 0,
+    resting_time: 28800,
+    score: 85,
+    sedentary_met_minutes: 30,
+    sedentary_time: 36000,
+    steps: 8500,
+    target_calories: 500,
+    target_meters: 5000,
+    timestamp: "2026-07-25T00:00:00Z",
+    total_calories: 2200,
+    ...overrides,
+  };
+}
+
+describe("stripActivityTimeSeries (issue #47)", () => {
+  it("removes met and class_5_min", () => {
+    const a = makeActivity({});
+    const stripped = stripActivityTimeSeries(a) as Record<string, unknown>;
+    expect(stripped).not.toHaveProperty("met");
+    expect(stripped).not.toHaveProperty("class_5_min");
+  });
+
+  it("preserves all scalar/summary fields", () => {
+    const a = makeActivity({});
+    const stripped = stripActivityTimeSeries(a);
+    expect(stripped.score).toBe(85);
+    expect(stripped.steps).toBe(8500);
+    expect(stripped.active_calories).toBe(500);
+    expect(stripped.total_calories).toBe(2200);
+    expect(stripped.contributors).toEqual(a.contributors);
+    expect(stripped.high_activity_time).toBe(600);
+    expect(stripped.day).toBe("2026-07-25");
+  });
+
+  it("does not mutate the input record", () => {
+    const a = makeActivity({});
+    const metBefore = a.met;
+    stripActivityTimeSeries(a);
+    expect(a.met).toBe(metBefore);
+    expect(a.class_5_min).toBe("1122330011223300");
+  });
+});

--- a/apps/oura-mcp/src/tools/activity.ts
+++ b/apps/oura-mcp/src/tools/activity.ts
@@ -3,7 +3,29 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyActivity } from "../oura/endpoints.js";
+import type { DailyActivity } from "../oura/types.js";
 import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+
+// Bulky per-sample fields stripped from DailyActivity when include_time_series
+// is false (#47): `met` is a ~700-sample per-minute array, `class_5_min` is a
+// per-5-min activity-class string. Both are meaningful for deep-dive analysis
+// but dominate response size for the common "how active was day X" question.
+const ACTIVITY_TIME_SERIES_FIELDS = ["met", "class_5_min"] as const;
+
+/**
+ * Returns a copy of the DailyActivity with the bulky per-sample fields
+ * removed, keeping all scalar/summary fields (score, contributors, steps,
+ * calories, per-intensity MET minutes, time breakdowns).
+ */
+export function stripActivityTimeSeries(
+  d: DailyActivity,
+): Omit<DailyActivity, (typeof ACTIVITY_TIME_SERIES_FIELDS)[number]> {
+  const copy: Record<string, unknown> = { ...d };
+  for (const f of ACTIVITY_TIME_SERIES_FIELDS) {
+    delete copy[f];
+  }
+  return copy as Omit<DailyActivity, (typeof ACTIVITY_TIME_SERIES_FIELDS)[number]>;
+}
 
 export function registerActivityTools(server: McpServer, client: OuraClient): void {
   server.tool(
@@ -11,19 +33,30 @@ export function registerActivityTools(server: McpServer, client: OuraClient): vo
     "Returns daily activity scores (0-100), step count, active calories, total calories, " +
       "MET minutes by intensity, and time breakdowns. " +
       "All time fields (high_activity_time, sedentary_time, etc.) are in SECONDS. " +
-      "Dates: \"day\" is the calendar day the activity occurred.",
+      "Dates: \"day\" is the calendar day the activity occurred. " +
+      "By default, the response strips bulky per-sample fields (`met` per-minute array, " +
+      "`class_5_min` per-5-min activity-class string) to keep payloads small; all scalar/summary " +
+      "fields (score, contributors, steps, calories, MET minutes, time breakdowns) are always included. " +
+      "Set `include_time_series: true` to get the raw payload including `met` and `class_5_min`.",
     {
       start_date: z.string().optional().describe("Start date YYYY-MM-DD. Defaults to today minus 6 days (7-day inclusive window)."),
       end_date: z.string().optional().describe("End date YYYY-MM-DD. Defaults to today."),
       max_pages: z.number().int().min(1).max(20).optional().describe("Max pagination pages (default 5)."),
+      include_time_series: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, return the raw payload including the bulky `met` (per-minute array) and `class_5_min` (per-5-min string) fields. Default false (stripped).",
+        ),
     },
-    async ({ start_date, end_date, max_pages }) => {
+    async ({ start_date, end_date, max_pages, include_time_series }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
       try {
         const data = await getDailyActivity(client, range, max_pages);
-        return textContent(data);
+        const out = include_time_series ? data : data.map(stripActivityTimeSeries);
+        return textContent(out);
       } catch (e) {
         if (e instanceof OuraApiError) return errorContent(e.message);
         throw e;

--- a/apps/oura-mcp/src/tools/baseline_compare.test.ts
+++ b/apps/oura-mcp/src/tools/baseline_compare.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isPossiblyStaleNight, STALE_THRESHOLD_HOURS } from "./baseline_compare.js";
+
+describe("isPossiblyStaleNight (issue #46)", () => {
+  it("is false when the night ended recently (well within the threshold)", () => {
+    const bedtimeEnd = "2026-07-28T08:00:00Z";
+    const now = new Date("2026-07-28T10:00:00Z"); // 2h later
+    expect(isPossiblyStaleNight(bedtimeEnd, now)).toBe(false);
+  });
+
+  it("is true when the night ended more than the threshold before now", () => {
+    const bedtimeEnd = "2026-07-27T06:50:00Z";
+    // ~24h later, well past STALE_THRESHOLD_HOURS
+    const now = new Date("2026-07-28T07:00:00Z");
+    expect(isPossiblyStaleNight(bedtimeEnd, now)).toBe(true);
+  });
+
+  it("is false exactly at the threshold boundary (strictly greater-than)", () => {
+    const bedtimeEnd = "2026-07-28T00:00:00Z";
+    const now = new Date(Date.parse(bedtimeEnd) + STALE_THRESHOLD_HOURS * 3_600_000);
+    expect(isPossiblyStaleNight(bedtimeEnd, now)).toBe(false);
+  });
+
+  it("is true just past the threshold boundary", () => {
+    const bedtimeEnd = "2026-07-28T00:00:00Z";
+    const now = new Date(Date.parse(bedtimeEnd) + STALE_THRESHOLD_HOURS * 3_600_000 + 60_000);
+    expect(isPossiblyStaleNight(bedtimeEnd, now)).toBe(true);
+  });
+
+  it("returns false for an unparseable bedtime_end rather than throwing", () => {
+    expect(isPossiblyStaleNight("not-a-date", new Date())).toBe(false);
+  });
+
+  it("reproduces the #46 scenario: a matched night older than intended is flagged", () => {
+    // From the issue: bedtime 2026-07-26 22:41 -> 2026-07-27 06:50, queried
+    // at ~7am on 2026-07-28 (query time), expecting the night of 07-27->07-28.
+    const bedtimeEnd = "2026-07-27T06:50:00-07:00";
+    const queryTime = new Date("2026-07-28T07:00:00-07:00");
+    expect(isPossiblyStaleNight(bedtimeEnd, queryTime)).toBe(true);
+  });
+});

--- a/apps/oura-mcp/src/tools/baseline_compare.ts
+++ b/apps/oura-mcp/src/tools/baseline_compare.ts
@@ -6,6 +6,8 @@ import {
   METRIC_NAMES,
   addDays,
   fetchMetricByDay,
+  fetchMainSleepPeriodsByDay,
+  isSleepDerivedMetric,
 } from "../oura/metrics.js";
 import {
   defined,
@@ -16,6 +18,26 @@ import {
   percentileFromZ,
 } from "../oura/stats.js";
 import { textContent, errorContent, todayInTz } from "./utils.js";
+
+// #46: threshold (hours) beyond which a resolved night is flagged
+// `possibly_stale` — i.e. it ended long enough ago that a more recent
+// (possibly still-unsynced) night may exist and not be reflected here.
+// 12h was chosen because Oura sync typically completes well within a
+// morning; this is a static-analysis-derived heuristic (see comment at
+// call site) and has not been validated against live sync-lag data.
+export const STALE_THRESHOLD_HOURS = 12;
+
+/**
+ * Returns true when `bedtimeEndIso` (the end of the resolved sleep period)
+ * is more than STALE_THRESHOLD_HOURS before `now`. Pure/testable extraction
+ * of the #46 boundary check.
+ */
+export function isPossiblyStaleNight(bedtimeEndIso: string, now: Date): boolean {
+  const endMs = Date.parse(bedtimeEndIso);
+  if (isNaN(endMs)) return false;
+  const hoursSinceEnd = (now.getTime() - endMs) / 3_600_000;
+  return hoursSinceEnd > STALE_THRESHOLD_HOURS;
+}
 
 export function registerBaselineCompareTool(server: McpServer, client: OuraClient): void {
   server.tool(
@@ -28,7 +50,10 @@ export function registerBaselineCompareTool(server: McpServer, client: OuraClien
       "`actual_date_used` and `days_lag` in the response). The baseline window itself " +
       "remains anchored to the requested date. Default `fallback: \"strict\"` preserves " +
       "the no-data error behavior. " +
-      "Dates: \"date\" indexes the underlying metric — for sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, sleep_total, respiratory_rate) this is the date the sleep period started; for daily-report metrics (readiness, sleep_score, activity_score, spo2) this is the morning the score is reported on. The two conventions can refer to the same physiological night but different calendar dates.",
+      "Dates: \"date\" indexes the underlying metric — for sleep-derived metrics (hrv, rhr, deep_sleep, rem_sleep, sleep_total, respiratory_rate) this is the date the sleep period started; for daily-report metrics (readiness, sleep_score, activity_score, spo2) this is the morning the score is reported on. The two conventions can refer to the same physiological night but different calendar dates. " +
+      "For sleep-derived metrics, the response includes `bedtime_start`/`bedtime_end` of the sleep period the value actually came from, so you can confirm which night was matched. " +
+      "If that night ended more than 12 hours before the call was made, `possibly_stale: true` is set — this usually means the most recent night hasn't synced from the ring yet and an OLDER, already-synced night was matched instead (common for morning \"how did I sleep last night\" queries near the sync boundary). " +
+      "When `possibly_stale` is true, treat the result as \"most recent synced night\", not necessarily \"last night\", and consider retrying later or checking `oura_sleep_detail` directly.",
     {
       metric: z.enum(METRIC_NAMES).describe("Metric to compare against personal baseline."),
       date: z
@@ -103,6 +128,35 @@ export function registerBaselineCompareTool(server: McpServer, client: OuraClien
           }
         }
 
+        // #46: for sleep-derived metrics, resolve and expose which physical
+        // night (bedtime_start/bedtime_end) the matched value actually came
+        // from, and flag when that night ended long enough ago that a more
+        // recent (possibly still-unsynced) night could exist. This is a
+        // best-effort fix based on static analysis of the reported symptom
+        // (day-keyed lookup silently matching an older, already-synced
+        // night near the sync boundary) — it has NOT been verified against
+        // live Oura data / an actual sync-lag window, and the 12h threshold
+        // in isPossiblyStaleNight is a heuristic. Verify manually before
+        // relying on `possibly_stale` in production.
+        let nightBedtimeStart: string | null = null;
+        let nightBedtimeEnd: string | null = null;
+        let possiblyStale = false;
+        if (currentValue !== null && isSleepDerivedMetric(metric)) {
+          const dateUsed = actualDateUsed ?? compareDate;
+          const periodsByDay = await fetchMainSleepPeriodsByDay(
+            client,
+            metric,
+            dateUsed,
+            dateUsed,
+          );
+          const period = periodsByDay.get(dateUsed);
+          if (period) {
+            nightBedtimeStart = period.bedtime_start;
+            nightBedtimeEnd = period.bedtime_end;
+            possiblyStale = isPossiblyStaleNight(period.bedtime_end, new Date());
+          }
+        }
+
         const baselineValues = defined([...baselineSeries.values()]);
         const nDays = baselineValues.length;
 
@@ -165,6 +219,15 @@ export function registerBaselineCompareTool(server: McpServer, client: OuraClien
         if (actualDateUsed !== null) {
           result.actual_date_used = actualDateUsed;
           result.days_lag = daysLag;
+        }
+        if (nightBedtimeStart !== null && nightBedtimeEnd !== null) {
+          result.bedtime_start = nightBedtimeStart;
+          result.bedtime_end = nightBedtimeEnd;
+          result.possibly_stale = possiblyStale;
+          if (possiblyStale) {
+            result.stale_reason =
+              "Resolved night ended more than 12h before this call — a more recent night may exist but not yet be synced from the ring. This may not be the night you meant by \"last night\".";
+          }
         }
         if (note) result.note = note;
         return textContent(result);

--- a/apps/oura-mcp/src/tools/index.ts
+++ b/apps/oura-mcp/src/tools/index.ts
@@ -25,6 +25,7 @@ import { registerWeeklyDigestTool } from "./weekly_digest.js";
 import { registerRespiratoryTrendTool } from "./respiratory_trend.js";
 import { registerIllnessSignalsTool } from "./illness_signals.js";
 import { registerSymptomOnsetDetectTool } from "./symptom_onset_detect.js";
+import { registerNightSummaryTool } from "./night_summary.js";
 
 export function registerAllTools(server: McpServer, client: OuraClient): void {
   registerPersonalTools(server, client);
@@ -52,4 +53,5 @@ export function registerAllTools(server: McpServer, client: OuraClient): void {
   registerRespiratoryTrendTool(server, client);
   registerIllnessSignalsTool(server, client);
   registerSymptomOnsetDetectTool(server, client);
+  registerNightSummaryTool(server, client);
 }

--- a/apps/oura-mcp/src/tools/night_summary.test.ts
+++ b/apps/oura-mcp/src/tools/night_summary.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { mainPeriodForDay, mostRecentNight } from "./night_summary.js";
+import type { SleepPeriod, TimeSeriesSamples } from "../oura/types.js";
+
+function makePeriod(overrides: Partial<SleepPeriod>): SleepPeriod {
+  const ts: TimeSeriesSamples = { interval: 300, items: [1, 2, 3], timestamp: "2026-05-25T00:00:00Z" };
+  return {
+    id: "id",
+    average_breath: 14,
+    average_heart_rate: 60,
+    average_hrv: 50,
+    awake_time: null,
+    bedtime_end: "2026-05-25T08:00:00-07:00",
+    bedtime_start: "2026-05-24T23:00:00-07:00",
+    day: "2026-05-25",
+    deep_sleep_duration: 5400,
+    efficiency: 90,
+    heart_rate: ts,
+    hrv: ts,
+    latency: 600,
+    light_sleep_duration: 10000,
+    low_battery_alert: false,
+    lowest_heart_rate: 55,
+    movement_30_sec: "0000111",
+    period: 1,
+    readiness: null,
+    readiness_score_delta: null,
+    rem_sleep_duration: 6000,
+    restless_periods: null,
+    sleep_algorithm_version: null,
+    sleep_analysis_reason: null,
+    sleep_phase_30_sec: "1234",
+    sleep_phase_5_min: "12",
+    sleep_score_delta: null,
+    time_in_bed: null,
+    total_sleep_duration: 28800,
+    type: "long_sleep",
+    ring_id: null,
+    app_sleep_phase_5_min: "12",
+    ...overrides,
+  };
+}
+
+describe("mainPeriodForDay (issue #49)", () => {
+  it("picks the longest sleep/long_sleep period matching the day", () => {
+    const periods = [
+      makePeriod({ id: "short", day: "2026-05-25", type: "sleep", total_sleep_duration: 900 }),
+      makePeriod({ id: "long", day: "2026-05-25", type: "long_sleep", total_sleep_duration: 28800 }),
+      makePeriod({ id: "other_day", day: "2026-05-24", type: "long_sleep", total_sleep_duration: 30000 }),
+    ];
+    expect(mainPeriodForDay(periods, "2026-05-25")?.id).toBe("long");
+  });
+
+  it("excludes nap/late_nap/rest/deleted", () => {
+    const periods = [
+      makePeriod({ id: "nap", day: "2026-05-25", type: "nap" }),
+      makePeriod({ id: "rest", day: "2026-05-25", type: "rest" }),
+      makePeriod({ id: "gone", day: "2026-05-25", type: "deleted" }),
+    ];
+    expect(mainPeriodForDay(periods, "2026-05-25")).toBeUndefined();
+  });
+
+  it("returns undefined when no period matches the day", () => {
+    const periods = [makePeriod({ day: "2026-05-24" })];
+    expect(mainPeriodForDay(periods, "2026-05-25")).toBeUndefined();
+  });
+});
+
+describe("mostRecentNight (issue #49)", () => {
+  it("picks the period with the latest bedtime_end", () => {
+    const periods = [
+      makePeriod({ id: "older", bedtime_end: "2026-05-24T07:00:00-07:00" }),
+      makePeriod({ id: "newest", bedtime_end: "2026-05-26T07:30:00-07:00" }),
+      makePeriod({ id: "middle", bedtime_end: "2026-05-25T08:00:00-07:00" }),
+    ];
+    expect(mostRecentNight(periods)?.id).toBe("newest");
+  });
+
+  it("ignores nap/late_nap/rest/deleted types even if more recent", () => {
+    const periods = [
+      makePeriod({ id: "real_night", type: "long_sleep", bedtime_end: "2026-05-25T08:00:00-07:00" }),
+      makePeriod({ id: "later_nap", type: "nap", bedtime_end: "2026-05-25T14:00:00-07:00" }),
+    ];
+    expect(mostRecentNight(periods)?.id).toBe("real_night");
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(mostRecentNight([])).toBeUndefined();
+  });
+});

--- a/apps/oura-mcp/src/tools/night_summary.ts
+++ b/apps/oura-mcp/src/tools/night_summary.ts
@@ -1,0 +1,178 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OuraClient } from "../oura/client.js";
+import { OuraApiError } from "../oura/client.js";
+import { getDailySleep, getDailyReadiness, getSleepPeriods } from "../oura/endpoints.js";
+import { addDays, fetchMetricByDay, fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
+import { defined, mean } from "../oura/stats.js";
+import type { SleepPeriod } from "../oura/types.js";
+import { todayInTz, textContent, errorContent } from "./utils.js";
+
+// How many days back to search for "the most recent synced night" when no
+// `date` is given. 3 days comfortably covers a normal sync-lag window.
+const LOOKBACK_DAYS = 3;
+
+// Rolling window (days) for the HRV/RHR baseline context, matching
+// oura_daily_readiness's BASELINE_WINDOW_DAYS.
+const BASELINE_WINDOW_DAYS = 14;
+
+/**
+ * Picks the "main" sleep period (longest sleep/long_sleep, non-deleted) for
+ * a given day out of a list of periods. Duplicated in small form here (see
+ * also readiness.ts and metrics.ts) to keep this tool self-contained; all
+ * three implement the same selection rule.
+ */
+export function mainPeriodForDay(periods: SleepPeriod[], day: string): SleepPeriod | undefined {
+  let best: SleepPeriod | undefined;
+  for (const p of periods) {
+    if (p.type !== "sleep" && p.type !== "long_sleep") continue;
+    if (p.day !== day) continue;
+    const bestDur = best?.total_sleep_duration ?? -1;
+    const candidateDur = p.total_sleep_duration ?? -1;
+    if (!best || candidateDur > bestDur) best = p;
+  }
+  return best;
+}
+
+/**
+ * Finds the most recent complete night (largest bedtime_end) among
+ * sleep/long_sleep, non-deleted periods in the given list.
+ */
+export function mostRecentNight(periods: SleepPeriod[]): SleepPeriod | undefined {
+  let best: SleepPeriod | undefined;
+  for (const p of periods) {
+    if (p.type !== "sleep" && p.type !== "long_sleep") continue;
+    if (!best || Date.parse(p.bedtime_end) > Date.parse(best.bedtime_end)) best = p;
+  }
+  return best;
+}
+
+export function registerNightSummaryTool(server: McpServer, client: OuraClient): void {
+  server.tool(
+    "oura_night_summary",
+    "Composite tool: answers 'how did I sleep?' in a single call by combining the sleep score " +
+      "and contributors (from oura_daily_sleep), stage durations/HR/HRV/latency/efficiency highlights " +
+      "(from oura_sleep_detail, stripped of bulky time-series arrays), the same-morning readiness score " +
+      "and contributors, 14-day HRV/RHR baseline context, and any user tags overlapping the night. " +
+      "Identifies the night unambiguously via `bedtime_start`/`bedtime_end` so there is no ambiguity " +
+      "about which physical night is being summarized, regardless of the sleep-period-start vs. " +
+      "morning-of-report date convention mismatch documented elsewhere in this server. " +
+      "Default (no `date`): the most recently synced complete night within the last " +
+      `${LOOKBACK_DAYS} days. ` +
+      "Pass `date` (YYYY-MM-DD, morning-of-report convention — same as oura_daily_sleep's \"day\") " +
+      "to summarize a specific morning instead. " +
+      "Contains no bulky per-sample time-series data.",
+    {
+      date: z
+        .string()
+        .optional()
+        .describe(
+          "YYYY-MM-DD, morning-of-report date (same convention as oura_daily_sleep's `day`). Omit for the most recent synced night.",
+        ),
+    },
+    async ({ date }) => {
+      try {
+        let mainPeriod: SleepPeriod | undefined;
+        let resolvedDay: string;
+
+        if (date) {
+          // Widen by 1 day on each side, same reasoning as #33/#46: Oura's
+          // /sleep endpoint filters by bedtime_start, not by `day`.
+          const widened = { start_date: addDays(date, -1), end_date: addDays(date, 1) };
+          const periods = await getSleepPeriods(client, widened);
+          mainPeriod = mainPeriodForDay(periods, date);
+          resolvedDay = date;
+        } else {
+          const today = todayInTz();
+          const windowStart = addDays(today, -LOOKBACK_DAYS);
+          const periods = await getSleepPeriods(client, { start_date: windowStart, end_date: today });
+          mainPeriod = mostRecentNight(periods);
+          if (!mainPeriod) {
+            return errorContent(
+              `No synced sleep period found in the last ${LOOKBACK_DAYS} days. The most recent night may not have synced yet.`,
+            );
+          }
+          resolvedDay = mainPeriod.day;
+        }
+
+        if (!mainPeriod) {
+          return errorContent(`No sleep period found for ${resolvedDay}.`);
+        }
+
+        const dayRange = { start_date: resolvedDay, end_date: resolvedDay };
+        const [dailySleep, dailyReadiness, tagsByDay, hrvBaselineSeries, rhrBaselineSeries] =
+          await Promise.all([
+            getDailySleep(client, dayRange),
+            getDailyReadiness(client, dayRange),
+            // Tags may be logged the evening before (bedtime_start's calendar
+            // date) or the morning of; check both buckets.
+            fetchTagsByDay(client, addDays(resolvedDay, -1), resolvedDay, true),
+            fetchMetricByDay(
+              client,
+              "hrv",
+              addDays(resolvedDay, -BASELINE_WINDOW_DAYS),
+              addDays(resolvedDay, -1),
+            ),
+            fetchMetricByDay(
+              client,
+              "rhr",
+              addDays(resolvedDay, -BASELINE_WINDOW_DAYS),
+              addDays(resolvedDay, -1),
+            ),
+          ]);
+
+        const sleepScore = dailySleep.find((d) => d.day === resolvedDay);
+        const readiness = dailyReadiness.find((r) => r.day === resolvedDay);
+
+        const eveningTags = tagsByDay.get(addDays(resolvedDay, -1)) ?? [];
+        const morningTags = tagsByDay.get(resolvedDay) ?? [];
+        const tags: TagEntry[] = [...eveningTags, ...morningTags];
+
+        const hrvValues = defined([...hrvBaselineSeries.values()]);
+        const rhrValues = defined([...rhrBaselineSeries.values()]);
+        const hrvBaseline = hrvValues.length > 0 ? mean(hrvValues) : null;
+        const rhrBaseline = rhrValues.length > 0 ? mean(rhrValues) : null;
+
+        const result = {
+          date: resolvedDay,
+          bedtime_start: mainPeriod.bedtime_start,
+          bedtime_end: mainPeriod.bedtime_end,
+          sleep: {
+            score: sleepScore?.score ?? null,
+            contributors: sleepScore?.contributors ?? null,
+            total_sleep_duration: mainPeriod.total_sleep_duration,
+            time_in_bed: mainPeriod.time_in_bed,
+            efficiency: mainPeriod.efficiency,
+            latency: mainPeriod.latency,
+            awake_time: mainPeriod.awake_time,
+            deep_sleep_duration: mainPeriod.deep_sleep_duration,
+            light_sleep_duration: mainPeriod.light_sleep_duration,
+            rem_sleep_duration: mainPeriod.rem_sleep_duration,
+            restless_periods: mainPeriod.restless_periods,
+            average_heart_rate: mainPeriod.average_heart_rate,
+            lowest_heart_rate: mainPeriod.lowest_heart_rate,
+            average_hrv: mainPeriod.average_hrv,
+            average_breath: mainPeriod.average_breath,
+          },
+          readiness: readiness
+            ? {
+                score: readiness.score,
+                contributors: readiness.contributors,
+                temperature_deviation: readiness.temperature_deviation,
+              }
+            : null,
+          baselines: {
+            hrv_ms_14d_mean: hrvBaseline,
+            rhr_bpm_14d_mean: rhrBaseline,
+          },
+          tags,
+        };
+
+        return textContent(result);
+      } catch (e) {
+        if (e instanceof OuraApiError) return errorContent(e.message);
+        throw e;
+      }
+    },
+  );
+}

--- a/apps/oura-mcp/src/tools/session.ts
+++ b/apps/oura-mcp/src/tools/session.ts
@@ -8,7 +8,10 @@ import { resolveDateRange, validateDateRange, textContent, errorContent } from "
 export function registerSessionTools(server: McpServer, client: OuraClient): void {
   server.tool(
     "oura_sessions",
-    "Returns mindfulness and rest sessions: meditation, breathing, nap, relaxation, rest. " +
+    "Returns ONLY user-initiated sessions logged manually in the Oura app " +
+      "(meditation, breathing, relaxation, rest, and user-logged naps). " +
+      "Does NOT include auto-detected naps from the sleep stream — for those, " +
+      "use `oura_naps` (or `oura_sleep_detail` and filter where type is 'nap' or 'late_nap'). " +
       "Includes type, start/end datetime, mood rating, and HRV/HR sample arrays. " +
       "Dates: \"day\" is the calendar day the session occurred (derived from start_datetime).",
     {

--- a/apps/oura-mcp/src/tools/sleep.test.ts
+++ b/apps/oura-mcp/src/tools/sleep.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterPeriodsByDay,
+  shiftDate,
+  stripTimeSeries,
+} from "./sleep.js";
+import type { SleepPeriod, TimeSeriesSamples } from "../oura/types.js";
+
+function makePeriod(overrides: Partial<SleepPeriod>): SleepPeriod {
+  const ts: TimeSeriesSamples = { interval: 300, items: [1, 2, 3], timestamp: "2026-05-25T00:00:00Z" };
+  return {
+    id: "id",
+    average_breath: null,
+    average_heart_rate: 60,
+    average_hrv: 50,
+    awake_time: null,
+    bedtime_end: "2026-05-25T08:00:00-07:00",
+    bedtime_start: "2026-05-24T23:00:00-07:00",
+    day: "2026-05-25",
+    deep_sleep_duration: null,
+    efficiency: 90,
+    heart_rate: ts,
+    hrv: ts,
+    latency: 600,
+    light_sleep_duration: null,
+    low_battery_alert: false,
+    lowest_heart_rate: 55,
+    movement_30_sec: "0000111",
+    period: 1,
+    readiness: null,
+    readiness_score_delta: null,
+    rem_sleep_duration: null,
+    restless_periods: null,
+    sleep_algorithm_version: null,
+    sleep_analysis_reason: null,
+    sleep_phase_30_sec: "1234",
+    sleep_phase_5_min: "12",
+    sleep_score_delta: null,
+    time_in_bed: null,
+    total_sleep_duration: 28800,
+    type: "long_sleep",
+    ring_id: null,
+    app_sleep_phase_5_min: "12",
+    ...overrides,
+  };
+}
+
+describe("shiftDate", () => {
+  it("adds positive days across a month boundary", () => {
+    expect(shiftDate("2026-05-25", 1)).toBe("2026-05-26");
+    expect(shiftDate("2026-05-31", 1)).toBe("2026-06-01");
+  });
+
+  it("subtracts days across a month boundary", () => {
+    expect(shiftDate("2026-06-01", -1)).toBe("2026-05-31");
+    expect(shiftDate("2026-05-25", -1)).toBe("2026-05-24");
+  });
+
+  it("is a no-op for 0", () => {
+    expect(shiftDate("2026-05-25", 0)).toBe("2026-05-25");
+  });
+});
+
+describe("filterPeriodsByDay", () => {
+  it("keeps records whose day falls within [start, end] inclusive", () => {
+    const periods = [
+      makePeriod({ id: "a", day: "2026-05-24" }),
+      makePeriod({ id: "b", day: "2026-05-25" }),
+      makePeriod({ id: "c", day: "2026-05-26" }),
+    ];
+    const out = filterPeriodsByDay(periods, "2026-05-25", "2026-05-25");
+    expect(out.map((p) => p.id)).toEqual(["b"]);
+  });
+
+  it("includes single-day record when widening would pull in adjacent days (issue #33 regression)", () => {
+    // Simulates the widened upstream call: the user asked for 2026-05-25,
+    // we fetched 2026-05-24..26, and the long_sleep with day:2026-05-25 must survive.
+    const periods = [
+      makePeriod({ id: "prior", day: "2026-05-24", bedtime_start: "2026-05-23T23:00:00-07:00" }),
+      makePeriod({ id: "target", day: "2026-05-25", bedtime_start: "2026-05-24T23:44:00-07:00" }),
+      makePeriod({ id: "after", day: "2026-05-26", bedtime_start: "2026-05-25T23:00:00-07:00" }),
+    ];
+    const out = filterPeriodsByDay(periods, "2026-05-25", "2026-05-25");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe("target");
+  });
+
+  it("returns empty when no records match", () => {
+    const periods = [makePeriod({ day: "2026-05-20" })];
+    expect(filterPeriodsByDay(periods, "2026-05-25", "2026-05-25")).toEqual([]);
+  });
+
+  it("handles multi-day ranges", () => {
+    const periods = [
+      makePeriod({ id: "a", day: "2026-05-23" }),
+      makePeriod({ id: "b", day: "2026-05-24" }),
+      makePeriod({ id: "c", day: "2026-05-25" }),
+      makePeriod({ id: "d", day: "2026-05-26" }),
+    ];
+    const out = filterPeriodsByDay(periods, "2026-05-24", "2026-05-25");
+    expect(out.map((p) => p.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("stripTimeSeries", () => {
+  it("removes all known time-series fields (issue #36)", () => {
+    const p = makePeriod({});
+    const stripped = stripTimeSeries(p) as Record<string, unknown>;
+    expect(stripped).not.toHaveProperty("heart_rate");
+    expect(stripped).not.toHaveProperty("hrv");
+    expect(stripped).not.toHaveProperty("sleep_phase_30_sec");
+    expect(stripped).not.toHaveProperty("sleep_phase_5_min");
+    expect(stripped).not.toHaveProperty("app_sleep_phase_5_min");
+    expect(stripped).not.toHaveProperty("movement_30_sec");
+  });
+
+  it("preserves summary scalars", () => {
+    const p = makePeriod({});
+    const stripped = stripTimeSeries(p);
+    expect(stripped.id).toBe(p.id);
+    expect(stripped.day).toBe(p.day);
+    expect(stripped.efficiency).toBe(90);
+    expect(stripped.total_sleep_duration).toBe(28800);
+    expect(stripped.average_heart_rate).toBe(60);
+    expect(stripped.average_hrv).toBe(50);
+    expect(stripped.bedtime_start).toBe(p.bedtime_start);
+    expect(stripped.bedtime_end).toBe(p.bedtime_end);
+    expect(stripped.type).toBe("long_sleep");
+  });
+
+  it("does not mutate the input record", () => {
+    const p = makePeriod({});
+    const heart_rate_before = p.heart_rate;
+    stripTimeSeries(p);
+    expect(p.heart_rate).toBe(heart_rate_before);
+    expect(p.sleep_phase_30_sec).toBe("1234");
+  });
+
+  it("include_time_series=true path returns the raw record (no stripping)", () => {
+    // Sanity check the inverse path used inside the handler: when raw records
+    // are passed through unmodified, time-series fields are still present.
+    const p = makePeriod({});
+    const passthrough = { ...p };
+    expect(passthrough.heart_rate).not.toBeNull();
+    expect(passthrough.sleep_phase_30_sec).toBe("1234");
+  });
+});
+
+describe("oura_naps filter contract (issue #37)", () => {
+  // The handler logic is: filterPeriodsByDay -> filter by type -> project.
+  // This exercises the combined pipeline without needing to spin up an McpServer.
+  const periods = [
+    makePeriod({ id: "long", type: "long_sleep", day: "2026-05-25" }),
+    makePeriod({ id: "nap1", type: "nap", day: "2026-05-25", bedtime_start: "2026-05-25T13:00:00-07:00", bedtime_end: "2026-05-25T13:30:00-07:00", total_sleep_duration: 1500, efficiency: 80, average_heart_rate: 65, average_hrv: 40 }),
+    makePeriod({ id: "late", type: "late_nap", day: "2026-05-25", bedtime_start: "2026-05-24T17:24:00-07:00", bedtime_end: "2026-05-24T18:05:00-07:00", total_sleep_duration: 2460, efficiency: 70, average_heart_rate: 70, average_hrv: 35 }),
+    makePeriod({ id: "rest", type: "rest", day: "2026-05-25" }),
+    makePeriod({ id: "out", type: "nap", day: "2026-05-23" }),
+  ];
+
+  it("keeps only nap and late_nap within the requested window", () => {
+    const filtered = filterPeriodsByDay(periods, "2026-05-25", "2026-05-25");
+    const naps = filtered.filter((p) => p.type === "nap" || p.type === "late_nap");
+    expect(naps.map((p) => p.id).sort()).toEqual(["late", "nap1"]);
+  });
+
+  it("projects only the documented summary fields per nap", () => {
+    const filtered = filterPeriodsByDay(periods, "2026-05-25", "2026-05-25");
+    const naps = filtered
+      .filter((p) => p.type === "nap" || p.type === "late_nap")
+      .map((p) => ({
+        day: p.day,
+        type: p.type,
+        bedtime_start: p.bedtime_start,
+        bedtime_end: p.bedtime_end,
+        total_sleep_duration: p.total_sleep_duration,
+        efficiency: p.efficiency,
+        average_heart_rate: p.average_heart_rate,
+        average_hrv: p.average_hrv,
+      }));
+    const nap1 = naps.find((n) => n.total_sleep_duration === 1500);
+    expect(nap1).toMatchObject({
+      day: "2026-05-25",
+      type: "nap",
+      total_sleep_duration: 1500,
+      efficiency: 80,
+      average_heart_rate: 65,
+      average_hrv: 40,
+    });
+    // None of the heavy time-series fields leak through the projection.
+    expect(nap1).not.toHaveProperty("heart_rate");
+    expect(nap1).not.toHaveProperty("sleep_phase_30_sec");
+  });
+});

--- a/apps/oura-mcp/src/tools/sleep.test.ts
+++ b/apps/oura-mcp/src/tools/sleep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   filterPeriodsByDay,
+  filterPeriodsByType,
   shiftDate,
   stripTimeSeries,
 } from "./sleep.js";
@@ -143,6 +144,41 @@ describe("stripTimeSeries", () => {
     const passthrough = { ...p };
     expect(passthrough.heart_rate).not.toBeNull();
     expect(passthrough.sleep_phase_30_sec).toBe("1234");
+  });
+});
+
+describe("filterPeriodsByType (issue #48)", () => {
+  const periods = [
+    makePeriod({ id: "night", type: "long_sleep" }),
+    makePeriod({ id: "nap", type: "nap" }),
+    makePeriod({ id: "late", type: "late_nap" }),
+    makePeriod({ id: "rest", type: "rest" }),
+    makePeriod({ id: "short", type: "sleep" }),
+    makePeriod({ id: "gone", type: "deleted" }),
+  ];
+
+  it("returns all periods unchanged when type is omitted (default unchanged)", () => {
+    expect(filterPeriodsByType(periods, undefined)).toEqual(periods);
+  });
+
+  it("returns all periods unchanged when type is an empty array", () => {
+    expect(filterPeriodsByType(periods, [])).toEqual(periods);
+  });
+
+  it("filters to a single requested type", () => {
+    const out = filterPeriodsByType(periods, ["long_sleep"]);
+    expect(out.map((p) => p.id)).toEqual(["night"]);
+  });
+
+  it("filters to multiple requested types (naps only)", () => {
+    const out = filterPeriodsByType(periods, ["nap", "late_nap"]);
+    expect(out.map((p) => p.id).sort()).toEqual(["late", "nap"]);
+  });
+
+  it("returns empty when no period matches the requested type", () => {
+    // No "deleted"-typed... wait we do have one; use a type with zero matches instead.
+    const noneOfThisType = periods.filter((p) => p.type !== "rest");
+    expect(filterPeriodsByType(noneOfThisType, ["rest"])).toEqual([]);
   });
 });
 

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -13,7 +13,7 @@ import {
   textContent,
   errorContent,
 } from "./utils.js";
-import type { HrvTrendEntry } from "../oura/types.js";
+import type { HrvTrendEntry, SleepPeriod } from "../oura/types.js";
 import { fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 
 const dateRangeSchema = {
@@ -34,11 +34,61 @@ const dateRangeSchema = {
     .describe("Max pagination pages (default 5, each page ~25 records)."),
 };
 
+// Fields stripped from SleepPeriod records when include_time_series is false.
+const TIME_SERIES_FIELDS = [
+  "heart_rate",
+  "hrv",
+  "sleep_phase_30_sec",
+  "sleep_phase_5_min",
+  "app_sleep_phase_5_min",
+  "movement_30_sec",
+] as const;
+
+/**
+ * Returns a copy of the SleepPeriod with the time-series arrays/strings removed.
+ * Used by oura_sleep_detail and oura_naps to trim response size.
+ */
+export function stripTimeSeries(p: SleepPeriod): Omit<SleepPeriod, (typeof TIME_SERIES_FIELDS)[number]> {
+  const copy: Record<string, unknown> = { ...p };
+  for (const f of TIME_SERIES_FIELDS) {
+    delete copy[f];
+  }
+  return copy as Omit<SleepPeriod, (typeof TIME_SERIES_FIELDS)[number]>;
+}
+
+/**
+ * Adds N days to a YYYY-MM-DD date string. N may be negative.
+ * Computed in UTC; the input is interpreted as a calendar date, not a moment.
+ */
+export function shiftDate(ymd: string, days: number): string {
+  const d = new Date(`${ymd}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Filters sleep periods whose `day` field falls within [start, end] inclusive.
+ * Used to post-filter after widening the upstream /sleep call by 1 day on each
+ * side — see issue #33: the Oura /sleep endpoint filters by `bedtime_start`
+ * date, not by `day`, so a record with `day: X` but `bedtime_start: X-1` is
+ * silently dropped from a `start=end=X` query.
+ */
+export function filterPeriodsByDay(
+  periods: SleepPeriod[],
+  start_date: string,
+  end_date: string,
+): SleepPeriod[] {
+  return periods.filter((p) => p.day >= start_date && p.day <= end_date);
+}
+
 export function registerSleepTools(server: McpServer, client: OuraClient): void {
   server.tool(
     "oura_daily_sleep",
     "Returns daily sleep scores and contributor breakdown for a date range. " +
-      "Score is 0-100. Contributor values are 0-100. " +
+      "Score is 0-100. All contributor values are 0-100 on a higher-is-better scale " +
+      "(e.g. high `latency` means short time to fall asleep, not long latency). " +
+      "Contributor notes: `timing` = bedtime regularity (not clock time); " +
+      "`efficiency` = derived score (not the raw efficiency percentage). " +
       "Does NOT include raw stage durations — use oura_sleep_detail for that. " +
       "Dates: \"day\" is the morning the sleep score is reported on (i.e. the sleep period ending that morning).",
     dateRangeSchema,
@@ -62,15 +112,84 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
       "average and lowest heart rate (bpm), average HRV (ms RMSSD), sleep latency (seconds), " +
       "efficiency (0-100), and bedtime start/end. " +
       "All duration fields are in SECONDS, not minutes. " +
-      "Dates: \"day\" is the date the sleep period started (the evening you went to bed); the sleep period ends the following morning.",
+      "Dates: \"day\" is typically the morning-of-report date (the date the sleep period ends), " +
+      "matching oura_daily_sleep — but the keying is inconsistent across sleep period types: " +
+      "`long_sleep` and `late_nap` records are keyed to the morning of the NEXT sleep score window, " +
+      "while short `sleep` records are keyed to the calendar date they actually occurred on. " +
+      "This makes naive `day == X` filtering a hazard for naps in particular. " +
+      "When narrowing to a single day, this tool widens the upstream call by 1 day on each side " +
+      "and post-filters by `day` so `start_date == end_date == X` reliably returns all records with `day: X`. " +
+      "By default, the response strips time-series fields (heart_rate, hrv, sleep_phase_30_sec, " +
+      "sleep_phase_5_min, app_sleep_phase_5_min, movement_30_sec) to keep payloads small; " +
+      "set `include_time_series: true` to get the raw payload including those fields.",
+    {
+      ...dateRangeSchema,
+      include_time_series: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, return the raw payload including time-series fields (heart_rate.items, hrv.items, sleep_phase_30_sec, sleep_phase_5_min, app_sleep_phase_5_min, movement_30_sec). Default false (stripped).",
+        ),
+    },
+    async ({ start_date, end_date, max_pages, include_time_series }) => {
+      const range = resolveDateRange(start_date, end_date);
+      const err = validateDateRange(range.start_date, range.end_date);
+      if (err) return errorContent(err);
+      // Issue #33: widen by 1 day on each side and post-filter by `day`, since
+      // the Oura /sleep endpoint filters on bedtime_start date, not on `day`.
+      const widened = {
+        start_date: shiftDate(range.start_date, -1),
+        end_date: shiftDate(range.end_date, 1),
+      };
+      try {
+        const raw = await getSleepPeriods(client, widened, max_pages);
+        const filtered = filterPeriodsByDay(raw, range.start_date, range.end_date);
+        const out = include_time_series ? filtered : filtered.map(stripTimeSeries);
+        return textContent(out);
+      } catch (e) {
+        if (e instanceof OuraApiError) return errorContent(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.tool(
+    "oura_naps",
+    "Returns only auto-detected nap periods (type === \"nap\" || type === \"late_nap\") from the " +
+      "/sleep stream. This is the right tool for \"did the user nap in window X?\" — `oura_sessions` " +
+      "only returns user-initiated sessions, not auto-detected naps. " +
+      "Per-nap fields: day, type, bedtime_start, bedtime_end, total_sleep_duration (seconds), " +
+      "efficiency (0-100), average_heart_rate (bpm), average_hrv (ms RMSSD). " +
+      "Dates: `day` follows the Oura per-type keying — `late_nap` is keyed to the morning of the " +
+      "NEXT sleep score window, while short naps may be keyed to their calendar date. When hunting " +
+      "for naps that occurred on a specific evening, query a wider window (e.g. ±1 day) to be safe. " +
+      "Like oura_sleep_detail, this tool widens the upstream call by 1 day on each side and post-filters " +
+      "by `day` so single-day queries don't silently drop records.",
     dateRangeSchema,
     async ({ start_date, end_date, max_pages }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
+      const widened = {
+        start_date: shiftDate(range.start_date, -1),
+        end_date: shiftDate(range.end_date, 1),
+      };
       try {
-        const data = await getSleepPeriods(client, range, max_pages);
-        return textContent(data);
+        const raw = await getSleepPeriods(client, widened, max_pages);
+        const filtered = filterPeriodsByDay(raw, range.start_date, range.end_date);
+        const naps = filtered
+          .filter((p) => p.type === "nap" || p.type === "late_nap")
+          .map((p) => ({
+            day: p.day,
+            type: p.type,
+            bedtime_start: p.bedtime_start,
+            bedtime_end: p.bedtime_end,
+            total_sleep_duration: p.total_sleep_duration,
+            efficiency: p.efficiency,
+            average_heart_rate: p.average_heart_rate,
+            average_hrv: p.average_hrv,
+          }));
+        return textContent(naps);
       } catch (e) {
         if (e instanceof OuraApiError) return errorContent(e.message);
         throw e;

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -81,6 +81,30 @@ export function filterPeriodsByDay(
   return periods.filter((p) => p.day >= start_date && p.day <= end_date);
 }
 
+/** Allowed values for oura_sleep_detail's `type` filter (#48). */
+export const SLEEP_PERIOD_TYPES = [
+  "sleep",
+  "long_sleep",
+  "nap",
+  "late_nap",
+  "rest",
+  "deleted",
+] as const;
+
+/**
+ * Filters sleep periods down to the requested `type`(s). Omitted/undefined
+ * or empty array means "no filter" (all types returned) — default behavior
+ * is unchanged per #48's acceptance criteria.
+ */
+export function filterPeriodsByType(
+  periods: SleepPeriod[],
+  types: readonly string[] | undefined,
+): SleepPeriod[] {
+  if (!types || types.length === 0) return periods;
+  const wanted = new Set(types);
+  return periods.filter((p) => wanted.has(p.type));
+}
+
 export function registerSleepTools(server: McpServer, client: OuraClient): void {
   server.tool(
     "oura_daily_sleep",
@@ -121,7 +145,9 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
       "and post-filters by `day` so `start_date == end_date == X` reliably returns all records with `day: X`. " +
       "By default, the response strips time-series fields (heart_rate, hrv, sleep_phase_30_sec, " +
       "sleep_phase_5_min, app_sleep_phase_5_min, movement_30_sec) to keep payloads small; " +
-      "set `include_time_series: true` to get the raw payload including those fields.",
+      "set `include_time_series: true` to get the raw payload including those fields. " +
+      "Pass `type` to restrict which period types are returned (e.g. `[\"long_sleep\"]` for real " +
+      "nights only, or `[\"nap\", \"late_nap\"]` for naps only); omit for all types (default, unchanged).",
     {
       ...dateRangeSchema,
       include_time_series: z
@@ -130,8 +156,15 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
         .describe(
           "If true, return the raw payload including time-series fields (heart_rate.items, hrv.items, sleep_phase_30_sec, sleep_phase_5_min, app_sleep_phase_5_min, movement_30_sec). Default false (stripped).",
         ),
+      type: z
+        .array(z.enum(SLEEP_PERIOD_TYPES))
+        .min(1)
+        .optional()
+        .describe(
+          "Restrict results to these period types (\"sleep\", \"long_sleep\", \"nap\", \"late_nap\", \"rest\", \"deleted\"). Omit for all types (default).",
+        ),
     },
-    async ({ start_date, end_date, max_pages, include_time_series }) => {
+    async ({ start_date, end_date, max_pages, include_time_series, type }) => {
       const range = resolveDateRange(start_date, end_date);
       const err = validateDateRange(range.start_date, range.end_date);
       if (err) return errorContent(err);
@@ -143,7 +176,8 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
       };
       try {
         const raw = await getSleepPeriods(client, widened, max_pages);
-        const filtered = filterPeriodsByDay(raw, range.start_date, range.end_date);
+        const byDay = filterPeriodsByDay(raw, range.start_date, range.end_date);
+        const filtered = filterPeriodsByType(byDay, type);
         const out = include_time_series ? filtered : filtered.map(stripTimeSeries);
         return textContent(out);
       } catch (e) {


### PR DESCRIPTION
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38
Closes #46
Closes #47
Closes #48
Closes #49

## Per-issue summary

- **#32 (bug)** — `oura_sleep_detail` description now correctly states `day` is the morning-of-report date (matches `oura_daily_sleep`), not the date the period started.
- **#35 (bug)** — `oura_sleep_detail` description documents the per-type inconsistency: `long_sleep` and `late_nap` records are keyed to the morning of the next sleep score window, while short `sleep` records are keyed to their calendar date.
- **#38 (enhancement)** — `oura_daily_sleep` description states all contributors are 0-100 higher-is-better, with the `latency` example, plus one-liners for ambiguous `timing`/`efficiency`.
- **#34 (bug)** — `oura_sessions` description clarifies it returns ONLY user-initiated sessions and points to `oura_naps`/`oura_sleep_detail` for auto-detected naps.
- **#33 (bug)** — `oura_sleep_detail` widens the upstream `/sleep` call by 1 day on each side and post-filters by `day`, so `start_date == end_date` reliably returns matching records.
- **#36 (enhancement)** — `oura_sleep_detail` gains `include_time_series: boolean` (default `false`), stripping `heart_rate`, `hrv`, `sleep_phase_30_sec`, `sleep_phase_5_min`, `app_sleep_phase_5_min`, `movement_30_sec`.
- **#37 (enhancement)** — New `oura_naps` tool returns only `nap`/`late_nap` periods with a compact field set.
- **#48 (enhancement)** — `oura_sleep_detail` gains a `type` filter (`sleep`/`long_sleep`/`nap`/`late_nap`/`rest`/`deleted`). Omitted = all types, unchanged default behavior.
- **#47 (enhancement)** — `oura_daily_activity` gains `include_time_series: boolean` (default `false`), stripping the bulky `met` per-minute array and `class_5_min` string while keeping all scalar/summary fields (score, contributors, steps, calories, time breakdowns). Mirrors the param already added to `oura_sleep_detail` for the same underlying issue (#36/#47 are the same enhancement across two tools).
- **#49 (enhancement)** — New composite `oura_night_summary` tool: one call returns a night's sleep score + contributors, stage/HR/HRV/latency/efficiency highlights (no time-series arrays), same-morning readiness score + contributors, 14-day HRV/RHR baseline means, and any user tags overlapping the night. Defaults to the most recently synced night (looks back up to 3 days); identifies the night unambiguously via `bedtime_start`/`bedtime_end`.
- **#46 (bug, best-effort — see below)** — `oura_baseline_compare` now returns `bedtime_start`/`bedtime_end` for sleep-derived metrics (hrv, rhr, sleep_total, deep_sleep, rem_sleep, respiratory_rate) identifying which physical night backs the returned value, and sets `possibly_stale: true` + a `stale_reason` string when that night ended more than 12 hours before the call — flagging the sync-boundary case where a fresher night may exist but hasn't synced yet, and an older already-synced night was silently matched instead.

## ⚠️ Best-effort / needs live verification

**#46** is a best-effort fix based on static analysis of the reported symptom, not confirmed against a live Oura account near an actual sync-lag window. The `STALE_THRESHOLD_HOURS = 12` heuristic and the "flag any resolved night older than 12h" logic are documented as such in code comments in `apps/oura-mcp/src/tools/baseline_compare.ts`. Please smoke-test this manually:
- Query `oura_baseline_compare` for a sleep-derived metric in the morning, before that night has synced, and confirm `possibly_stale: true` appears with a sensible `bedtime_start`/`bedtime_end`.
- Query the same metric for an old historical date and sanity-check whether `possibly_stale` fires as expected there too (by design it will — the flag is unconditional on "how long ago did this night end", not scoped to "was this a live/near-now query"; this trade-off is called out in the code comment).

Also worth a manual pass (lower risk, but still touching live-data-shaped code):
- `oura_night_summary` default (no `date`) behavior on an account with a genuinely unsynced most-recent night, to confirm the 3-day lookback and "most recent by bedtime_end" selection feel right in practice.
- `oura_daily_activity` and `oura_sleep_detail` `include_time_series`/`type` params against real API responses (verified structurally via unit tests with synthetic fixtures, not against live payloads).

## Tests

`apps/oura-mcp/src/oura/metrics.test.ts`, `apps/oura-mcp/src/tools/activity.test.ts`, `apps/oura-mcp/src/tools/baseline_compare.test.ts`, `apps/oura-mcp/src/tools/night_summary.test.ts` (new), plus additions to the existing `sleep.test.ts` for the `type` filter. All pure-function/unit level (no live network calls), following the existing convention in this app.

`pnpm -r type-check` and `pnpm -r test` both pass (oura-mcp: 40 tests, all green).

## Test plan
- [ ] Manual smoke: `oura_sleep_detail(start_date=X, end_date=X)` for a date with known long_sleep — verify the record is returned (#33).
- [ ] Manual smoke: `oura_sleep_detail` with/without `include_time_series` and with `type` filter set to `["long_sleep"]` vs `["nap","late_nap"]` (#36/#48).
- [ ] Manual smoke: `oura_naps` for a window with a known auto-detected nap (#37).
- [ ] Manual smoke: `oura_daily_activity` with/without `include_time_series`, confirm response size drop and that `met`/`class_5_min` reappear when true (#47).
- [ ] Manual smoke: `oura_night_summary` with no `date` and with an explicit `date`, confirm bedtime range, readiness, and baselines all populate (#49).
- [ ] **Manual smoke, morning near sync boundary**: `oura_baseline_compare` for a sleep-derived metric — confirm `bedtime_start`/`bedtime_end` are present and `possibly_stale` behaves as expected (#46 — see caveat above).

Generated with Claude Code.
