### PR TITLE
[gmail-mcp] Add list_attachments and get_attachment tools

### DIFF
--- a/apps/gmail-mcp/package.json
+++ b/apps/gmail-mcp/package.json
@@ -15,6 +15,9 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "agents": "^0.11.6",
     "googleapis": "^171.4.0",
+    "mammoth": "^1.8.0",
+    "unpdf": "^0.12.1",
+    "xlsx": "^0.18.5",
     "zod": "^3.24.0"
   }
 }

--- a/apps/gmail-mcp/src/server.ts
+++ b/apps/gmail-mcp/src/server.ts
@@ -10,7 +10,7 @@ export function buildServer(env: Env): McpServer {
   });
 
   const gmail = buildGmailClient(env);
-  registerAllTools(server, gmail);
+  registerAllTools(server, gmail, env);
 
   return server;
 }

--- a/apps/gmail-mcp/src/tools/attachments.test.ts
+++ b/apps/gmail-mcp/src/tools/attachments.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for the gmail attachment tools. Gmail API is mocked —
+ * no network, no real OAuth. Verifies:
+ *   - `collectAttachments` walks nested multipart trees and pulls every
+ *     part with a `body.attachmentId`.
+ *   - `routeByMime` produces the right MCP content block per MIME type
+ *     (image → image block, text → text, unsupported → error).
+ *   - The `gmail_get_attachment` tool refuses oversize fetches when
+ *     `force !== true`, and proceeds when `force === true`.
+ *   - The size guard, base64url decoding, and "attachment not found"
+ *     branch all wire up correctly.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectAttachments,
+  base64UrlToBytes,
+  bytesToStandardBase64,
+  routeByMime,
+  registerAttachmentTools,
+  type AttachmentMeta,
+} from "./attachments.js";
+import type { Env } from "../types.js";
+
+// A 1x1 transparent PNG, base64url encoded (no padding, `+`/`/` swapped
+// for `-`/`_`). Used to verify image routing without bundling a binary
+// fixture.
+const ONE_PX_PNG_B64URL =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII";
+
+describe("collectAttachments", () => {
+  it("returns [] for a payload with no attachments", () => {
+    const out = collectAttachments({
+      mimeType: "text/plain",
+      body: { attachmentId: null, size: 0 },
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("walks a nested multipart tree and surfaces every attachment part", () => {
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          mimeType: "multipart/alternative",
+          parts: [
+            { mimeType: "text/plain", body: { size: 10 } },
+            { mimeType: "text/html", body: { size: 20 } },
+          ],
+        },
+        {
+          mimeType: "application/pdf",
+          filename: "report.pdf",
+          body: { attachmentId: "att-1", size: 12345 },
+        },
+        {
+          mimeType: "multipart/related",
+          parts: [
+            { mimeType: "text/html", body: { size: 30 } },
+            {
+              mimeType: "image/png",
+              filename: "inline.png",
+              body: { attachmentId: "att-2", size: 678 },
+            },
+          ],
+        },
+      ],
+    };
+    const out = collectAttachments(payload);
+    expect(out).toEqual([
+      {
+        filename: "report.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 12345,
+        attachment_id: "att-1",
+      },
+      {
+        filename: "inline.png",
+        mime_type: "image/png",
+        size_bytes: 678,
+        attachment_id: "att-2",
+      },
+    ]);
+  });
+});
+
+describe("base64UrlToBytes / bytesToStandardBase64", () => {
+  it("round-trips an ASCII string through base64url decode + standard base64 encode", () => {
+    // "hello" → "aGVsbG8=" (standard) → "aGVsbG8" (base64url, no padding)
+    const bytes = base64UrlToBytes("aGVsbG8");
+    expect(new TextDecoder().decode(bytes)).toBe("hello");
+    expect(bytesToStandardBase64(bytes)).toBe("aGVsbG8=");
+  });
+
+  it("handles base64url-specific characters (- and _)", () => {
+    // Bytes 0xfb 0xff → standard "+/8=" → base64url "-_8"
+    const bytes = base64UrlToBytes("-_8");
+    expect(Array.from(bytes)).toEqual([0xfb, 0xff]);
+  });
+});
+
+describe("routeByMime", () => {
+  it("returns an MCP image content block for image/png", async () => {
+    const bytes = base64UrlToBytes(ONE_PX_PNG_B64URL);
+    const result = await routeByMime(bytes, "image/png", "tiny.png");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.response.content).toHaveLength(1);
+    const block = result.response.content[0]!;
+    expect(block.type).toBe("image");
+    if (block.type === "image") {
+      expect(block.mimeType).toBe("image/png");
+      // standard base64 → padded
+      expect(block.data.endsWith("=") || block.data.length % 4 === 0).toBe(
+        true,
+      );
+    }
+  });
+
+  it("decodes text/plain bytes as UTF-8 text", async () => {
+    const bytes = new TextEncoder().encode("hello world");
+    const result = await routeByMime(bytes, "text/plain", "note.txt");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const block = result.response.content[0]!;
+    expect(block.type).toBe("text");
+    if (block.type === "text") expect(block.text).toBe("hello world");
+  });
+
+  it("decodes application/json as text", async () => {
+    const bytes = new TextEncoder().encode('{"a":1}');
+    const result = await routeByMime(bytes, "application/json", "data.json");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const block = result.response.content[0]!;
+    expect(block.type).toBe("text");
+    if (block.type === "text") expect(block.text).toBe('{"a":1}');
+  });
+
+  it("returns a structured error for an unsupported MIME type", async () => {
+    const result = await routeByMime(
+      new Uint8Array([0, 1, 2]),
+      "application/x-weird-binary",
+      "weird.bin",
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("Unsupported attachment MIME type");
+    expect(result.message).toContain("application/x-weird-binary");
+    expect(result.message).toContain("weird.bin");
+  });
+});
+
+/**
+ * Build a minimal McpServer-shaped stub that just captures `.tool()`
+ * registrations so the test can invoke handlers directly.
+ */
+function buildServerStub() {
+  const tools: Record<
+    string,
+    { description: string; handler: (args: unknown) => Promise<unknown> }
+  > = {};
+  const server = {
+    tool(
+      name: string,
+      description: string,
+      _schema: unknown,
+      handler: (args: unknown) => Promise<unknown>,
+    ) {
+      tools[name] = { description, handler };
+    },
+  };
+  return { server, tools };
+}
+
+function fakeGmail(overrides: {
+  messageGet?: () => Promise<unknown>;
+  attachmentGet?: () => Promise<unknown>;
+}) {
+  return {
+    users: {
+      messages: {
+        get: vi.fn(overrides.messageGet ?? (async () => ({ data: {} }))),
+        attachments: {
+          get: vi.fn(
+            overrides.attachmentGet ?? (async () => ({ data: { data: "" } })),
+          ),
+        },
+      },
+    },
+  };
+}
+
+describe("registerAttachmentTools size guard", () => {
+  const env: Env = {
+    URL_SECRET: "x",
+    GMAIL_CREDENTIALS: "x",
+    GMAIL_OAUTH_KEYS: "x",
+    GMAIL_ATTACHMENT_BYTE_CAP: "1024", // 1 KiB cap for the test
+  };
+
+  const oversizeAttachment: AttachmentMeta = {
+    filename: "big.txt",
+    mime_type: "text/plain",
+    size_bytes: 5_000,
+    attachment_id: "att-big",
+  };
+
+  function messageWithAttachment() {
+    return {
+      data: {
+        payload: {
+          mimeType: "multipart/mixed",
+          parts: [
+            {
+              mimeType: oversizeAttachment.mime_type,
+              filename: oversizeAttachment.filename,
+              body: {
+                attachmentId: oversizeAttachment.attachment_id,
+                size: oversizeAttachment.size_bytes,
+              },
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  it("refuses an oversize attachment when force is not true", async () => {
+    const { server, tools } = buildServerStub();
+    const gmail = fakeGmail({
+      messageGet: async () => messageWithAttachment(),
+      attachmentGet: async () => ({ data: { data: "aGVsbG8" } }),
+    });
+    registerAttachmentTools(
+      server as unknown as Parameters<typeof registerAttachmentTools>[0],
+      gmail as unknown as Parameters<typeof registerAttachmentTools>[1],
+      env,
+    );
+    const out = (await tools.gmail_get_attachment!.handler({
+      message_id: "m1",
+      attachment_id: oversizeAttachment.attachment_id,
+    })) as {
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(out.isError).toBe(true);
+    expect(out.content[0]!.text).toContain("exceeds the 1024-byte cap");
+    // Attachment bytes should NOT have been fetched.
+    expect(gmail.users.messages.attachments.get).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with an oversize attachment when force=true", async () => {
+    const { server, tools } = buildServerStub();
+    const gmail = fakeGmail({
+      messageGet: async () => messageWithAttachment(),
+      // "aGVsbG8" decodes to "hello"
+      attachmentGet: async () => ({ data: { data: "aGVsbG8" } }),
+    });
+    registerAttachmentTools(
+      server as unknown as Parameters<typeof registerAttachmentTools>[0],
+      gmail as unknown as Parameters<typeof registerAttachmentTools>[1],
+      env,
+    );
+    const out = (await tools.gmail_get_attachment!.handler({
+      message_id: "m1",
+      attachment_id: oversizeAttachment.attachment_id,
+      force: true,
+    })) as {
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(out.isError).toBeUndefined();
+    expect(out.content[0]!.type).toBe("text");
+    expect(out.content[0]!.text).toBe("hello");
+    expect(gmail.users.messages.attachments.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an error when the attachment_id is not found on the message", async () => {
+    const { server, tools } = buildServerStub();
+    const gmail = fakeGmail({
+      messageGet: async () => messageWithAttachment(),
+    });
+    registerAttachmentTools(
+      server as unknown as Parameters<typeof registerAttachmentTools>[0],
+      gmail as unknown as Parameters<typeof registerAttachmentTools>[1],
+      env,
+    );
+    const out = (await tools.gmail_get_attachment!.handler({
+      message_id: "m1",
+      attachment_id: "does-not-exist",
+    })) as {
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(out.isError).toBe(true);
+    expect(out.content[0]!.text).toContain("not found on message");
+  });
+});
+
+describe("gmail_list_attachments tool", () => {
+  it("returns metadata for every attachment on the message", async () => {
+    const { server, tools } = buildServerStub();
+    const gmail = fakeGmail({
+      messageGet: async () => ({
+        data: {
+          payload: {
+            mimeType: "multipart/mixed",
+            parts: [
+              { mimeType: "text/plain", body: { size: 10 } },
+              {
+                mimeType: "application/pdf",
+                filename: "doc.pdf",
+                body: { attachmentId: "a1", size: 100 },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const env: Env = {
+      URL_SECRET: "x",
+      GMAIL_CREDENTIALS: "x",
+      GMAIL_OAUTH_KEYS: "x",
+    };
+    registerAttachmentTools(
+      server as unknown as Parameters<typeof registerAttachmentTools>[0],
+      gmail as unknown as Parameters<typeof registerAttachmentTools>[1],
+      env,
+    );
+    const out = (await tools.gmail_list_attachments!.handler({
+      message_id: "m1",
+    })) as { content: Array<{ type: string; text: string }> };
+    const payload = JSON.parse(out.content[0]!.text) as {
+      message_id: string;
+      attachments: AttachmentMeta[];
+    };
+    expect(payload.message_id).toBe("m1");
+    expect(payload.attachments).toEqual([
+      {
+        filename: "doc.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 100,
+        attachment_id: "a1",
+      },
+    ]);
+  });
+});

--- a/apps/gmail-mcp/src/tools/attachments.ts
+++ b/apps/gmail-mcp/src/tools/attachments.ts
@@ -1,0 +1,411 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { gmail_v1 } from "googleapis";
+import { z } from "zod";
+import { textContent, errorContent, formatGmailError } from "./utils.js";
+import type { Env } from "../types.js";
+
+/**
+ * Gmail attachment tools.
+ *
+ * `gmail_list_attachments` walks a message's MIME tree and returns
+ * metadata for every part with a `body.attachmentId`. The model can
+ * use that metadata to decide whether to spend bytes / CPU on
+ * `gmail_get_attachment`.
+ *
+ * `gmail_get_attachment` fetches base64url bytes via
+ * `users.messages.attachments.get`, then routes by MIME type:
+ *   - images → MCP image content block (model sees it natively)
+ *   - text-like → decoded UTF-8 text
+ *   - PDF → server-side text extraction via `unpdf`
+ *   - `.docx` → markdown via `mammoth`
+ *   - `.xlsx` → CSV (first sheet) or JSON-of-CSVs (multi-sheet) via SheetJS
+ *   - anything else → structured error naming the MIME type + filename
+ *
+ * A size guard (default 10 MiB, configurable via env
+ * `GMAIL_ATTACHMENT_BYTE_CAP`) refuses oversize fetches unless the
+ * caller passes `force: true`.
+ *
+ * PDF page rasterization is out of scope — only text extraction is
+ * performed. Heavy parsing (large PDFs / spreadsheets) is wrapped in
+ * try/catch so we surface a clear error rather than time out silently.
+ */
+
+/** MIME types we treat as in-line images. */
+const IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+/**
+ * Non-`text/*` MIME types we still decode as UTF-8 text. `text/*`
+ * itself is matched via a prefix check, not this set.
+ */
+const TEXT_MIME_TYPES = new Set([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/x-yaml",
+  "application/yaml",
+  "application/x-sh",
+  "application/x-www-form-urlencoded",
+  "application/sql",
+  "application/csv",
+]);
+
+const PDF_MIME = "application/pdf";
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const XLSX_MIME =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+const DEFAULT_BYTE_CAP = 10 * 1024 * 1024; // 10 MiB
+
+type AttachmentPart = {
+  filename?: string | null;
+  mimeType?: string | null;
+  body?: { attachmentId?: string | null; size?: number | null } | null;
+  parts?: AttachmentPart[] | null;
+};
+
+export interface AttachmentMeta {
+  filename: string;
+  mime_type: string;
+  size_bytes: number;
+  attachment_id: string;
+}
+
+/**
+ * Walk a Gmail MIME tree and collect every part with a non-empty
+ * `body.attachmentId`. Inline images (Content-Disposition: inline)
+ * are included too — Gmail still surfaces them as attachments.
+ */
+export function collectAttachments(
+  part: AttachmentPart | undefined | null,
+  out: AttachmentMeta[] = [],
+  depth = 0,
+): AttachmentMeta[] {
+  if (!part || depth > 16) return out;
+  const aid = part.body?.attachmentId;
+  if (aid) {
+    out.push({
+      filename: part.filename ?? "",
+      mime_type: part.mimeType ?? "application/octet-stream",
+      size_bytes: part.body?.size ?? 0,
+      attachment_id: aid,
+    });
+  }
+  for (const child of part.parts ?? []) {
+    collectAttachments(child, out, depth + 1);
+  }
+  return out;
+}
+
+/**
+ * Decode Gmail's base64url payload (RFC 4648 §5: `-`/`_` substituted
+ * for `+`/`/`, padding optional) into a `Uint8Array` using the
+ * Workers-available `atob`.
+ */
+export function base64UrlToBytes(b64url: string): Uint8Array {
+  const std = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (std.length % 4)) % 4;
+  const padded = std + "=".repeat(padLen);
+  const bin = atob(padded);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+/** Re-encode a Uint8Array to standard base64 (for the MCP image block). */
+export function bytesToStandardBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s);
+}
+
+function parseCap(env: Env): number {
+  const raw = env.GMAIL_ATTACHMENT_BYTE_CAP;
+  if (!raw) return DEFAULT_BYTE_CAP;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_BYTE_CAP;
+  return Math.floor(n);
+}
+
+function isTextMime(mime: string): boolean {
+  if (mime.startsWith("text/")) return true;
+  if (TEXT_MIME_TYPES.has(mime)) return true;
+  // Recognize source-code-ish vendor types: anything ending in +json, +xml,
+  // +yaml is structurally text.
+  if (/\+(json|xml|yaml)$/.test(mime)) return true;
+  return false;
+}
+
+/**
+ * Lightweight HTML → markdown conversion for mammoth's docx output.
+ * Mammoth doesn't ship a markdown converter, so we do a small pass
+ * covering headings, paragraphs, lists, bold, italic, and links —
+ * enough that the model gets readable text rather than tag soup.
+ * Anything fancier (tables, nested formatting) gets a best-effort
+ * fallback: tags are stripped and content is preserved.
+ */
+export function htmlToMarkdown(html: string): string {
+  let s = html;
+  // Headings.
+  s = s.replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, "\n# $1\n");
+  s = s.replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, "\n## $1\n");
+  s = s.replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, "\n### $1\n");
+  s = s.replace(/<h4[^>]*>([\s\S]*?)<\/h4>/gi, "\n#### $1\n");
+  s = s.replace(/<h5[^>]*>([\s\S]*?)<\/h5>/gi, "\n##### $1\n");
+  s = s.replace(/<h6[^>]*>([\s\S]*?)<\/h6>/gi, "\n###### $1\n");
+  // Inline emphasis.
+  s = s.replace(/<(strong|b)[^>]*>([\s\S]*?)<\/\1>/gi, "**$2**");
+  s = s.replace(/<(em|i)[^>]*>([\s\S]*?)<\/\1>/gi, "*$2*");
+  // Links.
+  s = s.replace(
+    /<a[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    "[$2]($1)",
+  );
+  // List items.
+  s = s.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "- $1\n");
+  s = s.replace(/<\/?(ul|ol)[^>]*>/gi, "\n");
+  // Paragraphs and breaks.
+  s = s.replace(/<p[^>]*>/gi, "");
+  s = s.replace(/<\/p>/gi, "\n\n");
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  // Strip any remaining tags.
+  s = s.replace(/<[^>]+>/g, "");
+  // Decode common entities.
+  s = s
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+  // Collapse runs of 3+ blank lines.
+  s = s.replace(/\n{3,}/g, "\n\n");
+  return s.trim();
+}
+
+interface RouteResult {
+  ok: true;
+  response: ReturnType<typeof textContent> | {
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "image"; data: string; mimeType: string }
+    >;
+  };
+}
+
+interface RouteError {
+  ok: false;
+  message: string;
+}
+
+/**
+ * Dispatch decoded bytes to the correct MCP content block based on the
+ * declared MIME type. Returns either an MCP-shaped response or a
+ * structured-error message.
+ */
+export async function routeByMime(
+  bytes: Uint8Array,
+  mime: string,
+  filename: string,
+): Promise<RouteResult | RouteError> {
+  try {
+    if (IMAGE_MIME_TYPES.has(mime)) {
+      const data = bytesToStandardBase64(bytes);
+      return {
+        ok: true,
+        response: {
+          content: [{ type: "image", data, mimeType: mime }],
+        },
+      };
+    }
+    if (isTextMime(mime)) {
+      const text = new TextDecoder("utf-8").decode(bytes);
+      return { ok: true, response: textContent(text) };
+    }
+    if (mime === PDF_MIME) {
+      // `unpdf` ships a pure-JS bundled pdf.js for Workers/serverless.
+      // We dynamic-import so the module load only happens on actual PDF
+      // fetches (keeps cold-start cost off the other tool paths).
+      const { extractText, getDocumentProxy } = await import("unpdf");
+      const pdf = await getDocumentProxy(bytes);
+      const { text } = await extractText(pdf, { mergePages: true });
+      const merged = Array.isArray(text) ? text.join("\n") : text;
+      return { ok: true, response: textContent(merged) };
+    }
+    if (mime === DOCX_MIME) {
+      try {
+        // mammoth's BrowserInput shape takes an ArrayBuffer — avoids any
+        // Node `Buffer` dependency. mammoth doesn't ship a direct
+        // markdown converter, so we go HTML → light markdown.
+        const mammothModule = await import("mammoth");
+        const mammoth = (mammothModule.default ?? mammothModule) as {
+          convertToHtml: (input: {
+            arrayBuffer: ArrayBuffer;
+          }) => Promise<{ value: string }>;
+        };
+        // Copy into a fresh ArrayBuffer so we don't hand mammoth a
+        // SharedArrayBuffer-backed view (and so the buffer is the exact
+        // length of the payload).
+        const ab = bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength,
+        ) as ArrayBuffer;
+        const result = await mammoth.convertToHtml({ arrayBuffer: ab });
+        return { ok: true, response: textContent(htmlToMarkdown(result.value)) };
+      } catch (e) {
+        const detail = e instanceof Error ? e.message : String(e);
+        return {
+          ok: false,
+          message:
+            "docx parsing failed on Workers runtime — mammoth may require Node-only APIs not available here. " +
+            `Underlying error: ${detail}. Filename: ${filename || "(none)"}.`,
+        };
+      }
+    }
+    if (mime === XLSX_MIME) {
+      const XLSX = await import("xlsx");
+      const wb = XLSX.read(bytes, { type: "array" });
+      const sheetNames = wb.SheetNames;
+      if (sheetNames.length === 0) {
+        return { ok: true, response: textContent("") };
+      }
+      if (sheetNames.length === 1) {
+        const sheet = wb.Sheets[sheetNames[0]!]!;
+        const csv = XLSX.utils.sheet_to_csv(sheet);
+        return { ok: true, response: textContent(csv) };
+      }
+      const byName: Record<string, string> = {};
+      for (const name of sheetNames) {
+        const sheet = wb.Sheets[name];
+        if (sheet) byName[name] = XLSX.utils.sheet_to_csv(sheet);
+      }
+      return { ok: true, response: textContent(byName) };
+    }
+    return {
+      ok: false,
+      message:
+        `Unsupported attachment MIME type "${mime}" for file "${filename || "(no filename)"}". ` +
+        "Supported: image/{png,jpeg,webp,gif}, text/*, application/json, application/pdf, " +
+        ".docx, .xlsx.",
+    };
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      message:
+        `Failed to parse attachment "${filename || "(no filename)"}" as ${mime}: ${detail}. ` +
+        "This may be a Workers CPU/memory limit (large PDFs or spreadsheets).",
+    };
+  }
+}
+
+export function registerAttachmentTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  env: Env,
+): void {
+  const cap = parseCap(env);
+  const capMiB = (cap / (1024 * 1024)).toFixed(1);
+
+  server.tool(
+    "gmail_list_attachments",
+    "List metadata (filename, MIME type, size in bytes, attachment_id) for every attachment " +
+      "on a Gmail message. Walks the message's MIME tree and returns one entry per part with an " +
+      "attachmentId — use the returned attachment_id with gmail_get_attachment to fetch bytes.",
+    {
+      message_id: z.string().describe("Gmail message ID"),
+    },
+    async ({ message_id }) => {
+      try {
+        const res = await gmail.users.messages.get({
+          userId: "me",
+          id: message_id,
+          format: "full",
+        });
+        const payload = res.data.payload as AttachmentPart | undefined;
+        const attachments = collectAttachments(payload ?? null);
+        return textContent({ message_id, attachments });
+      } catch (e) {
+        return errorContent(formatGmailError(e));
+      }
+    },
+  );
+
+  server.tool(
+    "gmail_get_attachment",
+    `Fetch a Gmail attachment's bytes and return content routed by MIME type. ` +
+      `Size cap: ${capMiB} MiB (configurable via GMAIL_ATTACHMENT_BYTE_CAP env var) — ` +
+      `pass force=true to bypass for a single fetch. Supported MIME types: ` +
+      `image/{png,jpeg,webp,gif} returned as an MCP image block; text/*, application/json, ` +
+      `and common code/CSV MIME types decoded as UTF-8 text; application/pdf parsed to text ` +
+      `(page rasterization is out of scope — text extraction only); ` +
+      `.docx converted to markdown; .xlsx converted to CSV (or JSON of CSVs if multi-sheet). ` +
+      `Unsupported MIME types return a structured error. Heavy parsing may hit Workers CPU/memory ` +
+      `limits — failures return a clear error rather than silent timeout.`,
+    {
+      message_id: z.string().describe("Gmail message ID"),
+      attachment_id: z
+        .string()
+        .describe("Attachment ID from gmail_list_attachments"),
+      force: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, bypass the configured byte cap. Use sparingly — large attachments may exceed Workers CPU/memory limits.",
+        ),
+    },
+    async ({ message_id, attachment_id, force }) => {
+      try {
+        // Re-fetch the message metadata so we can pick out this attachment's
+        // MIME type, filename, and size. The Gmail attachments.get response
+        // only carries `data` + `size`, not the MIME type / filename — those
+        // live on the parent part.
+        const msgRes = await gmail.users.messages.get({
+          userId: "me",
+          id: message_id,
+          format: "full",
+        });
+        const payload = msgRes.data.payload as AttachmentPart | undefined;
+        const attachments = collectAttachments(payload ?? null);
+        const meta = attachments.find((a) => a.attachment_id === attachment_id);
+        if (!meta) {
+          return errorContent(
+            `Attachment ${attachment_id} not found on message ${message_id}. ` +
+              "Call gmail_list_attachments first to see available attachment_ids.",
+          );
+        }
+
+        if (meta.size_bytes > cap && force !== true) {
+          return errorContent(
+            `Attachment "${meta.filename || "(no filename)"}" is ${meta.size_bytes} bytes, ` +
+              `which exceeds the ${cap}-byte cap (${capMiB} MiB). ` +
+              "Pass force=true to bypass — note that very large attachments may exceed Workers CPU/memory limits.",
+          );
+        }
+
+        const attRes = await gmail.users.messages.attachments.get({
+          userId: "me",
+          messageId: message_id,
+          id: attachment_id,
+        });
+        const dataB64 = attRes.data.data;
+        if (!dataB64) {
+          return errorContent(
+            `Gmail returned no bytes for attachment ${attachment_id} on message ${message_id}.`,
+          );
+        }
+        const bytes = base64UrlToBytes(dataB64);
+        const routed = await routeByMime(bytes, meta.mime_type, meta.filename);
+        if (!routed.ok) return errorContent(routed.message);
+        return routed.response as Awaited<ReturnType<typeof textContent>>;
+      } catch (e) {
+        return errorContent(formatGmailError(e));
+      }
+    },
+  );
+}

--- a/apps/gmail-mcp/src/tools/index.ts
+++ b/apps/gmail-mcp/src/tools/index.ts
@@ -6,6 +6,8 @@ import { registerComposeTools } from "./compose.js";
 import { registerModifyTools } from "./modify.js";
 import { registerDeleteTools } from "./delete.js";
 import { registerFilterTools } from "./filters.js";
+import { registerAttachmentTools } from "./attachments.js";
+import type { Env } from "../types.js";
 
 /**
  * Wire every Gmail tool onto an `McpServer`. Tool registration is split
@@ -17,11 +19,16 @@ import { registerFilterTools } from "./filters.js";
  * in here so handlers can be plain closures rather than re-instantiating
  * the OAuth client per call.
  */
-export function registerAllTools(server: McpServer, gmail: gmail_v1.Gmail): void {
+export function registerAllTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  env: Env,
+): void {
   registerLabelTools(server, gmail);
   registerEmailTools(server, gmail);
   registerComposeTools(server, gmail);
   registerModifyTools(server, gmail);
   registerDeleteTools(server, gmail);
   registerFilterTools(server, gmail);
+  registerAttachmentTools(server, gmail, env);
 }

--- a/apps/gmail-mcp/src/types.ts
+++ b/apps/gmail-mcp/src/types.ts
@@ -2,4 +2,10 @@ export interface Env {
   URL_SECRET: string;
   GMAIL_CREDENTIALS: string;
   GMAIL_OAUTH_KEYS: string;
+  /**
+   * Maximum attachment size in bytes that `gmail_get_attachment` will
+   * fetch and decode without the `force: true` flag. Optional —
+   * falls back to a 10 MiB default in code if unset or unparseable.
+   */
+  GMAIL_ATTACHMENT_BYTE_CAP?: string;
 }

--- a/apps/gmail-mcp/wrangler.jsonc
+++ b/apps/gmail-mcp/wrangler.jsonc
@@ -5,5 +5,11 @@
   "compatibility_date": "2024-11-01",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
-  "workers_dev": true
+  "workers_dev": true,
+  "vars": {
+    // Default attachment byte cap for gmail_get_attachment (10 MiB).
+    // Override per-env by setting this var; `force: true` on the tool
+    // call bypasses the cap for a single fetch.
+    "GMAIL_ATTACHMENT_BYTE_CAP": "10485760"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,15 @@ importers:
       googleapis:
         specifier: ^171.4.0
         version: 171.4.0
+      mammoth:
+        specifier: ^1.8.0
+        version: 1.12.0
+      unpdf:
+        specifier: ^0.12.1
+        version: 0.12.2
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -688,6 +697,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@mapbox/node-pre-gyp@1.0.11':
+    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
+    hasBin: true
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -890,9 +903,24 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -942,6 +970,10 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -950,9 +982,23 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -968,9 +1014,15 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -995,13 +1047,39 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  canvas@2.11.2:
+    resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
+    engines: {node: '>=6'}
+
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1029,9 +1107,17 @@ packages:
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cron-schedule@6.0.0:
     resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
@@ -1054,6 +1140,13 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@4.2.1:
+    resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==}
+    engines: {node: '>=8'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1061,6 +1154,12 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1077,6 +1176,9 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1178,9 +1280,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1189,6 +1302,11 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -1221,6 +1339,10 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
@@ -1245,6 +1367,9 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -1257,6 +1382,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -1264,6 +1393,13 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1276,8 +1412,15 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1313,6 +1456,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -1322,6 +1468,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1397,11 +1546,23 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
+  mammoth@1.12.0:
+    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1434,13 +1595,40 @@ packages:
   mimetext@3.0.28:
     resolution: {integrity: sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==}
 
+  mimic-response@2.1.0:
+    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
+    engines: {node: '>=8'}
+
   miniflare@4.20260424.0:
     resolution: {integrity: sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.27.0:
+    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1461,12 +1649,30 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1486,6 +1692,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1502,6 +1714,10 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1531,6 +1747,9 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1551,12 +1770,24 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
@@ -1566,6 +1797,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -1589,6 +1823,12 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1624,9 +1864,25 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@3.1.1:
+    resolution: {integrity: sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1638,9 +1894,23 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -1649,6 +1919,11 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1669,6 +1944,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1686,12 +1964,18 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unpdf@0.12.2:
+    resolution: {integrity: sha512-3eyDFfayk+Sf5+inJ4OyhecR2BtRFEeZqUfGPdq2O8aBLau9MYL9lAP+GEcSAaVd2JWqde8Dnz38z0x7KRglaA==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1705,6 +1989,9 @@ packages:
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1798,6 +2085,12 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1807,6 +2100,17 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   workerd@1.20260424.1:
     resolution: {integrity: sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==}
@@ -1842,12 +2146,24 @@ packages:
       utf-8-validate:
         optional: true
 
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
@@ -2306,6 +2622,22 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/node-pre-gyp@1.0.11':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.7.0
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
@@ -2476,10 +2808,24 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xmldom/xmldom@0.8.13': {}
+
+  abbrev@1.1.1:
+    optional: true
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  adler-32@1.3.1: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -2527,11 +2873,30 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1:
+    optional: true
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@6.2.3: {}
 
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2:
+    optional: true
 
   base64-js@1.5.1: {}
 
@@ -2540,6 +2905,8 @@ snapshots:
   bignumber.js@9.3.1: {}
 
   blake3-wasm@2.1.5: {}
+
+  bluebird@3.4.7: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -2554,6 +2921,12 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
 
   browserslist@4.28.2:
     dependencies:
@@ -2579,13 +2952,42 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  canvas@2.11.2:
+    dependencies:
+      '@mapbox/node-pre-gyp': 1.0.11
+      nan: 2.27.0
+      simple-get: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
+
+  chownr@2.0.0:
+    optional: true
 
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  codepage@1.15.0: {}
+
+  color-support@1.1.3:
+    optional: true
+
+  concat-map@0.0.1:
+    optional: true
+
+  console-control-strings@1.1.0:
+    optional: true
 
   content-disposition@1.1.0: {}
 
@@ -2601,10 +3003,14 @@ snapshots:
 
   core-js-pure@3.49.0: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  crc-32@1.2.2: {}
 
   cron-schedule@6.0.0: {}
 
@@ -2620,9 +3026,23 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@4.2.1:
+    dependencies:
+      mimic-response: 2.1.0
+    optional: true
+
+  delegates@1.0.0:
+    optional: true
+
   depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dingbat-to-unicode@1.0.1: {}
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.8
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2639,6 +3059,9 @@ snapshots:
   electron-to-chromium@1.5.344: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0:
+    optional: true
 
   encodeurl@2.0.0: {}
 
@@ -2773,12 +3196,35 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  frac@1.1.2: {}
+
   fresh@2.0.0: {}
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  fs.realpath@1.0.0:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   gaxios@7.1.4:
     dependencies:
@@ -2825,6 +3271,16 @@ snapshots:
       resolve-pkg-maps: 1.0.0
     optional: true
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
+
   google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
@@ -2859,6 +3315,9 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-unicode@2.0.1:
+    optional: true
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -2873,6 +3332,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -2884,13 +3351,26 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  immediate@3.0.6: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
   inherits@2.0.4: {}
 
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
+  is-fullwidth-code-point@3.0.0:
+    optional: true
+
   is-promise@4.0.0: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2914,6 +3394,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -2926,6 +3413,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   kleur@4.1.5: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2976,6 +3467,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.8
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2983,6 +3480,24 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+    optional: true
+
+  mammoth@1.12.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.8
+      xmlbuilder: 10.1.1
 
   math-intrinsics@1.1.0: {}
 
@@ -3009,6 +3524,9 @@ snapshots:
       js-base64: 3.7.8
       mime-types: 2.1.35
 
+  mimic-response@2.1.0:
+    optional: true
+
   miniflare@4.20260424.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -3021,7 +3539,32 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
+  minipass@5.0.0:
+    optional: true
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+    optional: true
+
+  mkdirp@1.0.4:
+    optional: true
+
   ms@2.1.3: {}
+
+  nan@2.27.0:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -3031,6 +3574,11 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+    optional: true
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -3038,6 +3586,19 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.38: {}
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -3053,6 +3614,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  option@0.2.4: {}
+
+  pako@1.0.11: {}
+
   parseurl@1.3.3: {}
 
   partyserver@0.5.3(@cloudflare/workers-types@4.20260426.1):
@@ -3065,6 +3630,8 @@ snapshots:
       event-target-polyfill: 0.0.4
     optionalDependencies:
       react: 19.2.5
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -3086,6 +3653,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  process-nextick-args@2.0.1: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3106,9 +3675,31 @@ snapshots:
 
   react@19.2.5: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0:
+    optional: true
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
     optional: true
 
   rolldown@1.0.0-rc.17:
@@ -3142,6 +3733,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -3174,6 +3767,11 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0:
+    optional: true
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -3244,7 +3842,26 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7:
+    optional: true
+
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@3.1.1:
+    dependencies:
+      decompress-response: 4.2.1
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
   source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
 
   stackback@0.0.2: {}
 
@@ -3252,17 +3869,48 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    optional: true
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    optional: true
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
   supports-color@10.2.2: {}
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    optional: true
 
   tinybench@2.9.0: {}
 
@@ -3276,6 +3924,9 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
+
+  tr46@0.0.3:
+    optional: true
 
   tslib@2.8.1:
     optional: true
@@ -3296,11 +3947,20 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  underscore@1.13.8: {}
+
   undici@7.24.8: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unpdf@0.12.2:
+    optionalDependencies:
+      canvas: 2.11.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   unpipe@1.0.0: {}
 
@@ -3311,6 +3971,8 @@ snapshots:
       picocolors: 1.1.1
 
   url-template@2.0.8: {}
+
+  util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 
@@ -3355,6 +4017,15 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1:
+    optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    optional: true
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3363,6 +4034,15 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
 
   workerd@1.20260424.1:
     optionalDependencies:
@@ -3399,9 +4079,24 @@ snapshots:
 
   ws@8.18.0: {}
 
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
+
+  xmlbuilder@10.1.1: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0:
+    optional: true
 
   yargs-parser@22.0.0: {}
 


### PR DESCRIPTION
Closes #30

## Summary

Adds two tools to the gmail-mcp Worker so Claude can pull attachment content directly out of Gmail messages instead of asking the user to download + re-upload.

- `gmail_list_attachments(message_id)` walks the message MIME tree and returns one entry per attachment part: `{filename, mime_type, size_bytes, attachment_id}`.
- `gmail_get_attachment(message_id, attachment_id, force?)` fetches the bytes and routes by MIME type:
  - `image/{png,jpeg,webp,gif}` → MCP image content block
  - `text/*`, `application/json`, common code/CSV/XML/YAML → UTF-8 text
  - `application/pdf` → server-side text extraction via `unpdf`
  - `.docx` → markdown via `mammoth` (HTML output passed through a small HTML→markdown pass)
  - `.xlsx` → CSV (single sheet) or `{sheetName: csv}` JSON (multi-sheet) via SheetJS
  - Unsupported MIME → structured error naming the type + filename

A configurable size guard (`GMAIL_ATTACHMENT_BYTE_CAP`, default 10 MiB, wired as a wrangler `vars` entry) refuses oversize fetches unless `force: true`. All parsing is wrapped in try/catch so Workers CPU/memory failures surface a clear error rather than time out silently.

## Library choices

- PDF: `unpdf` — pure-JS bundled pdf.js for serverless/Workers, text extraction only (no page rasterization, per the issue scope).
- docx: `mammoth` — fed an `ArrayBuffer` (BrowserInput shape) to avoid a Node `Buffer` dependency. Mammoth doesn't ship a direct markdown converter, so the output goes through a small in-repo HTML→markdown pass (headings, lists, bold/italic, links, paragraphs).
- xlsx: SheetJS (`xlsx`) — works in pure JS on Workers.

If any of these turn out to be Workers-incompatible at runtime (mammoth in particular is the riskiest — it transitively pulls some Node-leaning deps), the dispatcher catches the thrown error and returns a structured error instead of failing at deploy.

## Tests

`apps/gmail-mcp/src/tools/attachments.test.ts` — 12 tests, all mocked (no network, no real Gmail):

- `collectAttachments` walks a nested multipart tree and returns every part with a `body.attachmentId`.
- `base64UrlToBytes` / `bytesToStandardBase64` round-trip ASCII and handle `-`/`_` correctly.
- `routeByMime` returns an image content block for `image/png`, decoded text for `text/plain` and `application/json`, and a structured error for unsupported MIME types.
- `gmail_get_attachment` refuses an oversize attachment when `force` is unset (and confirms `attachments.get` was NOT called); proceeds when `force: true`.
- `gmail_get_attachment` returns an error when the `attachment_id` is not found on the message.
- `gmail_list_attachments` returns the expected metadata shape end-to-end.

`pnpm -r type-check` and `pnpm -r test` pass.

## Smoke test — NOT YET RUN

The end-to-end live-Gmail smoke test from the issue acceptance criteria has not been run in this autonomous session and is pending human verification before merge. From a fresh Claude chat against the deployed Worker:

- [ ] Image attachment: retrieve a PNG/JPEG and confirm Claude sees it natively. Record the message_id.
- [ ] PDF attachment: retrieve a small PDF and confirm `unpdf` returns readable text. Record the message_id.
- [ ] `.docx` or `.xlsx`: retrieve one of each (if possible) and confirm the converted content is usable. Record the message_ids. If mammoth fails at runtime on Workers, the docx path will surface a clear error — that's the documented fallback.
- [ ] Size guard: confirm an oversize attachment is refused, and that `force: true` lets it through.
- [ ] Unsupported MIME: confirm the structured error mentions the MIME type and filename.

## Notes

- New env var `GMAIL_ATTACHMENT_BYTE_CAP` lives in `wrangler.jsonc` `vars` with the default `"10485760"`. Optional in code — falls back to 10 MiB if missing or unparseable.
- `unpdf` pulls in `canvas` as an optional dep for rasterization (we don't use it); pnpm flagged the build script as ignored, which is fine on Workers.
- `agents` 0.11.6 has a peer-dep warning expecting `zod@^4` while this repo is on `zod@^3` — pre-existing in the repo, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)