### PR TITLE
[trip-mcp] Use optional per-app secret for KV-scoped deploy token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,14 @@ name: deploy
 # Required repo secrets:
 #   CLOUDFLARE_API_TOKEN  — token with "Edit Cloudflare Workers" template
 #   CLOUDFLARE_ACCOUNT_ID — Cloudflare account ID
+#
+# Optional per-app override secrets:
+#   CLOUDFLARE_API_TOKEN_TRIP — trip-mcp is the only app with a KV namespace
+#     binding (CACHE), which the shared token above isn't scoped for
+#     (needs Workers KV Storage:Edit in addition to Workers Scripts:Edit).
+#     If this secret is set, trip-mcp's deploy step uses it instead of the
+#     shared token, so the shared token doesn't need broadening for every
+#     other app. See #28.
 
 on:
   push:
@@ -158,7 +166,11 @@ jobs:
       - if: steps.gate.outputs.should == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # trip-mcp binds a KV namespace, which needs Workers KV
+          # Storage:Edit — a scope the shared token intentionally doesn't
+          # carry. Use the optional per-app secret when it's set instead of
+          # widening the shared token for every other app (#28).
+          apiToken: ${{ matrix.app == 'trip-mcp' && (secrets.CLOUDFLARE_API_TOKEN_TRIP || secrets.CLOUDFLARE_API_TOKEN) || secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/${{ matrix.app }}
           command: deploy


### PR DESCRIPTION
## Summary

- Restructures `.github/workflows/deploy.yml` so trip-mcp's deploy step can use a separate, optional per-app Cloudflare API token instead of the shared `secrets.CLOUDFLARE_API_TOKEN` used by every other app in the deploy matrix.
- No change to the shared token's required scope, and no change to the oura-mcp / gmail-mcp / github-mcp deploy path.

## Why

trip-mcp is the only app in the monorepo with a KV namespace binding (`CACHE` in `apps/trip-mcp/wrangler.jsonc`). Cloudflare requires `Workers KV Storage:Edit` for KV-bound deploys, but the shared `CLOUDFLARE_API_TOKEN` repo secret is intentionally scoped to just `Workers Scripts:Edit` + `Account Settings:Read` — the minimum needed by the other three apps. Deploying trip-mcp with that token fails with Cloudflare API error 10023 ("kv bindings require kv write perms").

Widening the shared token would give every app's deploy step broader permissions than it needs. Instead, the trip-mcp step in the matrix now resolves its token as:

```
apiToken: ${{ matrix.app == 'trip-mcp' && (secrets.CLOUDFLARE_API_TOKEN_TRIP || secrets.CLOUDFLARE_API_TOKEN) || secrets.CLOUDFLARE_API_TOKEN }}
```

- For any app other than trip-mcp: unchanged, uses `secrets.CLOUDFLARE_API_TOKEN`.
- For trip-mcp: uses `secrets.CLOUDFLARE_API_TOKEN_TRIP` if that secret is set, otherwise falls back to the shared token (current failing behavior, so nothing regresses if the new secret doesn't exist yet).

## Action required before trip-mcp deploys succeed

**This PR is a workflow restructure only — it does not fix the underlying permissions gap.** To actually unblock trip-mcp's CI deploy, the repo owner must:

1. Create a new Cloudflare API token scoped with **both** `Workers Scripts:Edit` **and** `Workers KV Storage:Edit` for the relevant Cloudflare account.
2. Add it as a GitHub Actions repo secret named exactly **`CLOUDFLARE_API_TOKEN_TRIP`**.

Until that secret exists, trip-mcp's deploy step will keep falling back to the existing shared token and will continue failing with the same KV-permissions error described in #28 — this PR alone does not close that gap.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — YAML parses cleanly.
- [x] Traced the GitHub Actions expression by hand for all three cases (non-trip app, trip-mcp with `CLOUDFLARE_API_TOKEN_TRIP` unset, trip-mcp with it set) — resolves to the expected token in each case, with no change to non-trip apps.
- [ ] Once `CLOUDFLARE_API_TOKEN_TRIP` is added as a repo secret, trigger a `workflow_dispatch` run with `app: trip-mcp` (or push a trip-mcp change to `main`) and confirm the deploy step succeeds.

Refs #28