### PR TITLE
[gmail-mcp] Add attachment retrieval tools (list_attachments, get_attachment)

### DIFF
--- a/apps/gmail-mcp/src/tools/attachments.test.ts
+++ b/apps/gmail-mcp/src/tools/attachments.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { gmail_v1 } from "googleapis";
+import { registerAttachmentTools } from "./attachments.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: true;
+}>;
+
+/**
+ * Minimal fake of the `McpServer` surface `registerAttachmentTools` uses:
+ * capture each registered tool's handler by name so tests can invoke it
+ * directly, bypassing the MCP transport entirely.
+ */
+function fakeServer() {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, ..._rest: unknown[]) => {
+      const cb = _rest[_rest.length - 1] as ToolHandler;
+      handlers.set(name, cb);
+    },
+  } as unknown as McpServer;
+  return { server, handlers };
+}
+
+function fakeGmail(overrides: Partial<gmail_v1.Gmail["users"]["messages"]> = {}) {
+  return {
+    users: {
+      messages: {
+        get: vi.fn(),
+        attachments: { get: vi.fn() },
+        ...overrides,
+      },
+    },
+  } as unknown as gmail_v1.Gmail;
+}
+
+describe("list_attachments", () => {
+  it("returns metadata for top-level attachment parts", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        payload: {
+          mimeType: "multipart/mixed",
+          parts: [
+            { mimeType: "text/plain", body: { data: "aGk" } },
+            {
+              mimeType: "application/pdf",
+              filename: "report.pdf",
+              body: { attachmentId: "att-1", size: 12345 },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await handlers.get("list_attachments")!({ messageId: "msg-1" });
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.messageId).toBe("msg-1");
+    expect(parsed.attachments).toEqual([
+      {
+        attachmentId: "att-1",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        size: 12345,
+      },
+    ]);
+    expect(gmail.users.messages.get).toHaveBeenCalledWith({
+      userId: "me",
+      id: "msg-1",
+      format: "full",
+    });
+  });
+
+  it("recurses into nested multipart/alternative parts to find attachments", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        payload: {
+          mimeType: "multipart/mixed",
+          parts: [
+            {
+              mimeType: "multipart/alternative",
+              parts: [
+                { mimeType: "text/plain", body: { data: "aGk" } },
+                { mimeType: "text/html", body: { data: "aGk" } },
+              ],
+            },
+            {
+              mimeType: "image/png",
+              filename: "screenshot.png",
+              body: { attachmentId: "att-2", size: 999 },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await handlers.get("list_attachments")!({ messageId: "msg-2" });
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0]).toMatchObject({
+      attachmentId: "att-2",
+      filename: "screenshot.png",
+    });
+  });
+
+  it("returns an empty array when the message has no attachments", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { payload: { mimeType: "text/plain", body: { data: "aGk" } } },
+    });
+
+    const result = await handlers.get("list_attachments")!({ messageId: "msg-3" });
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.attachments).toEqual([]);
+  });
+
+  it("returns errorContent on Gmail API failure", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("401 Invalid Credentials"),
+    );
+
+    const result = await handlers.get("list_attachments")!({ messageId: "msg-4" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Gmail auth expired");
+  });
+});
+
+describe("get_attachment", () => {
+  it("fetches attachment bytes and returns base64url data verbatim with size", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    const base64url = "SGVsbG8t_1234"; // contains '-' and '_' — must not be re-encoded
+    (
+      gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      data: { size: 42, data: base64url },
+    });
+
+    const result = await handlers.get("get_attachment")!({
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toEqual({
+      messageId: "msg-1",
+      attachmentId: "att-1",
+      size: 42,
+      data: base64url,
+    });
+    expect(gmail.users.messages.attachments.get).toHaveBeenCalledWith({
+      userId: "me",
+      messageId: "msg-1",
+      id: "att-1",
+    });
+  });
+
+  it("returns errorContent on Gmail API failure", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    (
+      gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("429 Rate Limit Exceeded"));
+
+    const result = await handlers.get("get_attachment")!({
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Gmail rate limited");
+  });
+});

--- a/apps/gmail-mcp/src/tools/attachments.ts
+++ b/apps/gmail-mcp/src/tools/attachments.ts
@@ -1,0 +1,80 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { gmail_v1 } from "googleapis";
+import { z } from "zod";
+import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { collectAttachments, type MimePart } from "./email.js";
+
+/**
+ * Gmail attachment-retrieval tools (issue #30).
+ *
+ * `list_attachments` walks the message's MIME tree (recursively, via
+ * `collectAttachments` shared with `read_email`) and returns metadata only
+ * — filename, MIME type, size, and the `attachmentId` needed to fetch
+ * bytes. `get_attachment` fetches the raw attachment via
+ * `users.messages.attachments.get` and returns it as base64url data,
+ * unchanged from what the Gmail API returns (Gmail's attachment `data` is
+ * base64url — `-`/`_` instead of `+`/`/` — and is passed through verbatim
+ * rather than re-encoded).
+ *
+ * MIME-aware routing (image content blocks, PDF/docx/xlsx text
+ * extraction), the size cap + `force` override, and end-to-end smoke
+ * testing against real attachments are deferred — see the tracking issue
+ * referenced in the PR that introduced this file.
+ */
+export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail): void {
+  server.tool(
+    "list_attachments",
+    "List attachment metadata for a Gmail message by message ID: filename, MIME type, " +
+      "size in bytes, and attachmentId. Pass the attachmentId to get_attachment to fetch content.",
+    {
+      messageId: z.string().describe("Gmail message ID"),
+    },
+    async ({ messageId }) => {
+      try {
+        const res = await gmail.users.messages.get({
+          userId: "me",
+          id: messageId,
+          format: "full",
+        });
+        const attachments = res.data.payload
+          ? collectAttachments(res.data.payload as MimePart)
+          : [];
+        const result = JSON.stringify({ messageId, attachments });
+        return textContent(result);
+      } catch (e) {
+        return errorContent(formatGmailError(e));
+      }
+    },
+  );
+
+  server.tool(
+    "get_attachment",
+    "Fetch a Gmail attachment's raw content by message ID and attachmentId (from " +
+      "list_attachments). Returns the attachment's base64url-encoded data, per the Gmail API, " +
+      "and its size in bytes.",
+    {
+      messageId: z.string().describe("Gmail message ID"),
+      attachmentId: z
+        .string()
+        .describe("Attachment ID, from a prior list_attachments call"),
+    },
+    async ({ messageId, attachmentId }) => {
+      try {
+        const res = await gmail.users.messages.attachments.get({
+          userId: "me",
+          messageId,
+          id: attachmentId,
+        });
+        const result = JSON.stringify({
+          messageId,
+          attachmentId,
+          size: res.data.size ?? 0,
+          data: res.data.data ?? "",
+        });
+        return textContent(result);
+      } catch (e) {
+        return errorContent(formatGmailError(e));
+      }
+    },
+  );
+}

--- a/apps/gmail-mcp/src/tools/email.ts
+++ b/apps/gmail-mcp/src/tools/email.ts
@@ -15,12 +15,47 @@ import { textContent, errorContent, formatGmailError } from "./utils.js";
  * migration sub-task.
  */
 
-type MimePart = {
+export type MimePart = {
   mimeType?: string | null;
-  body?: { data?: string | null } | null;
+  body?: { data?: string | null; attachmentId?: string | null; size?: number | null } | null;
   parts?: MimePart[] | null;
   filename?: string | null;
 };
+
+export type AttachmentMeta = {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+};
+
+/**
+ * Walk a Gmail MIME tree and collect metadata for every part that carries
+ * an attachment (i.e. has both a `filename` and a `body.attachmentId`).
+ * Recurses through nested multipart containers (mixed/alternative/related
+ * etc.) so attachments nested below a multipart/alternative body — a
+ * common real-world shape — aren't missed. Shares the depth guard used by
+ * `extractBody` to avoid pathological/cyclic trees.
+ */
+export function collectAttachments(part: MimePart, depth = 0): AttachmentMeta[] {
+  if (depth > 8) return [];
+
+  const results: AttachmentMeta[] = [];
+  if (part.filename && part.body?.attachmentId) {
+    results.push({
+      attachmentId: part.body.attachmentId,
+      filename: part.filename,
+      mimeType: part.mimeType ?? "application/octet-stream",
+      size: part.body.size ?? 0,
+    });
+  }
+
+  for (const child of part.parts ?? []) {
+    results.push(...collectAttachments(child, depth + 1));
+  }
+
+  return results;
+}
 
 /**
  * Walk a Gmail MIME tree and pull out a plain-text representation of the

--- a/apps/gmail-mcp/src/tools/index.ts
+++ b/apps/gmail-mcp/src/tools/index.ts
@@ -6,12 +6,13 @@ import { registerComposeTools } from "./compose.js";
 import { registerModifyTools } from "./modify.js";
 import { registerDeleteTools } from "./delete.js";
 import { registerFilterTools } from "./filters.js";
+import { registerAttachmentTools } from "./attachments.js";
 
 /**
  * Wire every Gmail tool onto an `McpServer`. Tool registration is split
  * into modules by Gmail API surface (labels, email, compose, modify,
- * delete, filters); each `register*Tools` call adds its tools onto the
- * server.
+ * delete, filters, attachments); each `register*Tools` call adds its
+ * tools onto the server.
  *
  * The `gmail` client is built once per request in `server.ts` and passed
  * in here so handlers can be plain closures rather than re-instantiating
@@ -24,4 +25,5 @@ export function registerAllTools(server: McpServer, gmail: gmail_v1.Gmail): void
   registerModifyTools(server, gmail);
   registerDeleteTools(server, gmail);
   registerFilterTools(server, gmail);
+  registerAttachmentTools(server, gmail);
 }


### PR DESCRIPTION
Refs #30.

## Summary

Adds two new Gmail MCP tools so a chat turn can discover and fetch
attachment bytes instead of hitting a dead end:

- **`list_attachments(messageId)`** — walks the message's MIME tree and
  returns `{ attachmentId, filename, mimeType, size }` for every
  attachment. Uses a new `collectAttachments()` helper in `email.ts` that
  recurses through nested multipart containers (`multipart/alternative`,
  `multipart/related`, nested `multipart/mixed`), unlike `read_email`'s
  existing attachment listing, which only scans top-level parts.
- **`get_attachment(messageId, attachmentId)`** — calls
  `gmail.users.messages.attachments.get` and returns the attachment's
  `data` (Gmail's native base64url encoding, passed through verbatim —
  not re-encoded to standard base64) and `size` in bytes.

Both follow the existing tool-module pattern (zod schema, `try/catch` →
`errorContent(formatGmailError(e))`, `textContent(JSON.stringify(...))`
on success) and are registered in `registerAllTools`.

## Scope note

#30's acceptance criteria also call for MIME-aware content routing
(image content blocks, PDF/docx/xlsx text extraction/conversion), a
configurable size cap with a `force` override, and an end-to-end smoke
test against real attachments. Those are a substantially larger effort
(new parsing dependencies, real Workers CPU/memory constraints) and are
intentionally out of scope for this PR — filed as a follow-up:
tusensii/mcp-stack#51. This PR ships the retrieval plumbing (metadata +
raw fetch) that follow-up depends on, so #30 stays open until #51 lands.

## Test plan

- [x] `pnpm --filter gmail-mcp test` — 6 new tests covering metadata
      extraction, MIME-tree recursion, no-attachments, raw fetch with
      base64url data preserved verbatim, and Gmail error formatting for
      both tools.
- [x] `pnpm -r type-check` and `pnpm -r test` — all workspaces pass.
- [x] `pnpm wrangler deploy --dry-run` from `apps/gmail-mcp` — builds
      cleanly.
- [ ] End-to-end smoke test against real attachments (image/PDF/docx or
      xlsx) — deferred to #51, which adds the MIME-routed consumption
      path these tools are tested against in a live chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)