### PR TITLE
[github-mcp] Auto-create missing labels in issue creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,11 @@ and the desired behavior; the fix is decided in the PR.
   documented behavior"; everything else is `enhancement`.
 - `app:<app-name>` — e.g. `app:oura-mcp`. Useful once cross-app issues land.
 
-Labels must exist on the repo before `github_create_issue` can apply them.
-Create them once via the GitHub UI; after that the MCP can use them freely.
+Labels don't need to pre-exist: `github_create_issue`, `github_add_labels`,
+and `github_set_labels` auto-create any label name that isn't already on the
+repo (color chosen by a naming heuristic — `app:*` purple, other
+`prefix:*` labels blue, unprefixed grey) and report the created names back
+in `auto_created_labels`.
 
 ### Assignees
 

--- a/apps/github-mcp/src/tools/issues.ts
+++ b/apps/github-mcp/src/tools/issues.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
 import { resolveRepo, handleError, textContent, errorContent } from "./utils.js";
+import { ensureLabelsExist } from "./label-sync.js";
 
 const repoArg = z
   .string()
@@ -16,13 +17,19 @@ export function registerIssueTools(
   allowedRepos: Set<string> | undefined,
 ): void {
   const createIssueLabelsDesc =
-    defaultLabels.length > 0
-      ? `Label names to apply. Merged with deployment defaults [${defaultLabels.join(", ")}] (deduped).`
-      : "Label names to apply.";
+    (defaultLabels.length > 0
+      ? `Label names to apply. Merged with deployment defaults [${defaultLabels.join(", ")}] (deduped). `
+      : "Label names to apply. ") +
+    "Labels that don't yet exist on the repo are created automatically " +
+    "(color chosen by a naming heuristic: app:* → purple, other prefix:* labels → blue, " +
+    "everything else → grey); any names created this way are listed in the " +
+    "response under 'auto_created_labels'.";
 
   server.tool(
     "github_create_issue",
-    "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional.",
+    "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional. " +
+      "Unknown labels are auto-created rather than silently dropped — see the 'labels' " +
+      "parameter description.",
     {
       repo: repoArg,
       title: z.string().min(1).describe("Issue title."),
@@ -36,6 +43,10 @@ export function registerIssueTools(
       if ("error" in r) return r.error;
       const mergedLabels = Array.from(new Set([...defaultLabels, ...(labels ?? [])]));
       try {
+        const autoCreatedLabels =
+          mergedLabels.length > 0
+            ? await ensureLabelsExist(client, r.owner, r.repo, mergedLabels)
+            : [];
         const issue = await client.post<unknown>(`/repos/${r.owner}/${r.repo}/issues`, {
           title,
           ...(body !== undefined ? { body } : {}),
@@ -43,7 +54,11 @@ export function registerIssueTools(
           ...(assignees ? { assignees } : {}),
           ...(milestone !== undefined ? { milestone } : {}),
         });
-        return textContent(issue);
+        return textContent(
+          autoCreatedLabels.length > 0
+            ? { ...(issue as Record<string, unknown>), auto_created_labels: autoCreatedLabels }
+            : issue,
+        );
       } catch (e) {
         return handleError(e);
       }

--- a/apps/github-mcp/src/tools/label-sync.test.ts
+++ b/apps/github-mcp/src/tools/label-sync.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { ensureLabelsExist, labelColorFor, type LabelLookupClient } from "./label-sync.js";
+import { GitHubApiError } from "../github/client.js";
+
+function stubClient(existingLabels: string[]): LabelLookupClient & {
+  post: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn().mockResolvedValue(existingLabels.map((name) => ({ name }))),
+    post: vi.fn().mockResolvedValue({}),
+  };
+}
+
+describe("labelColorFor", () => {
+  it("uses purple for app:* labels", () => {
+    expect(labelColorFor("app:github-mcp")).toBe("5319e7");
+  });
+
+  it("is case-insensitive on the prefix", () => {
+    expect(labelColorFor("APP:github-mcp")).toBe("5319e7");
+  });
+
+  it("uses blue for area:* labels", () => {
+    expect(labelColorFor("area:docs")).toBe("1d76db");
+  });
+
+  it("uses blue for any other prefix:* label", () => {
+    expect(labelColorFor("priority:high")).toBe("1d76db");
+    expect(labelColorFor("type:bug")).toBe("1d76db");
+  });
+
+  it("uses grey for unprefixed labels", () => {
+    expect(labelColorFor("bug")).toBe("ededed");
+    expect(labelColorFor("enhancement")).toBe("ededed");
+    expect(labelColorFor("claude-task")).toBe("ededed");
+  });
+});
+
+describe("ensureLabelsExist", () => {
+  it("returns empty and makes no calls when names is empty", async () => {
+    const client = stubClient(["bug"]);
+    const created = await ensureLabelsExist(client, "acme", "widgets", []);
+    expect(created).toEqual([]);
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it("creates nothing when all labels already exist", async () => {
+    const client = stubClient(["bug", "app:github-mcp"]);
+    const created = await ensureLabelsExist(client, "acme", "widgets", ["bug", "app:github-mcp"]);
+    expect(created).toEqual([]);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it("matches existing labels case-insensitively", async () => {
+    const client = stubClient(["Bug"]);
+    const created = await ensureLabelsExist(client, "acme", "widgets", ["bug"]);
+    expect(created).toEqual([]);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it("creates missing labels with the heuristic color and a standard description", async () => {
+    const client = stubClient(["bug"]);
+    const created = await ensureLabelsExist(client, "acme", "widgets", [
+      "bug",
+      "app:gmail-mcp-worker",
+    ]);
+    expect(created).toEqual(["app:gmail-mcp-worker"]);
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith("/repos/acme/widgets/labels", {
+      name: "app:gmail-mcp-worker",
+      color: "5319e7",
+      description: "Auto-created by github-mcp.",
+    });
+  });
+
+  it("creates multiple missing labels and reports all of them", async () => {
+    const client = stubClient([]);
+    const created = await ensureLabelsExist(client, "acme", "widgets", [
+      "app:oura-mcp",
+      "area:docs",
+      "claude-task",
+    ]);
+    expect(created.sort()).toEqual(["app:oura-mcp", "area:docs", "claude-task"].sort());
+    expect(client.post).toHaveBeenCalledTimes(3);
+  });
+
+  it("treats a 422 'already exists' race on create as success, not an error", async () => {
+    const client = stubClient([]);
+    client.post.mockRejectedValueOnce(new GitHubApiError(422, "already_exists"));
+    const created = await ensureLabelsExist(client, "acme", "widgets", ["bug"]);
+    expect(created).toEqual([]);
+  });
+
+  it("rethrows non-422 errors from label creation", async () => {
+    const client = stubClient([]);
+    client.post.mockRejectedValueOnce(new GitHubApiError(403, "Forbidden"));
+    await expect(ensureLabelsExist(client, "acme", "widgets", ["bug"])).rejects.toThrow(
+      "Forbidden",
+    );
+  });
+});

--- a/apps/github-mcp/src/tools/label-sync.ts
+++ b/apps/github-mcp/src/tools/label-sync.ts
@@ -1,0 +1,70 @@
+import { GitHubApiError } from "../github/client.js";
+
+/**
+ * Minimal shape of `GitHubClient` this module depends on — kept narrow so
+ * tests can pass a stub instead of a real client.
+ */
+export interface LabelLookupClient {
+  get<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T>;
+  post<T>(path: string, body: unknown): Promise<T>;
+}
+
+interface RepoLabel {
+  name: string;
+}
+
+/**
+ * Pick a color for an auto-created label based on naming convention.
+ * `app:*` labels get the established purple used across the monorepo's
+ * queue-scannability convention (see CLAUDE.md); any other `prefix:*` label
+ * (e.g. `area:*`, `priority:*`) gets a neutral blue; unprefixed labels get
+ * neutral grey.
+ */
+export function labelColorFor(name: string): string {
+  if (/^app:/i.test(name)) return "5319e7";
+  if (/^[^:\s]+:/.test(name)) return "1d76db";
+  return "ededed";
+}
+
+/**
+ * Ensure every label in `names` exists on the repo, creating any that are
+ * missing using a color heuristic (see `labelColorFor`). Returns the list
+ * of label names that were actually created (empty if all already existed).
+ *
+ * Only the first page (100) of repo labels is consulted — repos with more
+ * distinct labels than that are not expected in this workflow. A label
+ * creation that races another caller and 422s as "already exists" is
+ * treated as success, not an error.
+ */
+export async function ensureLabelsExist(
+  client: LabelLookupClient,
+  owner: string,
+  repo: string,
+  names: string[],
+): Promise<string[]> {
+  if (names.length === 0) return [];
+
+  const existing = await client.get<RepoLabel[]>(`/repos/${owner}/${repo}/labels`, {
+    per_page: 100,
+  });
+  const existingNames = new Set(existing.map((l) => l.name.toLowerCase()));
+  const missing = names.filter((n) => !existingNames.has(n.toLowerCase()));
+
+  const created: string[] = [];
+  for (const name of missing) {
+    try {
+      await client.post(`/repos/${owner}/${repo}/labels`, {
+        name,
+        color: labelColorFor(name),
+        description: "Auto-created by github-mcp.",
+      });
+      created.push(name);
+    } catch (e) {
+      // A concurrent caller may have created the same label first (422
+      // "already_exists"); that's fine, the label exists either way. Any
+      // other failure (permissions, rate limit, etc.) should surface.
+      if (!(e instanceof GitHubApiError && e.statusCode === 422)) throw e;
+    }
+  }
+  return created;
+}

--- a/apps/github-mcp/src/tools/labels.ts
+++ b/apps/github-mcp/src/tools/labels.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
 import { resolveRepo, handleError, textContent } from "./utils.js";
+import { ensureLabelsExist } from "./label-sync.js";
 
 const repoArg = z
   .string()
@@ -25,7 +26,10 @@ export function registerLabelTools(
 ): void {
   server.tool(
     "github_add_labels",
-    "Add labels to an issue (additive; existing labels kept).",
+    "Add labels to an issue (additive; existing labels kept). Labels that don't yet exist " +
+      "on the repo are created automatically (color chosen by a naming heuristic: app:* → " +
+      "purple, other prefix:* labels → blue, unprefixed → grey); any names created this way " +
+      "are listed in the response under 'auto_created_labels'.",
     {
       repo: repoArg,
       issue_number: z.number().int().min(1),
@@ -35,11 +39,16 @@ export function registerLabelTools(
       const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
+        const autoCreatedLabels = await ensureLabelsExist(client, r.owner, r.repo, labels);
         const result = await client.post<unknown>(
           `/repos/${r.owner}/${r.repo}/issues/${issue_number}/labels`,
           { labels },
         );
-        return textContent(result);
+        return textContent(
+          autoCreatedLabels.length > 0
+            ? { labels: result, auto_created_labels: autoCreatedLabels }
+            : result,
+        );
       } catch (e) {
         return handleError(e);
       }
@@ -48,7 +57,10 @@ export function registerLabelTools(
 
   server.tool(
     "github_set_labels",
-    "Replace all labels on an issue with the provided set. Pass empty array to clear.",
+    "Replace all labels on an issue with the provided set. Pass empty array to clear. Labels " +
+      "that don't yet exist on the repo are created automatically (color chosen by a naming " +
+      "heuristic: app:* → purple, other prefix:* labels → blue, unprefixed → grey); any names created " +
+      "this way are listed in the response under 'auto_created_labels'.",
     {
       repo: repoArg,
       issue_number: z.number().int().min(1),
@@ -58,11 +70,16 @@ export function registerLabelTools(
       const r = resolveRepo(repo, defaultRepo, allowedRepos);
       if ("error" in r) return r.error;
       try {
+        const autoCreatedLabels = await ensureLabelsExist(client, r.owner, r.repo, labels);
         const result = await client.put<unknown>(
           `/repos/${r.owner}/${r.repo}/issues/${issue_number}/labels`,
           { labels },
         );
-        return textContent(result);
+        return textContent(
+          autoCreatedLabels.length > 0
+            ? { labels: result, auto_created_labels: autoCreatedLabels }
+            : result,
+        );
       } catch (e) {
         return handleError(e);
       }


### PR DESCRIPTION
Closes #31

## Why

`github_create_issue`, `github_add_labels`, and `github_set_labels` silently dropped any label that didn't already exist on the target repo, forcing a separate `github_create_label` call before filing an issue. In approval-gated clients that's a second, independently-deniable approval prompt — that's exactly what happened filing issue #30, where `github_create_label` for `app:gmail-mcp-worker` got "No approval received" and the issue shipped unlabeled.

## What changed

- Added `apps/github-mcp/src/tools/label-sync.ts` exporting `ensureLabelsExist()`: fetches the repo's existing labels, diffs them (case-insensitively) against the requested set, and creates whatever's missing in a loop — no extra approval-gated tool call, since it's all inside the one `github_create_issue` / `github_add_labels` / `github_set_labels` invocation.
- Color heuristic per the issue's acceptance criteria: `app:*` → purple (`5319e7`, matching the existing convention), any other `prefix:*` label → blue (`1d76db`), unprefixed labels → grey (`ededed`). Description is set to `"Auto-created by github-mcp."`.
- A 422 "already exists" on the create-label call (e.g. a concurrent caller created it first) is treated as success, not an error; other failures (permissions, rate limit) still surface.
- Wired into `github_create_issue`, `github_add_labels`, and `github_set_labels`. When any labels were auto-created, the response includes an `auto_created_labels` array; when nothing needed creating, the response shape is unchanged (backward compatible).
- Tool descriptions updated so callers know unknown labels are auto-created rather than dropped.
- `CLAUDE.md`'s labels section updated — it previously said labels must be created via the GitHub UI before `github_create_issue` could apply them; that's no longer true.

## Scope note

`github_update_issue` also replaces the issue's label set wholesale and has the same silent-drop behavior, but it isn't named in the issue's acceptance criteria (`github_create_issue`, `github_add_labels`, `github_set_labels` only), so it's left as-is here. Happy to file a follow-up issue if that's wanted.

## Test plan

- [x] Added `apps/github-mcp/src/tools/label-sync.test.ts` (first test file in github-mcp) covering the color heuristic (app:*, other prefix:*, unprefixed) and `ensureLabelsExist` (no-op on empty input, skips existing labels case-insensitively, creates missing ones with correct color/description, creates multiple, tolerates a 422 "already exists" race, rethrows other errors).
- [x] `pnpm --filter github-mcp test` — 12 passed
- [x] `pnpm --filter github-mcp type-check` — clean
- [x] `pnpm -r type-check` and `pnpm -r test` — clean across the monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)