### PR TITLE
[infra] Add human-friendly display titles to all MCP tools

### DIFF
--- a/apps/github-mcp/src/tools/assignees.ts
+++ b/apps/github-mcp/src/tools/assignees.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { resolveRepo, handleError, textContent } from "./utils.js";
+import { resolveRepo, handleError, textContent, titledTool } from "./utils.js";
 
 const repoArg = z
   .string()
@@ -14,8 +14,10 @@ export function registerAssigneeTools(
   defaultRepo: string | undefined,
   allowedRepos: Set<string> | undefined,
 ): void {
-  server.tool(
+  titledTool(
+    server,
     "github_add_assignees",
+    "Assigning an issue…",
     "Add assignees to an issue (additive). Usernames must have access to the repo.",
     {
       repo: repoArg,
@@ -37,8 +39,10 @@ export function registerAssigneeTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_remove_assignees",
+    "Unassigning an issue…",
     "Remove specific assignees from an issue.",
     {
       repo: repoArg,

--- a/apps/github-mcp/src/tools/comments.ts
+++ b/apps/github-mcp/src/tools/comments.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { resolveRepo, handleError, textContent } from "./utils.js";
+import { resolveRepo, handleError, textContent, titledTool } from "./utils.js";
 
 const repoArg = z
   .string()
@@ -14,8 +14,10 @@ export function registerCommentTools(
   defaultRepo: string | undefined,
   allowedRepos: Set<string> | undefined,
 ): void {
-  server.tool(
+  titledTool(
+    server,
     "github_add_issue_comment",
+    "Commenting on an issue…",
     "Post a comment on an issue.",
     {
       repo: repoArg,
@@ -37,8 +39,10 @@ export function registerCommentTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_list_issue_comments",
+    "Reviewing issue comments…",
     "List comments on an issue.",
     {
       repo: repoArg,
@@ -62,8 +66,10 @@ export function registerCommentTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_update_issue_comment",
+    "Editing an issue comment…",
     "Edit an issue comment by its comment ID (not issue number).",
     {
       repo: repoArg,
@@ -85,8 +91,10 @@ export function registerCommentTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_delete_issue_comment",
+    "Deleting an issue comment…",
     "Delete an issue comment by its comment ID.",
     {
       repo: repoArg,

--- a/apps/github-mcp/src/tools/issues.ts
+++ b/apps/github-mcp/src/tools/issues.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { resolveRepo, handleError, textContent, errorContent } from "./utils.js";
+import { resolveRepo, handleError, textContent, errorContent, titledTool } from "./utils.js";
 import { ensureLabelsExist } from "./label-sync.js";
 
 const repoArg = z
@@ -25,8 +25,10 @@ export function registerIssueTools(
     "everything else → grey); any names created this way are listed in the " +
     "response under 'auto_created_labels'.";
 
-  server.tool(
+  titledTool(
+    server,
     "github_create_issue",
+    "Filing an issue…",
     "Open a new GitHub issue. Title required; body, labels, assignees, milestone optional. " +
       "Unknown labels are auto-created rather than silently dropped — see the 'labels' " +
       "parameter description.",
@@ -65,8 +67,10 @@ export function registerIssueTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_get_issue",
+    "Reviewing an issue…",
     "Fetch a single issue by number.",
     {
       repo: repoArg,
@@ -84,8 +88,10 @@ export function registerIssueTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_list_issues",
+    "Reviewing issues…",
     "List issues in a repo. Note: GitHub's API treats pull requests as issues; " +
       "results may include PRs (filter on 'pull_request' field absence to exclude). " +
       "For cross-repo search with richer filters, use github_search_issues.",
@@ -114,8 +120,10 @@ export function registerIssueTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_update_issue",
+    "Updating an issue…",
     "Edit an issue: title, body, state, labels (replaces all), assignees (replaces all), milestone. " +
       "To close as 'not planned' rather than 'completed', set state_reason='not_planned'.",
     {
@@ -151,8 +159,10 @@ export function registerIssueTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_lock_issue",
+    "Locking an issue…",
     "Lock an issue to limit further conversation. Optional reason: off-topic, too heated, resolved, spam.",
     {
       repo: repoArg,
@@ -174,8 +184,10 @@ export function registerIssueTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_unlock_issue",
+    "Unlocking an issue…",
     "Unlock a previously locked issue.",
     {
       repo: repoArg,

--- a/apps/github-mcp/src/tools/labels.ts
+++ b/apps/github-mcp/src/tools/labels.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { resolveRepo, handleError, textContent } from "./utils.js";
+import { resolveRepo, handleError, textContent, titledTool } from "./utils.js";
 import { ensureLabelsExist } from "./label-sync.js";
 
 const repoArg = z
@@ -24,8 +24,10 @@ export function registerLabelTools(
   defaultRepo: string | undefined,
   allowedRepos: Set<string> | undefined,
 ): void {
-  server.tool(
+  titledTool(
+    server,
     "github_add_labels",
+    "Adding issue labels…",
     "Add labels to an issue (additive; existing labels kept). Labels that don't yet exist " +
       "on the repo are created automatically (color chosen by a naming heuristic: app:* → " +
       "purple, other prefix:* labels → blue, unprefixed → grey); any names created this way " +
@@ -55,8 +57,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_set_labels",
+    "Replacing issue labels…",
     "Replace all labels on an issue with the provided set. Pass empty array to clear. Labels " +
       "that don't yet exist on the repo are created automatically (color chosen by a naming " +
       "heuristic: app:* → purple, other prefix:* labels → blue, unprefixed → grey); any names created " +
@@ -86,8 +90,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_remove_label",
+    "Removing an issue label…",
     "Remove a single label from an issue.",
     {
       repo: repoArg,
@@ -108,8 +114,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_create_label",
+    "Creating a repo label…",
     "Create a new label on a repo. 'color' is required by the GitHub API (6-digit hex, no leading #). Fails with a 422 error if a label with the same name already exists — use github_update_label to change an existing one.",
     {
       repo: repoArg,
@@ -131,8 +139,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_update_label",
+    "Updating a repo label…",
     "Update an existing repo label by its current name. Can rename (new_name), recolor (color), or change description. Only provided fields are sent.",
     {
       repo: repoArg,
@@ -160,8 +170,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_delete_label",
+    "Deleting a repo label…",
     "Delete a label from a repo by name. CASCADE WARNING: this also removes the label from every issue and pull request currently using it. Use with care — to merely take a label off one issue, use github_remove_label instead.",
     {
       repo: repoArg,
@@ -181,8 +193,10 @@ export function registerLabelTools(
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "github_list_repo_labels",
+    "Reviewing repo labels…",
     "List labels defined on a repo.",
     {
       repo: repoArg,

--- a/apps/github-mcp/src/tools/search.ts
+++ b/apps/github-mcp/src/tools/search.ts
@@ -1,11 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { GitHubClient } from "../github/client.js";
-import { handleError, textContent } from "./utils.js";
+import { handleError, textContent, titledTool } from "./utils.js";
 
 export function registerSearchTools(server: McpServer, client: GitHubClient): void {
-  server.tool(
+  titledTool(
+    server,
     "github_search_issues",
+    "Searching issues…",
     "Search issues and pull requests across all repos accessible to the token. " +
       "Uses GitHub's search syntax — examples: " +
       "'repo:tusensii/mcp-stack is:issue is:open label:bug', " +

--- a/apps/github-mcp/src/tools/utils.ts
+++ b/apps/github-mcp/src/tools/utils.ts
@@ -1,7 +1,7 @@
 import { GitHubApiError } from "../github/client.js";
 import { errorContent, type McpToolResponse } from "@mcp-stack/mcp-core";
 
-export { textContent, errorContent } from "@mcp-stack/mcp-core";
+export { textContent, errorContent, titledTool } from "@mcp-stack/mcp-core";
 
 const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 

--- a/apps/gmail-mcp/src/tools/attachments.test.ts
+++ b/apps/gmail-mcp/src/tools/attachments.test.ts
@@ -9,15 +9,14 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
 }>;
 
 /**
- * Minimal fake of the `McpServer` surface `registerAttachmentTools` uses:
- * capture each registered tool's handler by name so tests can invoke it
+ * Minimal fake of the `McpServer` surface `registerAttachmentTools` uses
+ * (via `titledTool`): capture each registered tool's handler by name so tests can invoke it
  * directly, bypassing the MCP transport entirely.
  */
 function fakeServer() {
   const handlers = new Map<string, ToolHandler>();
   const server = {
-    tool: (name: string, ..._rest: unknown[]) => {
-      const cb = _rest[_rest.length - 1] as ToolHandler;
+    registerTool: (name: string, _config: unknown, cb: ToolHandler) => {
       handlers.set(name, cb);
     },
   } as unknown as McpServer;

--- a/apps/gmail-mcp/src/tools/attachments.ts
+++ b/apps/gmail-mcp/src/tools/attachments.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 import { collectAttachments, type MimePart } from "./email.js";
 
 /**
@@ -22,8 +22,10 @@ import { collectAttachments, type MimePart } from "./email.js";
  * referenced in the PR that introduced this file.
  */
 export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "list_attachments",
+    "Reviewing attachments…",
     "List attachment metadata for a Gmail message by message ID: filename, MIME type, " +
       "size in bytes, and attachmentId. Pass the attachmentId to get_attachment to fetch content.",
     {
@@ -47,8 +49,10 @@ export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "get_attachment",
+    "Fetching an attachment…",
     "Fetch a Gmail attachment's raw content by message ID and attachmentId (from " +
       "list_attachments). Returns the attachment's base64url-encoded data, per the Gmail API, " +
       "and its size in bytes.",

--- a/apps/gmail-mcp/src/tools/compose.ts
+++ b/apps/gmail-mcp/src/tools/compose.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail compose tools (`send_email`, `create_draft`). Tool name strings,
@@ -63,8 +63,10 @@ export function toBase64Url(str: string): string {
 }
 
 export function registerComposeTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "send_email",
+    "Sending an email…",
     "Send an email from your Gmail account.",
     {
       to: z.string().describe("Recipient email address"),
@@ -89,8 +91,10 @@ export function registerComposeTools(server: McpServer, gmail: gmail_v1.Gmail): 
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "create_draft",
+    "Drafting an email…",
     "Create a draft email without sending it.",
     {
       to: z.string().describe("Recipient email address"),

--- a/apps/gmail-mcp/src/tools/delete.ts
+++ b/apps/gmail-mcp/src/tools/delete.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail permanent-deletion tools (`delete_email`, `batch_delete_emails`).
@@ -10,8 +10,10 @@ import { textContent, errorContent, formatGmailError } from "./utils.js";
  * implementation in `gmail-mcp-worker/src/tools/delete.ts`.
  */
 export function registerDeleteTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "delete_email",
+    "Permanently deleting an email…",
     "PERMANENT — Delete an email, bypassing trash. This cannot be undone. " +
       'Use modify_email_labels with removeLabelIds:["INBOX"] to archive instead.',
     {
@@ -28,8 +30,10 @@ export function registerDeleteTools(server: McpServer, gmail: gmail_v1.Gmail): v
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "batch_delete_emails",
+    "Permanently deleting emails…",
     "PERMANENT — Delete multiple emails, bypassing trash. This cannot be undone. " +
       'Use batch_modify_emails with removeLabelIds:["INBOX"] to archive instead.',
     {

--- a/apps/gmail-mcp/src/tools/email.ts
+++ b/apps/gmail-mcp/src/tools/email.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail email-content tools. Tool name strings, parameter shapes, and
@@ -103,8 +103,10 @@ function extractBody(part: MimePart, depth = 0): string {
 const MAX_BODY_CHARS = 2_500;
 
 export function registerEmailTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "search_emails",
+    "Searching your email…",
     'Search Gmail using Gmail search syntax (e.g. "is:unread", "from:boss@example.com", "newer_than:7d"). ' +
       "Returns message IDs, thread IDs, and snippets. Pass nextPageToken from a previous response as pageToken to fetch the next page.",
     {
@@ -139,8 +141,10 @@ export function registerEmailTools(server: McpServer, gmail: gmail_v1.Gmail): vo
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "read_email",
+    "Reading an email…",
     "Read the full content of an email by message ID. Returns headers, decoded body, and attachment filenames.",
     {
       messageId: z.string().describe("Gmail message ID"),

--- a/apps/gmail-mcp/src/tools/filters.ts
+++ b/apps/gmail-mcp/src/tools/filters.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail filter tools (`create_filter`, `list_filters`, `delete_filter`).
@@ -16,8 +16,10 @@ import { textContent, errorContent, formatGmailError } from "./utils.js";
  * lists no `required` arrays inside the nested objects.
  */
 export function registerFilterTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "create_filter",
+    "Creating an email filter…",
     "Create a Gmail filter that automatically applies actions to matching incoming emails. " +
       'For negation, use a minus prefix in the query field (e.g. query: "-from:noreply@example.com"). ' +
       "The negatedQuery field is not supported by the Gmail API.",
@@ -78,8 +80,10 @@ export function registerFilterTools(server: McpServer, gmail: gmail_v1.Gmail): v
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "list_filters",
+    "Reviewing email filters…",
     "List all active Gmail filters.",
     {},
     async () => {
@@ -93,8 +97,10 @@ export function registerFilterTools(server: McpServer, gmail: gmail_v1.Gmail): v
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "delete_filter",
+    "Deleting an email filter…",
     "Delete a Gmail filter by ID. Get filter IDs from list_filters.",
     {
       filterId: z.string().describe("Gmail filter ID to delete"),

--- a/apps/gmail-mcp/src/tools/labels.ts
+++ b/apps/gmail-mcp/src/tools/labels.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail label tools. Tool name strings, descriptions, input parameter
@@ -13,8 +13,10 @@ import { textContent, errorContent, formatGmailError } from "./utils.js";
  * the exact byte-for-byte payload the old JSON-RPC dispatcher returned.
  */
 export function registerLabelTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "list_email_labels",
+    "Reviewing email labels…",
     "List all Gmail labels (system labels like INBOX, SENT, plus any user-created labels).",
     {},
     async () => {
@@ -34,8 +36,10 @@ export function registerLabelTools(server: McpServer, gmail: gmail_v1.Gmail): vo
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "create_label",
+    "Creating an email label…",
     "Create a new Gmail label.",
     {
       name: z.string().describe("Label name"),
@@ -61,8 +65,10 @@ export function registerLabelTools(server: McpServer, gmail: gmail_v1.Gmail): vo
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "update_label",
+    "Updating an email label…",
     "Rename or change visibility of an existing Gmail label.",
     {
       labelId: z.string().describe("Gmail label ID"),
@@ -90,8 +96,10 @@ export function registerLabelTools(server: McpServer, gmail: gmail_v1.Gmail): vo
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "delete_label",
+    "Deleting an email label…",
     "Delete a Gmail label. System labels (INBOX, SENT, etc.) cannot be deleted.",
     {
       labelId: z.string().describe("Gmail label ID to delete"),
@@ -106,8 +114,10 @@ export function registerLabelTools(server: McpServer, gmail: gmail_v1.Gmail): vo
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "get_or_create_label",
+    "Finding or creating an email label…",
     "Return an existing label by exact name, or create it if it does not exist. Name match is case-sensitive.",
     {
       name: z.string().describe("Label name to find or create"),

--- a/apps/gmail-mcp/src/tools/modify.ts
+++ b/apps/gmail-mcp/src/tools/modify.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, formatGmailError, titledTool } from "./utils.js";
 
 /**
  * Gmail label-modification tools (`modify_email_labels`,
@@ -11,8 +11,10 @@ import { textContent, errorContent, formatGmailError } from "./utils.js";
  * `gmail-mcp-worker/src/tools/modify.ts`.
  */
 export function registerModifyTools(server: McpServer, gmail: gmail_v1.Gmail): void {
-  server.tool(
+  titledTool(
+    server,
     "modify_email_labels",
+    "Updating labels on an email…",
     'Add or remove labels on a single email. Archive by passing removeLabelIds: ["INBOX"]. ' +
       "Get label IDs from list_email_labels.",
     {
@@ -38,8 +40,10 @@ export function registerModifyTools(server: McpServer, gmail: gmail_v1.Gmail): v
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "batch_modify_emails",
+    "Updating labels on emails…",
     "Apply the same label change to multiple emails in a single API call (up to 1000 message IDs). " +
       'Archive pattern: removeLabelIds: ["INBOX"].',
     {

--- a/apps/gmail-mcp/src/tools/utils.ts
+++ b/apps/gmail-mcp/src/tools/utils.ts
@@ -10,7 +10,7 @@
  * and "Gmail rate limited — try again shortly".
  */
 
-export { textContent, errorContent } from "@mcp-stack/mcp-core";
+export { textContent, errorContent, titledTool } from "@mcp-stack/mcp-core";
 
 export function formatGmailError(error: unknown): string {
   if (error instanceof Error) {

--- a/apps/oura-mcp/src/tools/activity.ts
+++ b/apps/oura-mcp/src/tools/activity.ts
@@ -4,7 +4,7 @@ import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyActivity } from "../oura/endpoints.js";
 import type { DailyActivity } from "../oura/types.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 // Bulky per-sample fields stripped from DailyActivity when include_time_series
 // is false (#47): `met` is a ~700-sample per-minute array, `class_5_min` is a
@@ -28,8 +28,10 @@ export function stripActivityTimeSeries(
 }
 
 export function registerActivityTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_activity",
+    "Reviewing activity data…",
     "Returns daily activity scores (0-100), step count, active calories, total calories, " +
       "MET minutes by intensity, and time breakdowns. " +
       "All time fields (high_activity_time, sedentary_time, etc.) are in SECONDS. " +

--- a/apps/oura-mcp/src/tools/alcohol_impact.ts
+++ b/apps/oura-mcp/src/tools/alcohol_impact.ts
@@ -7,7 +7,7 @@ import {
   getEnhancedTags,
   getSleepPeriods,
 } from "../oura/endpoints.js";
-import { textContent, errorContent, todayInTz, daysAgoInTz } from "./utils.js";
+import { textContent, errorContent, todayInTz, daysAgoInTz, titledTool } from "./utils.js";
 import { defined, mean, stddev } from "../oura/stats.js";
 import type { SleepPeriod, EnhancedTag } from "../oura/types.js";
 
@@ -63,8 +63,10 @@ function computeMetricStats(alcoholVals: number[], nonAlcoholVals: number[]): Me
 }
 
 export function registerAlcoholImpactTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_alcohol_impact",
+    "Analyzing alcohol impact…",
     "Compares biometrics (HRV, deep sleep, RHR, readiness, sleep latency) between " +
       "alcohol-tagged days and non-alcohol days. Also estimates how many days HRV " +
       "takes to recover after an alcohol day. Tag is auto-discovered by name match " +

--- a/apps/oura-mcp/src/tools/anomaly_detect.ts
+++ b/apps/oura-mcp/src/tools/anomaly_detect.ts
@@ -8,7 +8,7 @@ import {
   getDailyActivity,
   getSleepPeriods,
 } from "../oura/endpoints.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 import { defined, mean, stddev, zScore } from "../oura/stats.js";
 import type { SleepPeriod } from "../oura/types.js";
 
@@ -207,8 +207,10 @@ export function detectAnomalies(
 }
 
 export function registerAnomalyDetectTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_anomaly_detect",
+    "Scanning for anomalies…",
     "Flags days where a metric deviates from its rolling baseline by more than " +
       "z_threshold standard deviations. Scans each day in date_range against the " +
       "preceding baseline_window_days for each metric. Skips metrics with fewer than " +

--- a/apps/oura-mcp/src/tools/baseline_compare.ts
+++ b/apps/oura-mcp/src/tools/baseline_compare.ts
@@ -17,7 +17,7 @@ import {
   interpretZ,
   percentileFromZ,
 } from "../oura/stats.js";
-import { textContent, errorContent, todayInTz } from "./utils.js";
+import { textContent, errorContent, todayInTz, titledTool } from "./utils.js";
 
 // #46: threshold (hours) beyond which a resolved night is flagged
 // `possibly_stale` — i.e. it ended long enough ago that a more recent
@@ -40,8 +40,10 @@ export function isPossiblyStaleNight(bedtimeEndIso: string, now: Date): boolean 
 }
 
 export function registerBaselineCompareTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_baseline_compare",
+    "Comparing against baseline…",
     "Compares a single day's metric value against the user's personal rolling baseline. " +
       "Returns z-score, percentile, delta vs baseline mean, and a categorical interpretation. " +
       "Baseline window excludes the comparison date itself. " +

--- a/apps/oura-mcp/src/tools/correlation.ts
+++ b/apps/oura-mcp/src/tools/correlation.ts
@@ -11,7 +11,7 @@ import {
 } from "../oura/metrics.js";
 import { getEnhancedTags } from "../oura/endpoints.js";
 import { pearson, interpretPearson } from "../oura/stats.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 
 const VALID_METRICS = new Set<string>(METRIC_NAMES);
 
@@ -63,8 +63,10 @@ async function fetchSeries(
 }
 
 export function registerCorrelationTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_correlation",
+    "Analyzing correlations…",
     "Pearson correlation between two daily series over a date range. " +
       "Each input may be a metric name (readiness, sleep_score, hrv, rhr, sleep_total, " +
       "deep_sleep, rem_sleep, respiratory_rate, spo2, activity_score) or a tag (prefix " +

--- a/apps/oura-mcp/src/tools/heartrate.ts
+++ b/apps/oura-mcp/src/tools/heartrate.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getHeartrate } from "../oura/endpoints.js";
-import { validateDatetimeRange, textContent, errorContent } from "./utils.js";
+import { validateDatetimeRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerHeartrateTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_heartrate",
+    "Reviewing heart rate data…",
     "Returns time-series heart rate samples as { bpm, source, timestamp } objects. " +
       "source is one of: awake, rest, sleep, session, live, workout. " +
       "Timestamps are ISO 8601. Samples are ~5-minute intervals during rest/sleep. " +

--- a/apps/oura-mcp/src/tools/illness_signals.ts
+++ b/apps/oura-mcp/src/tools/illness_signals.ts
@@ -11,7 +11,7 @@ import {
   zScore,
   percentileFromZ,
 } from "../oura/stats.js";
-import { textContent, errorContent, todayInTz } from "./utils.js";
+import { textContent, errorContent, todayInTz, titledTool } from "./utils.js";
 
 type TempStatus = "normal" | "elevated" | "febrile";
 type ExertionCeiling = "rest" | "zone_2_only" | "moderate" | "unrestricted";
@@ -124,8 +124,10 @@ function decideExertionCeiling(
 }
 
 export function registerIllnessSignalsTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_illness_signals",
+    "Checking for illness signals…",
     "Composite illness/recovery signal report for a single day. Aggregates body " +
       "temperature deviation, respiratory rate, HRV, RHR, and readiness score (each " +
       "compared to a 30-day rolling baseline that excludes the target date itself) " +

--- a/apps/oura-mcp/src/tools/intervention_analysis.ts
+++ b/apps/oura-mcp/src/tools/intervention_analysis.ts
@@ -10,7 +10,7 @@ import {
 } from "../oura/metrics.js";
 import { getEnhancedTags } from "../oura/endpoints.js";
 import { defined, mean, median, stddev } from "../oura/stats.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 
 interface PeriodStats {
   mean: number | null;
@@ -37,8 +37,10 @@ export function registerInterventionAnalysisTool(
   server: McpServer,
   client: OuraClient,
 ): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_intervention_analysis",
+    "Analyzing an intervention…",
     "Compares metric values in a window before vs after an intervention date " +
       "(e.g. dietary change, new medication, schedule shift). An exclusion window " +
       "around the intervention date is dropped to avoid washout effects. " +

--- a/apps/oura-mcp/src/tools/night_summary.ts
+++ b/apps/oura-mcp/src/tools/night_summary.ts
@@ -6,7 +6,7 @@ import { getDailySleep, getDailyReadiness, getSleepPeriods } from "../oura/endpo
 import { addDays, fetchMetricByDay, fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 import { defined, mean } from "../oura/stats.js";
 import type { SleepPeriod } from "../oura/types.js";
-import { todayInTz, textContent, errorContent } from "./utils.js";
+import { todayInTz, textContent, errorContent, titledTool } from "./utils.js";
 
 // How many days back to search for "the most recent synced night" when no
 // `date` is given. 3 days comfortably covers a normal sync-lag window.
@@ -48,8 +48,10 @@ export function mostRecentNight(periods: SleepPeriod[]): SleepPeriod | undefined
 }
 
 export function registerNightSummaryTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_night_summary",
+    "Summarizing your night…",
     "Composite tool: answers 'how did I sleep?' in a single call by combining the sleep score " +
       "and contributors (from oura_daily_sleep), stage durations/HR/HRV/latency/efficiency highlights " +
       "(from oura_sleep_detail, stripped of bulky time-series arrays), the same-morning readiness score " +

--- a/apps/oura-mcp/src/tools/period_compare.ts
+++ b/apps/oura-mcp/src/tools/period_compare.ts
@@ -8,7 +8,7 @@ import {
   type Metric,
 } from "../oura/metrics.js";
 import { defined, mean, median, stddev } from "../oura/stats.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 
 interface PeriodStats {
   mean: number | null;
@@ -32,8 +32,10 @@ function summarize(values: ReadonlyArray<number | null>): PeriodStats {
 }
 
 export function registerPeriodCompareTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_period_compare",
+    "Comparing time periods…",
     "Side-by-side comparison of two arbitrary date ranges across one or more metrics. " +
       "Returns mean/median/stddev for each period plus delta_mean (b-a), delta_pct, " +
       "and a rough `meaningfully_different` flag (|delta| > 1 stddev of period A — " +

--- a/apps/oura-mcp/src/tools/personal.ts
+++ b/apps/oura-mcp/src/tools/personal.ts
@@ -2,11 +2,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getPersonalInfo } from "../oura/endpoints.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerPersonalTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_personal_info",
+    "Reviewing profile info…",
     "Returns your Oura profile: age, weight (kg), height (m), biological sex, and email.",
     {},
     async () => {

--- a/apps/oura-mcp/src/tools/readiness.ts
+++ b/apps/oura-mcp/src/tools/readiness.ts
@@ -6,7 +6,7 @@ import { getDailyReadiness, getSleepPeriods } from "../oura/endpoints.js";
 import { addDays, fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
 import { defined, mean } from "../oura/stats.js";
 import type { DailyReadiness, SleepPeriod } from "../oura/types.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 // Rolling window (days) used to compute personal baselines for raw biometric
 // values. Matches the "recent trend" framing Oura itself uses for contributor
@@ -61,8 +61,10 @@ function rollingBaseline(
 }
 
 export function registerReadinessTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_readiness",
+    "Reviewing readiness scores…",
     "Returns daily readiness scores (0-100) and contributor breakdown. " +
       "Contributors include HRV balance, resting heart rate, sleep balance, " +
       "activity balance, body temperature, and sleep regularity. " +

--- a/apps/oura-mcp/src/tools/recovery_forecast.ts
+++ b/apps/oura-mcp/src/tools/recovery_forecast.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyReadiness } from "../oura/endpoints.js";
-import { textContent, errorContent, todayInTz } from "./utils.js";
+import { textContent, errorContent, todayInTz, titledTool } from "./utils.js";
 import { mean, stddev, linearSlope, interpretSlope } from "../oura/stats.js";
 
 /** Add N days to YYYY-MM-DD. */
@@ -18,8 +18,10 @@ function clamp(value: number, lo: number, hi: number): number {
 }
 
 export function registerRecoveryForecastTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_recovery_forecast",
+    "Forecasting recovery…",
     "Forecasts a single day's readiness score using recent trend plus regression " +
       "toward a 30-day mean. Returns predicted_readiness with a confidence band " +
       "(±1 stddev of recent values, clamped 0-100), trend label, and basis string. " +

--- a/apps/oura-mcp/src/tools/resilience.ts
+++ b/apps/oura-mcp/src/tools/resilience.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyResilience } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerResilienceTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_resilience",
+    "Reviewing resilience data…",
     "Returns daily resilience level (exceptional/strong/adequate/limited/poor) " +
       "and contributor scores for sleep recovery, daytime recovery, and stress. " +
       "Dates: \"day\" is the morning the resilience level is reported on (reflecting sleep ending that morning and the trailing recent period).",

--- a/apps/oura-mcp/src/tools/respiratory_trend.ts
+++ b/apps/oura-mcp/src/tools/respiratory_trend.ts
@@ -10,6 +10,7 @@ import {
   errorContent,
   resolveDateRange,
   validateDateRange,
+  titledTool,
 } from "./utils.js";
 
 interface RespiratoryTrendEntry {
@@ -38,8 +39,10 @@ function pickPeriodForRespiratory(periods: SleepPeriod[]): SleepPeriod | undefin
 }
 
 export function registerRespiratoryTrendTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_respiratory_trend",
+    "Reviewing respiratory trends…",
     "Derived tool: fetches detailed sleep periods and returns a clean date-indexed " +
       "respiratory-rate series. One entry per date — when Oura reports multiple sleep " +
       "periods for a night, the longest period wins (with fallback to the next-longest " +

--- a/apps/oura-mcp/src/tools/ring.ts
+++ b/apps/oura-mcp/src/tools/ring.ts
@@ -2,11 +2,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getRingConfiguration } from "../oura/endpoints.js";
-import { textContent, errorContent } from "./utils.js";
+import { textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerRingTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_ring_configuration",
+    "Checking ring configuration…",
     "Returns hardware and firmware information about your Oura ring: size, color, design, firmware version.",
     {},
     async () => {

--- a/apps/oura-mcp/src/tools/session.ts
+++ b/apps/oura-mcp/src/tools/session.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getSessions } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerSessionTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_sessions",
+    "Reviewing sessions…",
     "Returns ONLY user-initiated sessions logged manually in the Oura app " +
       "(meditation, breathing, relaxation, rest, and user-logged naps). " +
       "Does NOT include auto-detected naps from the sleep stream — for those, " +

--- a/apps/oura-mcp/src/tools/sleep.ts
+++ b/apps/oura-mcp/src/tools/sleep.ts
@@ -12,6 +12,7 @@ import {
   validateDateRange,
   textContent,
   errorContent,
+  titledTool,
 } from "./utils.js";
 import type { HrvTrendEntry, SleepPeriod } from "../oura/types.js";
 import { fetchTagsByDay, type TagEntry } from "../oura/metrics.js";
@@ -106,8 +107,10 @@ export function filterPeriodsByType(
 }
 
 export function registerSleepTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_sleep",
+    "Reviewing sleep scores…",
     "Returns daily sleep scores and contributor breakdown for a date range. " +
       "Score is 0-100. All contributor values are 0-100 on a higher-is-better scale " +
       "(e.g. high `latency` means short time to fall asleep, not long latency). " +
@@ -130,8 +133,10 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "oura_sleep_detail",
+    "Reviewing sleep details…",
     "Returns detailed per-period sleep data including stage durations (seconds), " +
       "average and lowest heart rate (bpm), average HRV (ms RMSSD), sleep latency (seconds), " +
       "efficiency (0-100), and bedtime start/end. " +
@@ -187,8 +192,10 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "oura_naps",
+    "Checking for naps…",
     "Returns only auto-detected nap periods (type === \"nap\" || type === \"late_nap\") from the " +
       "/sleep stream. This is the right tool for \"did the user nap in window X?\" — `oura_sessions` " +
       "only returns user-initiated sessions, not auto-detected naps. " +
@@ -231,8 +238,10 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "oura_sleep_time_recommendation",
+    "Checking bedtime recommendations…",
     "Returns Oura's recommended sleep time window and status for each day. " +
       "Includes optimal_bedtime offsets (minutes from midnight) and recommendation label. " +
       "Dates: \"day\" is the date the recommendation applies to (the evening of that calendar day).",
@@ -254,8 +263,10 @@ export function registerSleepTools(server: McpServer, client: OuraClient): void 
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "oura_hrv_trend",
+    "Reviewing HRV trends…",
     "Derived tool: fetches detailed sleep periods and returns a clean date-indexed HRV series " +
       "with exactly one row per date (longest sleep period per day; falls back to next-longest if the longest has null HRV). " +
       "Fields per entry: date, average_hrv (ms RMSSD), lowest_hrv (ms RMSSD), " +

--- a/apps/oura-mcp/src/tools/spo2.ts
+++ b/apps/oura-mcp/src/tools/spo2.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailySpo2 } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerSpo2Tools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_spo2",
+    "Reviewing blood oxygen data…",
     "Returns average blood oxygen saturation (SpO2) percentage per night. " +
       "spo2_percentage.average is a percentage value (e.g. 97.3). " +
       "null means insufficient data for that night. " +

--- a/apps/oura-mcp/src/tools/stress.ts
+++ b/apps/oura-mcp/src/tools/stress.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getDailyStress } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerStressTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_daily_stress",
+    "Reviewing stress data…",
     "Returns daily stress metrics: stress_high (seconds in high-stress state), " +
       "recovery_high (seconds in high-recovery state), and day_summary label " +
       "(restored/normal/stressful/unknown). Both time fields are in SECONDS. " +

--- a/apps/oura-mcp/src/tools/summary.ts
+++ b/apps/oura-mcp/src/tools/summary.ts
@@ -6,11 +6,13 @@ import {
   getDailyReadiness,
   getDailyActivity,
 } from "../oura/endpoints.js";
-import { todayInTz, daysAgoInTz, textContent, errorContent } from "./utils.js";
+import { todayInTz, daysAgoInTz, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerSummaryTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_summary_today",
+    "Summarizing your day…",
     "Convenience tool: fetches today's and yesterday's sleep score, readiness score, " +
       "and activity score in parallel. Returns a compact merged object keyed by date. " +
       "Use this as the first tool when the user asks 'how am I doing?' or wants a daily overview. " +

--- a/apps/oura-mcp/src/tools/symptom_onset_detect.ts
+++ b/apps/oura-mcp/src/tools/symptom_onset_detect.ts
@@ -11,6 +11,7 @@ import {
   todayInTz,
   daysAgoInTz,
   validateDateRange,
+  titledTool,
 } from "./utils.js";
 
 const BASELINE_WINDOW = 28;
@@ -50,8 +51,10 @@ function zForDay(
 }
 
 export function registerSymptomOnsetDetectTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_symptom_onset_detect",
+    "Pinpointing symptom onset…",
     "Scans a date window for clusters of biometric anomalies indicative of illness " +
       "onset. For each day, computes z-scores for body temperature deviation, respiratory " +
       "rate, resting heart rate, and HRV using a 28-day rolling baseline ending the day " +

--- a/apps/oura-mcp/src/tools/tag.ts
+++ b/apps/oura-mcp/src/tools/tag.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getEnhancedTags } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerTagTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_tags",
+    "Reviewing tags…",
     "Returns user-created tags (enhanced format). " +
       "Each tag has a start_day, tag_type_code, optional comment text, " +
       "optional custom_name, and start/end times. " +

--- a/apps/oura-mcp/src/tools/utils.ts
+++ b/apps/oura-mcp/src/tools/utils.ts
@@ -72,4 +72,4 @@ export function validateDatetimeRange(
   return undefined;
 }
 
-export { textContent, errorContent } from "@mcp-stack/mcp-core";
+export { textContent, errorContent, titledTool } from "@mcp-stack/mcp-core";

--- a/apps/oura-mcp/src/tools/vo2max.ts
+++ b/apps/oura-mcp/src/tools/vo2max.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getVo2Max } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerVo2MaxTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_vo2_max",
+    "Reviewing VO2 max…",
     "Returns VO2 max estimates (mL/kg/min) as calculated by Oura. " +
       "Updates infrequently — monthly or after significant training changes. " +
       "Dates: \"day\" is the calendar day the VO2 max estimate was computed/reported on.",

--- a/apps/oura-mcp/src/tools/weekly_digest.ts
+++ b/apps/oura-mcp/src/tools/weekly_digest.ts
@@ -10,7 +10,7 @@ import {
   getEnhancedTags,
   getWorkouts,
 } from "../oura/endpoints.js";
-import { textContent, errorContent, todayInTz } from "./utils.js";
+import { textContent, errorContent, todayInTz, titledTool } from "./utils.js";
 import { defined, mean, linearSlope } from "../oura/stats.js";
 import type { SleepPeriod } from "../oura/types.js";
 import { detectAnomalies, buildMetricSeries } from "./anomaly_detect.js";
@@ -54,8 +54,10 @@ function round1(x: number): number {
 }
 
 export function registerWeeklyDigestTool(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_weekly_digest",
+    "Compiling your weekly digest…",
     "Composite weekly summary across sleep, readiness, HRV, activity, anomalies, " +
       "and tags. Returns area-by-area numbers plus highlights (positive things) " +
       "and watch_outs (concerns). Default window is the 7 days ending the most " +

--- a/apps/oura-mcp/src/tools/workout.ts
+++ b/apps/oura-mcp/src/tools/workout.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { OuraClient } from "../oura/client.js";
 import { OuraApiError } from "../oura/client.js";
 import { getWorkouts } from "../oura/endpoints.js";
-import { resolveDateRange, validateDateRange, textContent, errorContent } from "./utils.js";
+import { resolveDateRange, validateDateRange, textContent, errorContent, titledTool } from "./utils.js";
 
 export function registerWorkoutTools(server: McpServer, client: OuraClient): void {
-  server.tool(
+  titledTool(
+    server,
     "oura_workouts",
+    "Reviewing workouts…",
     "Returns logged and auto-detected workouts. " +
       "Fields include: activity type, start/end datetime, calories, distance (meters), " +
       "intensity (easy/moderate/hard), source (manual/confirmed/detected), and steps. " +

--- a/apps/trip-mcp/src/tools/conditions.ts
+++ b/apps/trip-mcp/src/tools/conditions.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import type { Env, Source, ToolPayload, Confidence } from "../types.js";
 import { makeSource, nowIso, ok } from "../types.js";
 import { findAreaById, type Area } from "../areas.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 import { getNpsAlerts, type NpsAlert } from "../sources/nps.js";
 import {
   getMountainPassConditions,
@@ -95,8 +95,10 @@ const argsSchema = {
 };
 
 export function registerConditionsTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "get_conditions",
+    "Checking current conditions…",
     "Composite trip-conditions snapshot for a PNW area or arbitrary point. Aggregates: NPS park alerts, WSDOT mountain pass conditions for the area's approach passes, WFIGS active fire perimeters intersecting a bbox around the area, and InciWeb PNW fire incidents. Each upstream source is isolated — one failure degrades to a named caveat rather than failing the whole call. USFS forest-page alert scraping is not yet implemented; `usfs_alerts` is always [] (check fs.usda.gov manually for forest-specific alerts when this matters). Use this for \"is there a fire near my route\" or \"is the road over Stevens Pass open\" questions. If `wsdot.passes` returns an error, the caveat will name it explicitly — point the user at wsdot.wa.gov/travel/real-time/mountainpasses directly. For shoulder-season trips (Apr–Jun, Oct–Nov) ALWAYS call this tool — pass status determines whether the trailhead is even reachable.",
     argsSchema,
     async ({ area_id, lat, lon, radius_km, approach_passes }) => {

--- a/apps/trip-mcp/src/tools/find_areas.ts
+++ b/apps/trip-mcp/src/tools/find_areas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { AREAS, findAreaById, findAreaWithMatch, type Area } from "../areas.js";
 import type { Env } from "../types.js";
 import { ok, makeSource } from "../types.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 
 interface AreaSummary {
   id: string;
@@ -37,8 +37,10 @@ function summarize(area: Area, match_reason?: string): AreaSummary {
 
 export function registerFindAreasTools(server: McpServer, _env: Env): void {
   void _env;
-  server.tool(
+  titledTool(
+    server,
     "find_areas",
+    "Finding wilderness areas…",
     "Resolve free-text area queries to canonical area records from the curated PNW registry (currently 12 hand-curated areas: Enchantments, Mt Rainier, North Cascades NP, Olympic NP, Glacier Peak Wilderness, Pasayten, Alpine Lakes Wilderness, Henry M. Jackson Wilderness, Goat Rocks, Mt St Helens, Mt Adams, Mt Baker). Returns area IDs that all other tools accept as `area_id`. This is the right first call for any vague PNW query like \"somewhere in the North Cascades\" or when you're not sure of the canonical area name. For areas outside the registry the response is empty — fall back to `web_research` for the trip details and use `get_weather` with explicit lat/lon. Match types: \"Exact name/alias match\" (high confidence), \"Substring/partial match\" (medium confidence — verify the resolved area is what the user actually meant before relying on it). If the resolved area looks wrong given the user's full query, surface that to the user and re-query with a more distinctive term.",
     {
       query: z

--- a/apps/trip-mcp/src/tools/permits.ts
+++ b/apps/trip-mcp/src/tools/permits.ts
@@ -17,7 +17,7 @@ import {
 } from "../sources/ridb.js";
 import type { Confidence, Env, Source, ToolPayload } from "../types.js";
 import { empty, makeSource, nowIso, ok } from "../types.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -112,8 +112,10 @@ function selfIssuedPayload(area: Area): ToolPayload<GetPermitsData> {
 }
 
 export function registerPermitTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "get_permits",
+    "Reviewing permit requirements…",
     "Returns Recreation.gov permit metadata for a PNW backpacking area: permit name, recreation.gov URL, application window dates, fees, lottery context, and historical odds where known (Enchantments Core Zone <5%, Snow Zone ~15%, etc.). For self-issued USFS wilderness areas (Glacier Peak, Pasayten, Henry M. Jackson) returns a static USFS pointer plus the local ranger station phone — there is no advance reservation system to query. If you already have an `area_id` from `find_areas` or a prior tool call in this conversation, pass it directly. Use this BEFORE `check_availability` to confirm the permit system is `rec_gov_lottery` or `rec_gov_reservation` — `check_availability` is meaningless for self-issued areas.",
     {
       area_id: z.string().optional().describe("Canonical area id, e.g. 'enchantments', 'mt_rainier'."),
@@ -206,8 +208,10 @@ export function registerPermitTools(server: McpServer, env: Env): void {
     },
   );
 
-  server.tool(
+  titledTool(
+    server,
     "check_availability",
+    "Checking permit availability…",
     "Checks live Recreation.gov permit availability for a date range. ONLY meaningful for `rec_gov_lottery` and `rec_gov_reservation` permit systems — call `get_permits` first to confirm the area uses one of these systems and to obtain the permit_id. For `self_issued` areas (Glacier Peak, Pasayten, most USFS wilderness) skip this tool entirely and use `get_permits` for the kiosk and ranger pointer. Returns the raw availability grid plus a one-line summary. Note: lottery permits (e.g., Enchantments 233273, 445863) may not return live availability through this endpoint because lotteries aren't \"availability\" in the campsite-grid sense — for lottery odds and windows, the `area.notes` from `find_areas` carries the curated context.",
     {
       permit_id: z.string().describe("RIDB permit id, e.g. '233273' for the Enchantments."),

--- a/apps/trip-mcp/src/tools/research_trip.ts
+++ b/apps/trip-mcp/src/tools/research_trip.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { findAreaById, findAreaWithMatch, AREAS, type Area } from "../areas.js";
 import type { Env, Source, ToolPayload } from "../types.js";
 import { ok, makeSource, nowIso } from "../types.js";
-import { payloadResponse, isoToday, daysFromNowIso } from "./utils.js";
+import { payloadResponse, isoToday, daysFromNowIso, titledTool } from "./utils.js";
 
 import { getPermit } from "../sources/ridb.js";
 import { getForecast, getActiveAlerts } from "../sources/nws.js";
@@ -69,8 +69,10 @@ function suggestArea(query: string, limit = 3): Area[] {
 }
 
 export function registerResearchTripTool(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "research_trip",
+    "Researching your trip…",
     "Top-level orchestrator for PNW (Washington, parts of Oregon) backpacking, day-hiking, and car-camping research. Use this for any trip-planning query that mentions a Pacific Northwest area, trail, or vague intent like \"somewhere in the North Cascades next weekend.\" PREFER THIS OVER PLAIN WEB SEARCH for PNW outdoor queries — it has a curated 12-area registry, enforces source citations with retrieval timestamps, surfaces ranger station phone numbers, and synthesizes permits + weather + conditions + recent trip reports in one call. For areas outside the curated registry the response degrades to web_research only; for non-PNW trips (Yosemite, Rockies, etc.) prefer plain web_search instead. Returns a synthesized brief plus `suggested_followups` pointing at deeper drill-down tools (`get_permits`, `get_weather`, `get_trip_reports`, `get_safety_brief`, `get_route_info`, `web_research`). ALWAYS surface ranger station phone numbers in your final answer and treat any low-confidence response as research, not ground truth — recommend the user call the ranger station before their trip. Modes: 'fast' (single parallel fan-out, ~30s) or 'thorough' (returns followup hints for the model to chain into a multi-call answer).",
     {
       query: z

--- a/apps/trip-mcp/src/tools/route_info.ts
+++ b/apps/trip-mcp/src/tools/route_info.ts
@@ -20,7 +20,7 @@ import {
   type OsmWaterSource,
 } from "../sources/osm.js";
 import { getElevation } from "../sources/usgs.js";
-import { payloadResponse, roundCoord } from "./utils.js";
+import { payloadResponse, roundCoord, titledTool } from "./utils.js";
 
 interface RouteInfoData {
   centroid: { lat: number; lon: number; area_id?: string; area_name?: string };
@@ -73,8 +73,10 @@ function haversineM(
 }
 
 export function registerRouteInfoTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "get_route_info",
+    "Reviewing route details…",
     "Returns trailheads, trails, water sources, and centroid elevation around a PNW area or arbitrary point. Pulls from OpenStreetMap (trails, parking, springs, streams, rivers) and USGS 3DEP (elevation). Trails are trimmed to the longest 10 by estimated length. Returns both `water_sources_within_500m` (strict — for \"is there water near camp\") and `water_sources_in_area` (radius-wide — for \"what water do I cross on this trail\"). Use this for first-pass route scouting; ALWAYS verify with a real trail map (Green Trails, USGS quad, or CalTopo) before the trip — OSM trail data has gaps and labels can be wrong. If you already have an `area_id` from `find_areas` or a prior tool call, pass it directly to avoid re-resolution. USGS elevation is sometimes flaky; if `centroid_elevation_ft` is null the source is omitted from citations and a caveat is added — surface the missing elevation to the user rather than inventing one.",
     {
       area_id: z.string().optional().describe("Known PNW area id (e.g. 'enchantments'). Overrides lat/lon."),

--- a/apps/trip-mcp/src/tools/safety.ts
+++ b/apps/trip-mcp/src/tools/safety.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { findAreaById, findAreaByText, type Area } from "../areas.js";
 import type { Env } from "../types.js";
 import { ok, empty, makeSource } from "../types.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 
 interface SafetyBrief {
   area: { id: string; name: string };
@@ -66,8 +66,10 @@ const AVALANCHE_LIKELY = new Set([
 
 export function registerSafetyTools(server: McpServer, _env: Env): void {
   void _env;
-  server.tool(
+  titledTool(
+    server,
     "get_safety_brief",
+    "Preparing a safety brief…",
     "Returns a structured safety brief for a PNW area: bear canister rules, recent wildlife considerations, river crossing concerns (with named rivers and timing advice), avalanche-terrain flag, ranger station phone numbers, and area-specific Ten Essentials notes. ALWAYS INCLUDE THIS OUTPUT in answers to safety-critical queries (river crossings, snow travel, glacier travel, avalanche terrain, solo trips, off-trail routes, climbs). The ranger station phone numbers are the single most reliable source of real-time backcountry conditions — surface them prominently in your final answer to the user, not buried in a footnote. This is curated guidance, not real-time conditions: combine with `get_trip_reports` (recent ground-truth) and `get_conditions` (current alerts/fires/passes) for a complete picture. If you're answering a query about future conditions (snow level next month, river flow next week), explicitly tell the user this brief is general guidance and the ranger call is the only way to get current ground truth.",
     {
       area_id: z.string().optional(),

--- a/apps/trip-mcp/src/tools/trip_reports.ts
+++ b/apps/trip-mcp/src/tools/trip_reports.ts
@@ -10,7 +10,7 @@ import type { Env } from "../types.js";
 import { empty, makeSource, ok } from "../types.js";
 import { findAreaById } from "../areas.js";
 import { searchTripReports, type TripReportSummary } from "../sources/wta.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 
 const argsShape = {
   area_id: z
@@ -42,8 +42,10 @@ const argsShape = {
 };
 
 export function registerTripReportTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "get_trip_reports",
+    "Reading recent trip reports…",
     "Returns recent Washington Trails Association (WTA) trip reports for a PNW area or trail. Trip reports are user-submitted observations of actual conditions (snow level, water sources, blowdowns, road status, bug pressure) and are the single best source of recent ground-truth for WA hikes — better than AllTrails for this use case. Scraped from wta.org with attribution; cache may be up to 24h stale (medium confidence). Use `area_id` from `find_areas` when available; if no reports come back for the area name, the orchestrator will retry with the most distinctive alias (e.g., \"Image Lake\" instead of \"Glacier Peak Wilderness\"). PNW only — for non-WA trips this tool will return empty; fall back to `web_research`. If a report mentions a road closure, blowdown, or condition that contradicts an official source (e.g., USFS says trail open, report says blocked), surface BOTH to the user and recommend they call the ranger station to resolve.",
     argsShape,
     async ({ area_id, area_name, trail_name, since_days, limit }) => {

--- a/apps/trip-mcp/src/tools/utils.ts
+++ b/apps/trip-mcp/src/tools/utils.ts
@@ -1,5 +1,5 @@
 import type { ToolPayload } from "../types.js";
-export { textContent, errorContent, formatToolError } from "@mcp-stack/mcp-core";
+export { textContent, errorContent, formatToolError, titledTool } from "@mcp-stack/mcp-core";
 
 /** Wrap a ToolPayload as the JSON body of a text MCP response. */
 export function payloadResponse<T>(payload: ToolPayload<T>) {

--- a/apps/trip-mcp/src/tools/weather.ts
+++ b/apps/trip-mcp/src/tools/weather.ts
@@ -17,7 +17,7 @@ import {
   type NwsAlert,
   type NwsForecastPeriod,
 } from "../sources/nws.js";
-import { payloadResponse, roundCoord } from "./utils.js";
+import { payloadResponse, roundCoord, titledTool } from "./utils.js";
 
 interface WeatherData {
   location: {
@@ -50,8 +50,10 @@ function summarizeAfd(productText: string): string {
 }
 
 export function registerWeatherTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "get_weather",
+    "Checking mountain weather…",
     "Returns NWS forecast (daily + optional hourly), active alerts, and the latest Area Forecast Discussion for a point. Either supply `area_id` (resolves to that area's centroid) or explicit lat/lon. Use this to assess go/no-go for a backpacking trip. CRITICAL CAVEATS to surface in your answer: (1) forecast confidence drops materially past 72 hours — for trips further out, recommend re-checking within 24h of departure; (2) NWS point forecasts are at valley elevations; expect 5–10°F cooler and significantly more precipitation at 6,000+ ft passes; (3) for any backcountry go/no-go decision involving snow, river crossings, or storms, surface the ranger station phone from `get_safety_brief` alongside this forecast — the ranger has real-time ground truth the forecast doesn't. The Area Forecast Discussion (include_afd: true, default) contains the meteorologist's narrative confidence assessment and is often the most useful field — quote it when relevant.",
     {
       lat: z.number().min(-90).max(90).optional().describe("Latitude (decimal). Ignored if area_id is supplied."),

--- a/apps/trip-mcp/src/tools/web_research.ts
+++ b/apps/trip-mcp/src/tools/web_research.ts
@@ -2,12 +2,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Env } from "../types.js";
 import { ok, empty, makeSource, nowIso } from "../types.js";
-import { payloadResponse } from "./utils.js";
+import { payloadResponse, titledTool } from "./utils.js";
 import { searchWeb, PNW_DEFAULT_SITES } from "../sources/web.js";
 
 export function registerWebResearchTools(server: McpServer, env: Env): void {
-  server.tool(
+  titledTool(
+    server,
     "web_research",
+    "Researching the web…",
     "Free-form web search across PNW outdoor community sources (NWHikers, SummitPost, Cascadeclimbers, Peakbagger, Reddit r/WashingtonHikers / r/PNWhiking / r/WildernessBackpacking, Mountaineers, CalTopo public maps, Steph Abegg). Use this for OBSCURE OR OFF-TRAIL routes not covered by WTA — peakbagging, cross-country zones, alpine climbs, old trip blogs, anything where the curated area registry returned empty. Powered by Brave Search; degrades gracefully when no API key is set. Returns titles + URLs + snippets — decide which results to read in full using your built-in web-fetch capability (this MCP does not expose its own fetch tool). Default `use_default_sites: false` searches the open web; set `use_default_sites: true` to restrict to the PNW outdoor community allowlist when you specifically want community trip reports rather than commercial guidebooks. Results are LOW CONFIDENCE by default — community content is uncited, may be old, and may describe conditions in a different season/year than the user's trip. Cross-reference any specific factual claim (snow level, road status, river crossing difficulty) with WTA, NWS, or an official source before passing it to the user as fact.",
     {
       query: z.string().describe("Search query, e.g. 'Glacier Peak Image Lake snow level July'"),

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -3,7 +3,8 @@
  * `agents` package. Apps register tools with `McpServer` from the SDK
  * directly (using their own Zod schemas); `mcp-core` only owns the
  * cross-cutting concerns: URL path-secret check, tool-response shape,
- * and a small set of error classes for the auth packages to throw.
+ * display-title registration (`titledTool`), and a small set of error
+ * classes for the auth packages to throw.
  *
  * The Workers-only `createMcpWorker` lives at the `/worker` subpath
  * so that loading `@mcp-stack/mcp-core` in Node (for tests, build
@@ -19,3 +20,4 @@ export {
   type McpToolResponse,
 } from "./responses.js";
 export { AuthExpired, RateLimited } from "./errors.js";
+export { titledTool } from "./titled-tool.js";

--- a/packages/mcp-core/src/titled-tool.test.ts
+++ b/packages/mcp-core/src/titled-tool.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "zod";
+import { titledTool } from "./titled-tool.js";
+import { textContent } from "./responses.js";
+
+/**
+ * Wire-level check: register tools through `titledTool`, list them over a
+ * real client/server pair, and assert the display title arrives in both
+ * `title` and `annotations.title` while `name` stays programmatic.
+ */
+async function listToolsFor(server: McpServer) {
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  const { tools } = await client.listTools();
+  return { client, tools };
+}
+
+describe("titledTool", () => {
+  it("exposes title and annotations.title over tools/list, keeping name", async () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    titledTool(
+      server,
+      "oura_daily_sleep",
+      "Reviewing sleep scores…",
+      "Returns daily sleep scores.",
+      { start_date: z.string().optional() },
+      async () => textContent("ok"),
+    );
+
+    const { tools } = await listToolsFor(server);
+    expect(tools).toHaveLength(1);
+    const tool = tools[0]!;
+    expect(tool.name).toBe("oura_daily_sleep");
+    expect(tool.title).toBe("Reviewing sleep scores…");
+    expect(tool.annotations?.title).toBe("Reviewing sleep scores…");
+    expect(tool.description).toBe("Returns daily sleep scores.");
+    expect(tool.inputSchema.properties).toHaveProperty("start_date");
+  });
+
+  it("supports zero-argument tools registered without a schema", async () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    titledTool(
+      server,
+      "ping",
+      "Pinging…",
+      "Returns pong.",
+      async () => textContent("pong"),
+    );
+
+    const { client, tools } = await listToolsFor(server);
+    expect(tools[0]?.title).toBe("Pinging…");
+    expect(tools[0]?.annotations?.title).toBe("Pinging…");
+
+    const result = await client.callTool({ name: "ping", arguments: {} });
+    expect(result.content).toEqual([{ type: "text", text: "pong" }]);
+  });
+
+  it("passes validated arguments through to the handler", async () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    titledTool(
+      server,
+      "echo",
+      "Echoing…",
+      "Echoes the message back.",
+      { message: z.string() },
+      async ({ message }) => textContent(message),
+    );
+
+    const { client } = await listToolsFor(server);
+    const result = await client.callTool({ name: "echo", arguments: { message: "hi" } });
+    expect(result.content).toEqual([{ type: "text", text: "hi" }]);
+  });
+});

--- a/packages/mcp-core/src/titled-tool.ts
+++ b/packages/mcp-core/src/titled-tool.ts
@@ -1,0 +1,61 @@
+/**
+ * Display-title tool registration. Wraps `McpServer.registerTool` so every
+ * tool carries a human-readable, action-phrased display title (e.g.
+ * "Reviewing sleep scores…") alongside its stable programmatic `name`.
+ *
+ * The MCP spec's display-name precedence is `title` > `annotations.title`
+ * > `name`. Which field a given client actually renders varies, so we set
+ * both to the same string; the programmatic name is never touched.
+ */
+
+import type {
+  McpServer,
+  RegisteredTool,
+  ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+
+/** Register a tool with a display title and an input schema. */
+export function titledTool<Args extends ZodRawShape>(
+  server: McpServer,
+  name: string,
+  title: string,
+  description: string,
+  inputSchema: Args,
+  cb: ToolCallback<Args>,
+): RegisteredTool;
+/** Register a zero-argument tool with a display title. */
+export function titledTool(
+  server: McpServer,
+  name: string,
+  title: string,
+  description: string,
+  cb: ToolCallback<undefined>,
+): RegisteredTool;
+export function titledTool(
+  server: McpServer,
+  name: string,
+  title: string,
+  description: string,
+  schemaOrCb: unknown,
+  maybeCb?: unknown,
+): RegisteredTool {
+  if (typeof schemaOrCb === "function") {
+    return server.registerTool(
+      name,
+      { title, description, annotations: { title } },
+      schemaOrCb as ToolCallback<undefined>,
+    );
+  }
+  return server.registerTool(
+    name,
+    {
+      title,
+      description,
+      inputSchema: schemaOrCb as ZodRawShape,
+      annotations: { title },
+    },
+    // maybeCb is required by the overloads whenever a schema is passed.
+    maybeCb as ToolCallback<ZodRawShape>,
+  );
+}


### PR DESCRIPTION
Closes #59

## Changes

- New `titledTool` helper in `packages/mcp-core` (exported from the package root) that wraps `McpServer.registerTool` and sets the same action-phrased display title in **both** the MCP top-level `title` field and `annotations.title`. Spec display-name precedence is `title` > `annotations.title` > `name`, and which field a given client reads varies, so both are set.
- All 78 tool registrations across the four apps (`oura-mcp` 30, `trip-mcp` 10, `gmail-mcp` 18, `github-mcp` 20) converted from the deprecated `server.tool(...)` to `titledTool(...)`. **Programmatic names, descriptions, parameter schemas, and handlers are byte-for-byte unchanged** — only the display metadata is new.
- Titles are phrased as friendly progressive actions, with wording that distinguishes reads from writes: "Reviewing sleep scores…", "Checking permit availability…" vs. "Sending an email…", "Permanently deleting an email…", "Filing an issue…".
- Each app's `tools/utils.ts` re-exports `titledTool`, matching the existing `textContent`/`errorContent` re-export pattern.
- `gmail-mcp` attachments test fake updated from `.tool()` to `.registerTool()` (registration now flows through `registerTool`).

## Verification findings (per acceptance criteria)

Verified at two levels that the metadata reaches the wire:

1. **SDK client (protocol level):** new test `packages/mcp-core/src/titled-tool.test.ts` connects a real `@modelcontextprotocol/sdk` `Client` over `InMemoryTransport` and asserts `tools/list` returns `title` and `annotations.title` set to the display title while `name` stays programmatic, and that handlers still receive validated args.
2. **Worker runtime (deployment shape):** booted `github-mcp` under `wrangler dev` and issued raw JSON-RPC `initialize` + `tools/list`; all 20 tools came back with both fields populated, e.g. `github_create_issue | Filing an issue… | Filing an issue…`.

**Rendering in Claude clients could not be confirmed pre-merge:** the currently *deployed* workers (no titles yet) show raw snake_case names in a live Claude Code session, so there is no live datapoint for title rendering until this deploys and the connectors reconnect. Per the issue's fallback clause: the metadata is in place in both fields; if the clients turn out to ignore both, nothing further is needed server-side. Worth a quick visual check in claude.ai after the auto-deploy on merge.

## Scope note

The issue lists seven apps, but this repo contains four (`oura-mcp`, `trip-mcp`, `gmail-mcp`, `github-mcp`) — all covered here. The remaining apps live outside this repo (see CLAUDE.md "What lives where") and need the same treatment separately; the helper is reusable if they consume `@mcp-stack/mcp-core`.

## Checks

- `pnpm -r type-check` — all 12 projects pass
- `pnpm -r test` — all suites pass (mcp-core 14, oura 40, trip 16, github 12, gmail 6)

---
_Generated by [Claude Code](https://claude.ai/code/session_012t2W7m8BrokZmQDNTW5ky4)_