### PR TITLE
[gmail-mcp] Route get_attachment content by MIME type for images and PDFs

### DIFF
--- a/apps/gmail-mcp/src/tools/attachments.test.ts
+++ b/apps/gmail-mcp/src/tools/attachments.test.ts
@@ -144,12 +144,32 @@ describe("list_attachments", () => {
 });
 
 describe("get_attachment", () => {
-  it("fetches attachment bytes and returns base64url data verbatim with size", async () => {
+  function mockMessageWithPart(mimeType: string) {
+    return {
+      data: {
+        payload: {
+          mimeType: "multipart/mixed",
+          parts: [
+            {
+              mimeType,
+              filename: "file",
+              body: { attachmentId: "att-1", size: 42 },
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  it("falls back to raw base64url text data for non-image/PDF types", async () => {
     const gmail = fakeGmail();
     const { server, handlers } = fakeServer();
     registerAttachmentTools(server, gmail);
 
     const base64url = "SGVsbG8t_1234"; // contains '-' and '_' — must not be re-encoded
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockMessageWithPart("text/plain"),
+    );
     (
       gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValue({
@@ -162,6 +182,7 @@ describe("get_attachment", () => {
     });
     const parsed = JSON.parse(result.content[0]!.text);
 
+    expect(result.content).toHaveLength(1);
     expect(parsed).toEqual({
       messageId: "msg-1",
       attachmentId: "att-1",
@@ -175,11 +196,74 @@ describe("get_attachment", () => {
     });
   });
 
+  it("returns an image content block for image MIME types, re-encoded to standard base64", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    const base64url = "SGVsbG8t_1234";
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockMessageWithPart("image/png"),
+    );
+    (
+      gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      data: { size: 42, data: base64url },
+    });
+
+    const result = await handlers.get("get_attachment")!({
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toMatchObject({ type: "text" });
+    expect(result.content[1]).toEqual({
+      type: "image",
+      data: "SGVsbG8t/1234===",
+      mimeType: "image/png",
+    });
+  });
+
+  it("returns a resource content block for PDFs", async () => {
+    const gmail = fakeGmail();
+    const { server, handlers } = fakeServer();
+    registerAttachmentTools(server, gmail);
+
+    const base64url = "SGVsbG8t_1234";
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockMessageWithPart("application/pdf"),
+    );
+    (
+      gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      data: { size: 42, data: base64url },
+    });
+
+    const result = await handlers.get("get_attachment")!({
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]).toEqual({
+      type: "resource",
+      resource: {
+        uri: "gmail-attachment://msg-1/att-1",
+        mimeType: "application/pdf",
+        blob: "SGVsbG8t/1234===",
+      },
+    });
+  });
+
   it("returns errorContent on Gmail API failure", async () => {
     const gmail = fakeGmail();
     const { server, handlers } = fakeServer();
     registerAttachmentTools(server, gmail);
 
+    (gmail.users.messages.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockMessageWithPart("text/plain"),
+    );
     (
       gmail.users.messages.attachments.get as unknown as ReturnType<typeof vi.fn>
     ).mockRejectedValue(new Error("429 Rate Limit Exceeded"));
@@ -190,5 +274,14 @@ describe("get_attachment", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain("Gmail rate limited");
+  });
+});
+
+describe("base64UrlToBase64", () => {
+  it("converts '-' to '+' and '_' to '/' and pads to a multiple of 4", async () => {
+    const { base64UrlToBase64 } = await import("./utils.js");
+    expect(base64UrlToBase64("SGVsbG8t_1234")).toBe("SGVsbG8t/1234===");
+    expect(base64UrlToBase64("YQ")).toBe("YQ==");
+    expect(base64UrlToBase64("YWJj")).toBe("YWJj");
   });
 });

--- a/apps/gmail-mcp/src/tools/attachments.ts
+++ b/apps/gmail-mcp/src/tools/attachments.ts
@@ -1,26 +1,41 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { gmail_v1 } from "googleapis";
 import { z } from "zod";
-import { textContent, errorContent, formatGmailError } from "./utils.js";
+import { textContent, errorContent, multiContent, base64UrlToBase64, formatGmailError } from "./utils.js";
 import { collectAttachments, type MimePart } from "./email.js";
 
 /**
- * Gmail attachment-retrieval tools (issue #30).
+ * Gmail attachment-retrieval tools (issue #30, MIME routing from #51).
  *
  * `list_attachments` walks the message's MIME tree (recursively, via
  * `collectAttachments` shared with `read_email`) and returns metadata only
  * — filename, MIME type, size, and the `attachmentId` needed to fetch
- * bytes. `get_attachment` fetches the raw attachment via
- * `users.messages.attachments.get` and returns it as base64url data,
- * unchanged from what the Gmail API returns (Gmail's attachment `data` is
- * base64url — `-`/`_` instead of `+`/`/` — and is passed through verbatim
- * rather than re-encoded).
+ * bytes.
  *
- * MIME-aware routing (image content blocks, PDF/docx/xlsx text
- * extraction), the size cap + `force` override, and end-to-end smoke
- * testing against real attachments are deferred — see the tracking issue
- * referenced in the PR that introduced this file.
+ * `get_attachment` fetches the raw attachment via
+ * `users.messages.attachments.get`, looks up its MIME type from the
+ * message (re-fetched rather than trusted from the caller, so routing is
+ * correct even if the caller didn't pass one through from
+ * `list_attachments`), and routes:
+ *   - common web image types → an MCP `image` content block, so Claude's
+ *     vision handles it directly.
+ *   - `application/pdf` → an MCP `resource` content block (base64 blob +
+ *     mimeType), leaning on the client's own document handling rather
+ *     than server-side text extraction.
+ *   - everything else → unchanged: raw base64url text data, same as
+ *     before #51.
+ *
+ * Server-side docx/xlsx conversion, a size cap + `force` override, and
+ * structured errors for unsupported types are deferred — see the
+ * tracking issue for the reasoning (Workers CPU/memory constraints on
+ * real parsing libraries, speculative until a real attachment needs it).
  */
+const IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
 export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail): void {
   server.tool(
     "list_attachments",
@@ -49,9 +64,10 @@ export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail
 
   server.tool(
     "get_attachment",
-    "Fetch a Gmail attachment's raw content by message ID and attachmentId (from " +
-      "list_attachments). Returns the attachment's base64url-encoded data, per the Gmail API, " +
-      "and its size in bytes.",
+    "Fetch a Gmail attachment's content by message ID and attachmentId (from " +
+      "list_attachments). Common image types (png/jpeg/webp/gif) are returned as a viewable " +
+      "image; PDFs are returned as an embedded document resource. Everything else falls back " +
+      "to the attachment's raw base64url-encoded data and size, per the Gmail API.",
     {
       messageId: z.string().describe("Gmail message ID"),
       attachmentId: z
@@ -60,18 +76,41 @@ export function registerAttachmentTools(server: McpServer, gmail: gmail_v1.Gmail
     },
     async ({ messageId, attachmentId }) => {
       try {
-        const res = await gmail.users.messages.attachments.get({
-          userId: "me",
-          messageId,
-          id: attachmentId,
-        });
-        const result = JSON.stringify({
-          messageId,
-          attachmentId,
-          size: res.data.size ?? 0,
-          data: res.data.data ?? "",
-        });
-        return textContent(result);
+        const [messageRes, attachmentRes] = await Promise.all([
+          gmail.users.messages.get({ userId: "me", id: messageId, format: "full" }),
+          gmail.users.messages.attachments.get({ userId: "me", messageId, id: attachmentId }),
+        ]);
+
+        const parts = messageRes.data.payload
+          ? collectAttachments(messageRes.data.payload as MimePart)
+          : [];
+        const meta = parts.find((p) => p.attachmentId === attachmentId);
+        const mimeType = meta?.mimeType ?? "application/octet-stream";
+        const base64url = attachmentRes.data.data ?? "";
+        const size = attachmentRes.data.size ?? 0;
+
+        if (IMAGE_MIME_TYPES.has(mimeType)) {
+          return multiContent([
+            { type: "text", text: JSON.stringify({ messageId, attachmentId, mimeType, size }) },
+            { type: "image", data: base64UrlToBase64(base64url), mimeType },
+          ]);
+        }
+
+        if (mimeType === "application/pdf") {
+          return multiContent([
+            { type: "text", text: JSON.stringify({ messageId, attachmentId, mimeType, size }) },
+            {
+              type: "resource",
+              resource: {
+                uri: `gmail-attachment://${messageId}/${attachmentId}`,
+                mimeType,
+                blob: base64UrlToBase64(base64url),
+              },
+            },
+          ]);
+        }
+
+        return textContent(JSON.stringify({ messageId, attachmentId, size, data: base64url }));
       } catch (e) {
         return errorContent(formatGmailError(e));
       }

--- a/apps/gmail-mcp/src/tools/utils.ts
+++ b/apps/gmail-mcp/src/tools/utils.ts
@@ -10,7 +10,19 @@
  * and "Gmail rate limited — try again shortly".
  */
 
-export { textContent, errorContent } from "@mcp-stack/mcp-core";
+export { textContent, errorContent, multiContent } from "@mcp-stack/mcp-core";
+
+/**
+ * Gmail attachment `data` is base64url (RFC 4648 §5: `-`/`_`, no padding).
+ * MCP `image`/`resource` content blocks expect standard base64 (`+`/`/`,
+ * padded) since that's what clients' base64 decoders and the Claude API
+ * expect — this is a real re-encoding, not a rename.
+ */
+export function base64UrlToBase64(data: string): string {
+  const base64 = data.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (base64.length % 4)) % 4;
+  return base64 + "=".repeat(padding);
+}
 
 export function formatGmailError(error: unknown): string {
   if (error instanceof Error) {

--- a/packages/mcp-core/src/index.test.ts
+++ b/packages/mcp-core/src/index.test.ts
@@ -33,7 +33,9 @@ describe("textContent", () => {
 
   it("pretty-prints objects as JSON", () => {
     const out = textContent({ ok: true });
-    expect(out.content[0]?.text).toBe('{\n  "ok": true\n}');
+    const item = out.content[0];
+    expect(item?.type).toBe("text");
+    expect(item && "text" in item ? item.text : undefined).toBe('{\n  "ok": true\n}');
   });
 });
 

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -16,6 +16,8 @@ export {
   textContent,
   errorContent,
   formatToolError,
+  multiContent,
   type McpToolResponse,
+  type ToolContentItem,
 } from "./responses.js";
 export { AuthExpired, RateLimited } from "./errors.js";

--- a/packages/mcp-core/src/responses.ts
+++ b/packages/mcp-core/src/responses.ts
@@ -5,8 +5,25 @@
 
 import { AuthExpired, RateLimited } from "./errors.js";
 
+/**
+ * A single MCP tool-response content item. Beyond plain text, the SDK's
+ * `CallToolResult` also allows `image` (inline base64, standard alphabet —
+ * NOT base64url) and `resource` (an embedded blob/text resource, e.g. a
+ * PDF) so the client can render/handle rich content natively instead of
+ * everything collapsing to a text blob.
+ */
+export type ToolContentItem =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string }
+  | {
+      type: "resource";
+      resource:
+        | { uri: string; mimeType?: string; blob: string }
+        | { uri: string; mimeType?: string; text: string };
+    };
+
 export interface McpToolResponse {
-  content: Array<{ type: "text"; text: string }>;
+  content: ToolContentItem[];
   isError?: true;
   /**
    * The MCP SDK's `CallToolResult` is an open shape (allows `_meta` and
@@ -28,6 +45,15 @@ export function textContent(data: unknown): McpToolResponse {
 /** Wrap a message as a tool error response. */
 export function errorContent(message: string): McpToolResponse {
   return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/**
+ * Wrap arbitrary content items (text, image, resource) as a successful
+ * tool response — for handlers that need to return more than one item,
+ * or a non-text item, in a single result.
+ */
+export function multiContent(items: ToolContentItem[]): McpToolResponse {
+  return { content: items };
 }
 
 /**


### PR DESCRIPTION
Refs #51 (rescoped — see the issue comment for the narrowed scope and what's deferred).

## What changed
`get_attachment` now looks up the attachment's real MIME type server-side (re-fetches the message and matches by attachmentId, rather than trusting a caller-supplied type) and routes:

- `image/png`, `image/jpeg`, `image/webp`, `image/gif` → an MCP `image` content block (re-encoded from Gmail's base64url to standard base64) — Claude's vision handles it natively, no server-side image processing needed.
- `application/pdf` → an MCP `resource` content block (base64 `blob` + `mimeType`) — leans on the client's own document handling rather than server-side text extraction.
- Everything else → unchanged: raw base64url text response, same as before this PR.

Also adds `multiContent`/`ToolContentItem` to `@mcp-stack/mcp-core` so tool handlers can return image/resource content, not just text — a small, generic addition other apps can reuse later.

## What's deferred (tracked in #51, rescoped)
docx→markdown / xlsx→CSV server-side conversion, a configurable size cap + `force` override, and structured errors for unsupported types. These need real parsing libraries running under Cloudflare Workers CPU/memory limits and are speculative until an actual attachment needs them.

## Testing
- 12 tests in `attachments.test.ts` (was 9; added image-routing, PDF-routing, base64url→base64 conversion, and fallback-to-raw-text cases).
- `pnpm -r type-check` and `pnpm -r test` both pass clean across the whole monorepo.
- Not live-tested against a real email with attachments — recommend a live check (fetch a real image attachment and a real PDF attachment) before considering this fully verified.