### PR TITLE
[trip-mcp] Address open trip-mcp issue queue (#65–#71)

### DIFF
--- a/apps/trip-mcp/README.md
+++ b/apps/trip-mcp/README.md
@@ -54,6 +54,8 @@ Add as a custom connector in claude.ai → Settings → Connectors → Add custo
 
 ## Caveats
 
+- `get_conditions` NPS alerts require the free `NPS_API_KEY` secret (nps.gov/subjects/developer/get-started.htm); a missing key surfaces as a named caveat rather than an HTTP status.
+- WSDOT pass conditions require the free `WSDOT_API_KEY` access code (wsdot.wa.gov/traffic/api/), passed as the `AccessCode` query param. A 401 means the code is missing, expired, or rotated — re-issue and `wrangler secret put WSDOT_API_KEY`.
 - WTA has no API; the scraper uses regex-based HTML parsing and will need babysitting when WTA redesigns. Snapshot test in `src/sources/wta.test.ts`.
 - USFS forest-page scraping is not yet implemented; `get_conditions` returns an empty `usfs_alerts` array with a caveat.
 - Auth is shared-secret-in-URL — fine for ≤10 trusted friends, not acceptable for the Anthropic Connectors Directory submission. Marketplace prep requires OAuth 2.1 (see Phase 3 in the original build plan).

--- a/apps/trip-mcp/README.md
+++ b/apps/trip-mcp/README.md
@@ -1,18 +1,20 @@
 # trip-mcp
 
 PNW backpacking & camping research MCP server. Single Cloudflare Worker exposing
-10 outcome-oriented tools that aggregate Recreation.gov, NWS, NPS, USFS, WSDOT,
-WFIGS, InciWeb, WTA, OSM, and USGS data.
+12 outcome-oriented tools that aggregate Recreation.gov, NWS, NPS, USFS, WSDOT,
+WFIGS, InciWeb, WTA, OSM, USGS, and Open-Meteo data.
 
 ## Tools
 
 | Tool | What it does |
 |---|---|
 | `research_trip` | Top-level orchestrator. Fans out to all sources in parallel and returns a synthesized brief plus `suggested_followups`. |
-| `find_areas` | Resolves a free-text query to canonical PNW area records. |
+| `find_areas` | Resolves a free-text query to canonical PNW area records; WTA hiking-guide fallback for off-registry WA trails. |
 | `get_permits` | All permit options for an area (Rec.gov + self-issued). |
 | `check_availability` | Live RIDB availability for a permit/campground + date range. |
-| `get_weather` | NWS daily/hourly forecast + active alerts + AFD. |
+| `get_weather` | NWS daily/hourly forecast + active alerts + AFD; optional Open-Meteo elevation-adjusted block. |
+| `get_elevation_profile` | Distance-indexed elevation series along a trail polyline (points, OSM id, or trail name). |
+| `get_trail_weather_profile` | Chart-ready {mile, elevation, temp, precip} series along a trail. |
 | `get_trip_reports` | Recent WTA trip reports for an area or trail. |
 | `get_conditions` | Combined NPS + USFS + WSDOT + WFIGS + InciWeb. |
 | `get_route_info` | OSM trails/trailheads/water + USGS elevation. |

--- a/apps/trip-mcp/src/areas.ts
+++ b/apps/trip-mcp/src/areas.ts
@@ -422,3 +422,27 @@ export function findAreaWithMatch(text: string): AreaMatch | undefined {
 export function findAreaById(id: string): Area | undefined {
   return AREAS.find((a) => a.id === id);
 }
+
+/**
+ * Popular-name → OSM/official-name aliases for high-traffic mismatches
+ * where the name everyone uses isn't what OSM tags the trail. Purely an
+ * internal seed for trail-name matching (NOT user-facing, NOT the area
+ * registry) — extend as new cases are found in the wild.
+ */
+export const TRAIL_NAME_ALIASES: Record<string, string> = {
+  // "Gothic Basin" is OSM's "Weden Creek Trail", USFS #724.
+  "gothic basin": "weden creek",
+};
+
+/**
+ * Expand a trail-name query with any seeded aliases whose key appears in
+ * it. Returns extra query strings to try alongside the original.
+ */
+export function expandTrailAliases(query: string): string[] {
+  const q = query.toLowerCase();
+  const out: string[] = [];
+  for (const [popular, osmName] of Object.entries(TRAIL_NAME_ALIASES)) {
+    if (q.includes(popular)) out.push(osmName);
+  }
+  return out;
+}

--- a/apps/trip-mcp/src/polyline.test.ts
+++ b/apps/trip-mcp/src/polyline.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { cumulativeM, haversineM, resamplePolyline } from "./polyline.js";
+
+// ~1.1km due-north segment near Barlow Pass.
+const A = { lat: 48.02, lon: -121.44 };
+const B = { lat: 48.03, lon: -121.44 };
+const C = { lat: 48.04, lon: -121.44 };
+
+describe("polyline", () => {
+  it("haversine of a 0.01deg latitude step is ~1113m", () => {
+    const d = haversineM(A, B);
+    expect(d).toBeGreaterThan(1050);
+    expect(d).toBeLessThan(1180);
+  });
+
+  it("cumulativeM starts at 0 and is monotonic", () => {
+    const cum = cumulativeM([A, B, C]);
+    expect(cum[0]).toBe(0);
+    expect(cum[1]!).toBeGreaterThan(0);
+    expect(cum[2]!).toBeGreaterThan(cum[1]!);
+  });
+
+  it("annotates without resampling when already under target", () => {
+    const out = resamplePolyline([A, B, C], 50);
+    expect(out).toHaveLength(3);
+    expect(out[0]!.mile).toBe(0);
+    expect(out[2]!.mile).toBeCloseTo(1.38, 1);
+  });
+
+  it("downsamples long polylines to the target count, keeping endpoints", () => {
+    const dense = Array.from({ length: 500 }, (_, i) => ({
+      lat: 48.02 + i * 0.0001,
+      lon: -121.44,
+    }));
+    const out = resamplePolyline(dense, 50);
+    expect(out).toHaveLength(50);
+    expect(out[0]!.lat).toBeCloseTo(48.02, 6);
+    expect(out[49]!.lat).toBeCloseTo(dense[499]!.lat, 4);
+    // Even spacing: consecutive mile deltas roughly constant.
+    const deltas = out.slice(1).map((p, i) => p.mile - out[i]!.mile);
+    const min = Math.min(...deltas);
+    const max = Math.max(...deltas);
+    expect(max - min).toBeLessThan(0.01);
+  });
+
+  it("handles degenerate zero-length input", () => {
+    const out = resamplePolyline([A, A, A], 10);
+    expect(out).toHaveLength(3);
+    expect(out.every((p) => p.mile === 0)).toBe(true);
+  });
+});

--- a/apps/trip-mcp/src/polyline.ts
+++ b/apps/trip-mcp/src/polyline.ts
@@ -1,0 +1,97 @@
+/**
+ * Polyline geometry helpers for elevation/weather profile tools:
+ * haversine distance, cumulative mileage, and even-spacing resampling.
+ * Pure functions — unit tested in polyline.test.ts.
+ */
+
+export interface PolyPoint {
+  lat: number;
+  lon: number;
+}
+
+export interface ProfilePoint extends PolyPoint {
+  /** Cumulative trail miles from the first input point. */
+  mile: number;
+}
+
+const EARTH_RADIUS_M = 6_371_000;
+const METERS_PER_MILE = 1_609.344;
+
+export function haversineM(a: PolyPoint, b: PolyPoint): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+/** Cumulative distance in meters at each vertex; [0] is always 0. */
+export function cumulativeM(points: PolyPoint[]): number[] {
+  const out: number[] = [0];
+  for (let i = 1; i < points.length; i++) {
+    out.push(out[i - 1]! + haversineM(points[i - 1]!, points[i]!));
+  }
+  return out;
+}
+
+export function metersToMiles(m: number): number {
+  return m / METERS_PER_MILE;
+}
+
+export function metersToFeet(m: number): number {
+  return m * 3.28084;
+}
+
+/**
+ * Resample a polyline to at most `targetCount` evenly distance-spaced
+ * points (linear interpolation between vertices, endpoints always kept).
+ * Inputs already at or under the target are annotated with mileage but
+ * otherwise returned as-is — upsampling would invent detail the mapped
+ * line doesn't have.
+ */
+export function resamplePolyline(points: PolyPoint[], targetCount: number): ProfilePoint[] {
+  if (points.length === 0) return [];
+  const cum = cumulativeM(points);
+  const total = cum[cum.length - 1]!;
+
+  if (points.length <= targetCount || total === 0) {
+    return points.map((p, i) => ({ lat: p.lat, lon: p.lon, mile: round3(metersToMiles(cum[i]!)) }));
+  }
+
+  const out: ProfilePoint[] = [];
+  let seg = 0;
+  for (let i = 0; i < targetCount; i++) {
+    const target = (total * i) / (targetCount - 1);
+    while (seg < points.length - 2 && cum[seg + 1]! < target) seg++;
+    const segStart = cum[seg]!;
+    const segLen = cum[seg + 1]! - segStart;
+    const t = segLen > 0 ? (target - segStart) / segLen : 0;
+    const a = points[seg]!;
+    const b = points[seg + 1]!;
+    out.push({
+      lat: a.lat + (b.lat - a.lat) * t,
+      lon: a.lon + (b.lon - a.lon) * t,
+      mile: round3(metersToMiles(target)),
+    });
+  }
+  return out;
+}
+
+/** Bounding box [minLon, minLat, maxLon, maxLat] around a point. */
+export function bboxAroundPoint(
+  lat: number,
+  lon: number,
+  radiusKm: number,
+): [number, number, number, number] {
+  const kmPerDegLat = 111.32;
+  const dLat = radiusKm / kmPerDegLat;
+  const cosLat = Math.max(0.01, Math.cos((lat * Math.PI) / 180));
+  const dLon = radiusKm / (kmPerDegLat * cosLat);
+  return [lon - dLon, lat - dLat, lon + dLon, lat + dLat];
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/apps/trip-mcp/src/sources/nps.test.ts
+++ b/apps/trip-mcp/src/sources/nps.test.ts
@@ -1,10 +1,16 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import * as nps from "./nps.js";
+import type { Env } from "../types.js";
 
 describe("nps source", () => {
   it("module loads", () => {
     void nps.getNpsAlerts;
     void nps.getNpsPark;
+  });
+
+  it("names the missing NPS_API_KEY secret instead of a bare HTTP status", async () => {
+    const env = { NPS_API_KEY: "", CONTACT: "test@example.com" } as Env;
+    await expect(nps.getNpsAlerts(env, ["mora"])).rejects.toThrow(/missing NPS_API_KEY secret/);
   });
 
   it.todo("getNpsAlerts joins parkCodes with commas");

--- a/apps/trip-mcp/src/sources/nps.ts
+++ b/apps/trip-mcp/src/sources/nps.ts
@@ -13,6 +13,11 @@ import { userAgent } from "../tools/utils.js";
 const BASE_URL = "https://developer.nps.gov/api/v1";
 
 function client(env: Env) {
+  if (!env.NPS_API_KEY) {
+    throw new Error(
+      "missing NPS_API_KEY secret — get a free key at nps.gov/subjects/developer/get-started.htm and `wrangler secret put NPS_API_KEY`",
+    );
+  }
   return createFetchClient({
     baseUrl: BASE_URL,
     userAgent: userAgent(env.CONTACT),

--- a/apps/trip-mcp/src/sources/openmeteo.ts
+++ b/apps/trip-mcp/src/sources/openmeteo.ts
@@ -1,0 +1,210 @@
+/**
+ * Open-Meteo clients (open-meteo.com). Free for non-commercial use, no
+ * API key; attribution required (CC BY 4.0).
+ *
+ *  - Elevation API: Copernicus GLO-90 DEM (90 m resolution, <~4 m
+ *    vertical error). Accepts comma-separated batches of up to 100
+ *    coordinate pairs per request.
+ *  - Forecast API: `best_match` model selection (1–2 km high-res models
+ *    over North America for the first days). Supplying `elevation`
+ *    applies hypsometric altitude correction to temperature/pressure
+ *    variables — this is a model adjustment, not a station observation.
+ */
+
+import { createFetchClient } from "@mcp-stack/http-fetch";
+import type { Env } from "../types.js";
+import { cached, TTL } from "../cache.js";
+import { userAgent } from "../tools/utils.js";
+
+const ELEVATION_URL = "https://api.open-meteo.com/v1/elevation";
+const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+
+export const OPEN_METEO_ATTRIBUTION = "Weather/elevation data by Open-Meteo.com (CC BY 4.0)";
+
+/** Max coordinate pairs the Elevation API accepts in one request. */
+export const ELEVATION_BATCH_LIMIT = 100;
+
+function client(env: Env) {
+  return createFetchClient({
+    userAgent: userAgent(env.CONTACT),
+    defaultHeaders: { Accept: "application/json" },
+    timeoutMs: 15_000,
+    retries: 1,
+  });
+}
+
+/** FNV-1a over a string — short stable cache keys for long coord lists. */
+function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function round5(n: number): number {
+  return Math.round(n * 1e5) / 1e5;
+}
+
+interface ElevationResponse {
+  elevation?: number[];
+}
+
+/**
+ * Batch point elevations in METERS (callers convert). At most
+ * ELEVATION_BATCH_LIMIT points — throws on more rather than silently
+ * splitting into serial requests. Returns null per point on gaps.
+ */
+export async function getElevationsMeters(
+  env: Env,
+  points: Array<{ lat: number; lon: number }>,
+): Promise<Array<number | null>> {
+  if (points.length === 0) return [];
+  if (points.length > ELEVATION_BATCH_LIMIT) {
+    throw new Error(`open-meteo elevation batch limit is ${ELEVATION_BATCH_LIMIT} points`);
+  }
+  const lats = points.map((p) => round5(p.lat)).join(",");
+  const lons = points.map((p) => round5(p.lon)).join(",");
+  const key = `openmeteo:elev:${fnv1a(`${lats}|${lons}`)}:${points.length}`;
+  return cached(env, key, TTL.USGS, async () => {
+    const res = await client(env).json<ElevationResponse>(
+      `${ELEVATION_URL}?latitude=${lats}&longitude=${lons}`,
+    );
+    const elev = res.elevation ?? [];
+    return points.map((_, i) => (typeof elev[i] === "number" ? elev[i]! : null));
+  });
+}
+
+export interface OpenMeteoDaily {
+  date: string;
+  temp_max_f: number | null;
+  temp_min_f: number | null;
+  precip_probability_max_pct: number | null;
+  precip_sum_in: number | null;
+  freezing_level_min_ft: number | null;
+  freezing_level_max_ft: number | null;
+}
+
+export interface OpenMeteoHourly {
+  time: string;
+  temp_f: number | null;
+  precip_probability_pct: number | null;
+  precip_in: number | null;
+  wind_speed_mph: number | null;
+  freezing_level_ft: number | null;
+}
+
+export interface OpenMeteoForecast {
+  /** Elevation (ft) the model actually used for altitude correction. */
+  model_elevation_ft: number;
+  daily: OpenMeteoDaily[];
+  hourly: OpenMeteoHourly[];
+}
+
+interface RawForecastResponse {
+  elevation?: number;
+  hourly_units?: Record<string, string>;
+  daily?: {
+    time?: string[];
+    temperature_2m_max?: Array<number | null>;
+    temperature_2m_min?: Array<number | null>;
+    precipitation_probability_max?: Array<number | null>;
+    precipitation_sum?: Array<number | null>;
+  };
+  hourly?: {
+    time?: string[];
+    temperature_2m?: Array<number | null>;
+    precipitation_probability?: Array<number | null>;
+    precipitation?: Array<number | null>;
+    wind_speed_10m?: Array<number | null>;
+    freezing_level_height?: Array<number | null>;
+  };
+}
+
+function num(v: number | null | undefined): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Elevation-corrected forecast for a point. `elevationM`, when given, is
+ * passed as the `elevation` parameter so temperature/pressure variables
+ * are altitude-adjusted; otherwise Open-Meteo falls back to its own
+ * 90 m DEM lookup.
+ *
+ * With `temperature_unit=fahrenheit`, Open-Meteo also returns
+ * `freezing_level_height` in FEET (verified against `hourly_units`) —
+ * the units block is consulted rather than assumed.
+ */
+export async function getPointForecast(
+  env: Env,
+  opts: {
+    lat: number;
+    lon: number;
+    elevationM?: number;
+    days?: number;
+    startDate?: string;
+    endDate?: string;
+  },
+): Promise<OpenMeteoForecast> {
+  const { lat, lon, elevationM } = opts;
+  const days = Math.min(Math.max(opts.days ?? 7, 1), 16);
+  const params = new URLSearchParams({
+    latitude: String(round5(lat)),
+    longitude: String(round5(lon)),
+    daily: "temperature_2m_max,temperature_2m_min,precipitation_probability_max,precipitation_sum",
+    hourly: "temperature_2m,precipitation_probability,precipitation,wind_speed_10m,freezing_level_height",
+    temperature_unit: "fahrenheit",
+    wind_speed_unit: "mph",
+    precipitation_unit: "inch",
+    timezone: "America/Los_Angeles",
+  });
+  if (typeof elevationM === "number") params.set("elevation", String(Math.round(elevationM)));
+  if (opts.startDate && opts.endDate) {
+    params.set("start_date", opts.startDate);
+    params.set("end_date", opts.endDate);
+  } else {
+    params.set("forecast_days", String(days));
+  }
+
+  const key = `openmeteo:fc:${fnv1a(params.toString())}`;
+  return cached(env, key, TTL.NWS_FORECAST, async () => {
+    const res = await client(env).json<RawForecastResponse>(`${FORECAST_URL}?${params.toString()}`);
+
+    const flUnit = res.hourly_units?.["freezing_level_height"] ?? "m";
+    const toFt = (v: number | null): number | null =>
+      v === null ? null : flUnit === "ft" ? v : v * 3.28084;
+
+    const hourly: OpenMeteoHourly[] = (res.hourly?.time ?? []).map((t, i) => ({
+      time: t,
+      temp_f: num(res.hourly?.temperature_2m?.[i]),
+      precip_probability_pct: num(res.hourly?.precipitation_probability?.[i]),
+      precip_in: num(res.hourly?.precipitation?.[i]),
+      wind_speed_mph: num(res.hourly?.wind_speed_10m?.[i]),
+      freezing_level_ft: roundOrNull(toFt(num(res.hourly?.freezing_level_height?.[i]))),
+    }));
+
+    const daily: OpenMeteoDaily[] = (res.daily?.time ?? []).map((date, i) => {
+      const dayHours = hourly.filter((h) => h.time.startsWith(date));
+      const levels = dayHours
+        .map((h) => h.freezing_level_ft)
+        .filter((v): v is number => v !== null);
+      return {
+        date,
+        temp_max_f: num(res.daily?.temperature_2m_max?.[i]),
+        temp_min_f: num(res.daily?.temperature_2m_min?.[i]),
+        precip_probability_max_pct: num(res.daily?.precipitation_probability_max?.[i]),
+        precip_sum_in: num(res.daily?.precipitation_sum?.[i]),
+        freezing_level_min_ft: levels.length > 0 ? Math.round(Math.min(...levels)) : null,
+        freezing_level_max_ft: levels.length > 0 ? Math.round(Math.max(...levels)) : null,
+      };
+    });
+
+    const modelElevM = typeof res.elevation === "number" ? res.elevation : 0;
+    return { model_elevation_ft: Math.round(modelElevM * 3.28084), daily, hourly };
+  });
+}
+
+function roundOrNull(v: number | null): number | null {
+  return v === null ? null : Math.round(v);
+}

--- a/apps/trip-mcp/src/sources/osm.test.ts
+++ b/apps/trip-mcp/src/sources/osm.test.ts
@@ -1,15 +1,87 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import * as osm from "./osm.js";
+import { expandTrailAliases } from "../areas.js";
 
 describe("osm source", () => {
   it("module loads", () => {
     void osm.findTrails;
     void osm.findTrailheads;
     void osm.findWaterSources;
+    void osm.getOsmGeometry;
+    void osm.findTrailGeometryByName;
   });
 
   it.todo("findTrails returns simplified ways within bbox");
   it.todo("findTrailheads filters to amenity=parking + hiking=yes");
   it.todo("findWaterSources tags springs vs streams correctly");
   it.todo("self-throttle enforces ~1 req/sec");
+});
+
+describe("trailMatchesQuery", () => {
+  const wedenCreek = {
+    name: "Weden Creek Trail",
+    alt_name: "Gothic Basin Trail",
+    official_name: "Weden Creek (Gothic Basin) Trail #724",
+    ref: "724",
+  };
+
+  it("matches the primary name substring, case-insensitively", () => {
+    expect(osm.trailMatchesQuery(wedenCreek, "weden creek")).toBe(true);
+    expect(osm.trailMatchesQuery(wedenCreek, "WEDEN")).toBe(true);
+  });
+
+  it("matches alt_name and official_name, not just name", () => {
+    expect(osm.trailMatchesQuery(wedenCreek, "gothic basin")).toBe(true);
+    expect(osm.trailMatchesQuery({ name: "X", loc_name: "Gothic Basin" }, "gothic")).toBe(true);
+  });
+
+  it("matches USFS trail numbers against ref in all common spellings", () => {
+    expect(osm.trailMatchesQuery(wedenCreek, "724")).toBe(true);
+    expect(osm.trailMatchesQuery(wedenCreek, "Trail 724")).toBe(true);
+    expect(osm.trailMatchesQuery(wedenCreek, "#724")).toBe(true);
+  });
+
+  it("matches semicolon-list refs and prefixed ref values", () => {
+    expect(osm.trailMatchesQuery({ name: "X", ref: "708;724" }, "724")).toBe(true);
+    expect(osm.trailMatchesQuery({ name: "X", ref: "Trail 724" }, "724")).toBe(true);
+  });
+
+  it("does not match unrelated names or numbers", () => {
+    expect(osm.trailMatchesQuery(wedenCreek, "perry creek")).toBe(false);
+    expect(osm.trailMatchesQuery(wedenCreek, "725")).toBe(false);
+    // "72" is not the ref and not a substring of any name.
+    expect(osm.trailMatchesQuery(wedenCreek, "72")).toBe(false);
+  });
+
+  it("empty query matches everything; missing tags match nothing", () => {
+    expect(osm.trailMatchesQuery(wedenCreek, "  ")).toBe(true);
+    expect(osm.trailMatchesQuery(undefined, "weden")).toBe(false);
+  });
+});
+
+describe("osmTrailMatchesQuery", () => {
+  it("matches mapped OsmTrail records across name, alt_names, and ref", () => {
+    const trail = {
+      id: "way/1",
+      name: "Weden Creek Trail",
+      ref: "724",
+      alt_names: ["Gothic Basin Trail"],
+      surface: "",
+      length_m_estimate: 0,
+    };
+    expect(osm.osmTrailMatchesQuery(trail, "gothic basin")).toBe(true);
+    expect(osm.osmTrailMatchesQuery(trail, "724")).toBe(true);
+    expect(osm.osmTrailMatchesQuery(trail, "sahale")).toBe(false);
+  });
+});
+
+describe("expandTrailAliases", () => {
+  it("expands seeded popular names embedded in a query", () => {
+    expect(expandTrailAliases("Gothic Basin")).toEqual(["weden creek"]);
+    expect(expandTrailAliases("gothic basin trail")).toEqual(["weden creek"]);
+  });
+
+  it("returns nothing for unseeded names", () => {
+    expect(expandTrailAliases("sahale arm")).toEqual([]);
+  });
 });

--- a/apps/trip-mcp/src/sources/osm.ts
+++ b/apps/trip-mcp/src/sources/osm.ts
@@ -46,6 +46,13 @@ export interface OsmWaterSource {
   geometry?: Array<{ lat: number; lon: number }>;
 }
 
+interface OverpassMember {
+  type?: string;
+  ref?: number;
+  role?: string;
+  geometry?: Array<{ lat: number; lon: number }>;
+}
+
 interface OverpassElement {
   type: "node" | "way" | "relation";
   id: number;
@@ -55,7 +62,7 @@ interface OverpassElement {
   center?: { lat: number; lon: number };
   tags?: Record<string, string>;
   geometry?: Array<{ lat: number; lon: number }>;
-  members?: unknown[];
+  members?: OverpassMember[];
 }
 
 interface OverpassResponse {
@@ -135,7 +142,129 @@ function geomLengthM(geom: Array<{ lat: number; lon: number }> | undefined): num
   return Math.round(total);
 }
 
+// --- Trail-name matching -------------------------------------------------
+
+/**
+ * Normalize a USFS-style trail-number query — "724", "#724", "Trail 724",
+ * "trail #724" — to the bare number, or null if the query isn't one.
+ */
+function refNumberFromQuery(q: string): string | null {
+  const m = q.trim().match(/^(?:trail\s*)?#?(\d{1,5}(?:\.\d+)?)$/i);
+  return m ? m[1]! : null;
+}
+
+/**
+ * Case-insensitive trail-name match across OSM naming tags, not just
+ * `name`: alt_name, loc_name, official_name, and the USFS trail number
+ * in `ref` (which may be "724", "#724", or a semicolon list). Popular
+ * names often differ from OSM's — "Gothic Basin" is OSM's "Weden Creek
+ * Trail" (USFS #724) — so single-field matching misses real trails.
+ */
+export function trailMatchesQuery(tags: Record<string, string> | undefined, query: string): boolean {
+  const q = query.toLowerCase().trim();
+  if (!q) return true;
+  if (!tags) return false;
+  for (const field of [tags.name, tags.alt_name, tags.loc_name, tags.official_name]) {
+    if (field && field.toLowerCase().includes(q)) return true;
+  }
+  const wanted = refNumberFromQuery(q);
+  if (wanted && tags.ref) {
+    const refs = tags.ref.split(/[;,]/).map((r) => r.trim().replace(/^(?:trail\s*)?#?/i, ""));
+    if (refs.includes(wanted)) return true;
+  }
+  return false;
+}
+
 // --- Public API ----------------------------------------------------------
+
+export interface OsmGeometry {
+  /** e.g. "way/123" or "relation/456" */
+  id: string;
+  name: string;
+  ref?: string;
+  points: Array<{ lat: number; lon: number }>;
+}
+
+/**
+ * Fetch the polyline geometry of one OSM element. Accepts "way/123",
+ * "relation/456", or a bare numeric id (assumed way). For relations,
+ * member-way geometries are concatenated in member order — OSM does not
+ * guarantee ordering, so treat relation output as approximate.
+ */
+export async function getOsmGeometry(env: Env, osmId: string): Promise<OsmGeometry | null> {
+  const m = osmId.trim().match(/^(?:(way|relation)\/)?(\d+)$/i);
+  if (!m) return null;
+  const type = (m[1] ?? "way").toLowerCase();
+  const id = m[2]!;
+  const key = `osm:geom:${type}/${id}`;
+  return cached(env, key, TTL.OSM, async () => {
+    const query = `[out:json][timeout:25];${type}(${id});out tags geom;`;
+    const elements = await runOverpass(env, query);
+    const el = elements[0];
+    if (!el) return null;
+    const points: Array<{ lat: number; lon: number }> = [];
+    if (el.geometry && el.geometry.length > 0) {
+      points.push(...el.geometry);
+    } else if (el.members) {
+      for (const member of el.members) {
+        if (member.type === "way" && member.geometry) points.push(...member.geometry);
+      }
+    }
+    if (points.length === 0) return null;
+    const result: OsmGeometry = {
+      id: `${el.type}/${el.id}`,
+      name: el.tags?.name ?? el.tags?.ref ?? "",
+      points,
+    };
+    if (el.tags?.ref) result.ref = el.tags.ref;
+    return result;
+  });
+}
+
+/**
+ * Find the trail near a point whose naming tags match `query` and return
+ * the longest matching way's geometry. Used by the profile tools to turn
+ * "trail_name + lat/lon hint" into a polyline.
+ */
+export async function findTrailGeometryByName(
+  env: Env,
+  bbox: Bbox,
+  query: string,
+): Promise<OsmGeometry | null> {
+  const key = `osm:trailgeom:${bboxKey(bbox)}:${query.toLowerCase().trim()}`;
+  return cached(env, key, TTL.OSM, async () => {
+    const swne = bboxAsSwne(bbox);
+    const q =
+      `[out:json][timeout:25];` +
+      `(` +
+      `way["highway"~"path|footway|track"]["foot"!~"no"](${swne});` +
+      `relation["route"="hiking"](${swne});` +
+      `);` +
+      `out tags geom;`;
+    const elements = await runOverpass(env, q);
+    let best: OverpassElement | null = null;
+    let bestLen = 0;
+    for (const el of elements) {
+      if (!trailMatchesQuery(el.tags, query)) continue;
+      const geom =
+        el.geometry ??
+        el.members?.flatMap((mem) => (mem.type === "way" && mem.geometry ? mem.geometry : []));
+      const len = geomLengthM(geom);
+      if (geom && geom.length > 1 && len > bestLen) {
+        best = { ...el, geometry: geom };
+        bestLen = len;
+      }
+    }
+    if (!best || !best.geometry) return null;
+    const result: OsmGeometry = {
+      id: `${best.type}/${best.id}`,
+      name: best.tags?.name ?? best.tags?.ref ?? "",
+      points: best.geometry,
+    };
+    if (best.tags?.ref) result.ref = best.tags.ref;
+    return result;
+  });
+}
 
 export async function findTrails(env: Env, bbox: Bbox): Promise<OsmTrail[]> {
   const key = `osm:trails:${bboxKey(bbox)}`;

--- a/apps/trip-mcp/src/sources/osm.ts
+++ b/apps/trip-mcp/src/sources/osm.ts
@@ -21,6 +21,10 @@ export type Bbox = [number, number, number, number];
 export interface OsmTrail {
   id: string;
   name: string;
+  /** USFS trail number when tagged (`ref`, e.g. "724"). */
+  ref?: string;
+  /** Other OSM naming tags: alt_name, loc_name, official_name. */
+  alt_names?: string[];
   surface: string;
   length_m_estimate: number;
 }
@@ -154,25 +158,49 @@ function refNumberFromQuery(q: string): string | null {
 }
 
 /**
- * Case-insensitive trail-name match across OSM naming tags, not just
- * `name`: alt_name, loc_name, official_name, and the USFS trail number
- * in `ref` (which may be "724", "#724", or a semicolon list). Popular
- * names often differ from OSM's — "Gothic Basin" is OSM's "Weden Creek
- * Trail" (USFS #724) — so single-field matching misses real trails.
+ * Case-insensitive trail-name match across a set of candidate names and
+ * an optional USFS trail number (`ref`, which may be "724", "#724", or a
+ * semicolon list). Popular names often differ from OSM's — "Gothic
+ * Basin" is OSM's "Weden Creek Trail" (USFS #724) — so single-field
+ * matching misses real trails.
  */
-export function trailMatchesQuery(tags: Record<string, string> | undefined, query: string): boolean {
+export function namesMatchQuery(
+  names: Array<string | undefined>,
+  ref: string | undefined,
+  query: string,
+): boolean {
   const q = query.toLowerCase().trim();
   if (!q) return true;
-  if (!tags) return false;
-  for (const field of [tags.name, tags.alt_name, tags.loc_name, tags.official_name]) {
+  const wanted = refNumberFromQuery(q);
+  if (wanted) {
+    // Numeric-style query ("724", "Trail 724", "#724"): whole-number
+    // matches only, so "72" can't hit the "#724" inside a name.
+    if (ref) {
+      const refs = ref.split(/[;,]/).map((r) => r.trim().replace(/^(?:trail\s*)?#?/i, ""));
+      if (refs.includes(wanted)) return true;
+    }
+    const numRe = new RegExp(`(^|[^\\d.])${wanted.replace(".", "\\.")}([^\\d.]|$)`);
+    return names.some((field) => field !== undefined && numRe.test(field));
+  }
+  for (const field of names) {
     if (field && field.toLowerCase().includes(q)) return true;
   }
-  const wanted = refNumberFromQuery(q);
-  if (wanted && tags.ref) {
-    const refs = tags.ref.split(/[;,]/).map((r) => r.trim().replace(/^(?:trail\s*)?#?/i, ""));
-    if (refs.includes(wanted)) return true;
-  }
   return false;
+}
+
+/** namesMatchQuery over raw OSM tags (name, alt_name, loc_name, official_name, ref). */
+export function trailMatchesQuery(tags: Record<string, string> | undefined, query: string): boolean {
+  if (!tags) return !query.trim();
+  return namesMatchQuery(
+    [tags.name, tags.alt_name, tags.loc_name, tags.official_name],
+    tags.ref,
+    query,
+  );
+}
+
+/** namesMatchQuery over a mapped OsmTrail record. */
+export function osmTrailMatchesQuery(trail: OsmTrail, query: string): boolean {
+  return namesMatchQuery([trail.name, ...(trail.alt_names ?? [])], trail.ref, query);
 }
 
 // --- Public API ----------------------------------------------------------
@@ -278,12 +306,20 @@ export async function findTrails(env: Env, bbox: Bbox): Promise<OsmTrail[]> {
       `);` +
       `out tags geom;`;
     const elements = await runOverpass(env, query);
-    return elements.map((el) => ({
-      id: `${el.type}/${el.id}`,
-      name: el.tags?.name ?? el.tags?.ref ?? "",
-      surface: el.tags?.surface ?? el.tags?.["trail_visibility"] ?? "",
-      length_m_estimate: geomLengthM(el.geometry),
-    }));
+    return elements.map((el) => {
+      const trail: OsmTrail = {
+        id: `${el.type}/${el.id}`,
+        name: el.tags?.name ?? el.tags?.ref ?? "",
+        surface: el.tags?.surface ?? el.tags?.["trail_visibility"] ?? "",
+        length_m_estimate: geomLengthM(el.geometry),
+      };
+      if (el.tags?.ref) trail.ref = el.tags.ref;
+      const altNames = [el.tags?.alt_name, el.tags?.loc_name, el.tags?.official_name].filter(
+        (n): n is string => Boolean(n),
+      );
+      if (altNames.length > 0) trail.alt_names = altNames;
+      return trail;
+    });
   });
 }
 

--- a/apps/trip-mcp/src/sources/wsdot.test.ts
+++ b/apps/trip-mcp/src/sources/wsdot.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect } from "vitest";
 import * as wsdot from "./wsdot.js";
+import type { Env } from "../types.js";
 
 describe("wsdot source", () => {
   it("module loads", () => {
     void wsdot.getMountainPassConditions;
     void wsdot.findPassByName;
+  });
+
+  it("names the missing WSDOT_API_KEY secret instead of a bare 401", async () => {
+    const env = { WSDOT_API_KEY: "", CONTACT: "test@example.com" } as Env;
+    await expect(wsdot.getMountainPassConditions(env)).rejects.toThrow(
+      /missing WSDOT_API_KEY secret/,
+    );
   });
 
   it("findPassByName does case-insensitive contains match", () => {

--- a/apps/trip-mcp/src/sources/wsdot.ts
+++ b/apps/trip-mcp/src/sources/wsdot.ts
@@ -50,19 +50,26 @@ function client(env: Env) {
 export async function getMountainPassConditions(env: Env): Promise<MountainPassCondition[]> {
   const key = "wsdot:passes";
   return cached(env, key, TTL.WSDOT_PASS, async () => {
+    if (!env.WSDOT_API_KEY) {
+      throw new Error(
+        "missing WSDOT_API_KEY secret — get a free access code at wsdot.wa.gov/traffic/api/ and `wrangler secret put WSDOT_API_KEY`",
+      );
+    }
     const c = client(env);
     const url = `${ENDPOINT}?AccessCode=${encodeURIComponent(env.WSDOT_API_KEY)}`;
     // Probe raw first so we can log diagnostics on auth/format failures.
     const rawRes = await c.fetch(url);
     const text = await rawRes.text();
     if (!rawRes.ok) {
-      const keyHint = env.WSDOT_API_KEY
-        ? `present(len=${env.WSDOT_API_KEY.length})`
-        : "MISSING";
       console.warn(
-        `WSDOT ${rawRes.status} ${rawRes.statusText} key=${keyHint} ` +
+        `WSDOT ${rawRes.status} ${rawRes.statusText} key=present(len=${env.WSDOT_API_KEY.length}) ` +
           `body[0:300]=${text.slice(0, 300).replace(/\s+/g, " ")}`,
       );
+      if (rawRes.status === 401) {
+        throw new Error(
+          "wsdot_http_401 — AccessCode rejected; the WSDOT_API_KEY secret is likely expired or rotated. Re-issue at wsdot.wa.gov/traffic/api/ and `wrangler secret put WSDOT_API_KEY`",
+        );
+      }
       throw new Error(`wsdot_http_${rawRes.status}`);
     }
     let res: RawPassCondition[];

--- a/apps/trip-mcp/src/sources/wta.test.ts
+++ b/apps/trip-mcp/src/sources/wta.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseHikeListing,
+  parseHikePage,
   parseTripReport,
   parseTripReportListing,
 } from "./wta.js";
@@ -247,5 +248,61 @@ describe("parseHikeListing", () => {
 
   it("returns [] on empty input", () => {
     expect(parseHikeListing("")).toEqual([]);
+  });
+});
+
+// Reduced from the live /go-hiking/hikes/gothic-basin page (probed
+// 2026-08-02): JSON-LD GeoCoordinates + map payload + hike-stats <dl>.
+const HIKE_PAGE_FIXTURE = `
+<script type="application/ld+json">
+{"@context": "https://schema.org", "@type": "TouristAttraction", "name": "Gothic Basin",
+ "aggregateRating": {"@type": "AggregateRating", "ratingValue": 4.6},
+ "geo": {"@type": "GeoCoordinates", "latitude": 48.0261166667, "longitude": -121.4425}}
+</script>
+<h1 class="documentFirstHeading">Gothic Basin</h1>
+<div class="hike-region"><span>North Cascades -- Mountain Loop Highway</span></div>
+<dl class="hike-stats grid-container grid-container--auto-small">
+  <div class="hike-stats__stat">
+    <dt> <img alt="" src="/distance.svg" /> Length </dt>
+    <dd>9.2 miles, roundtrip</dd>
+  </div>
+  <div class="hike-stats__stat">
+    <dt> <img alt="" src="/elevationgain.svg" /> Elevation Gain </dt>
+    <dd> 2,840 feet </dd>
+  </div>
+  <div class="hike-stats__stat">
+    <dt> <img alt="" src="/highest-point.svg" /> Highest Point </dt>
+    <dd> 5,200 feet </dd>
+  </div>
+</dl>
+<script>
+  hike = {"trailhead": [-121.4425, 48.0261166667], "id": "gothic-basin", "title": "Gothic Basin"};
+</script>`;
+
+describe("parseHikePage", () => {
+  it("extracts coordinates from JSON-LD geo plus stats from the hike-stats dl", () => {
+    const out = parseHikePage(HIKE_PAGE_FIXTURE, "https://www.wta.org/go-hiking/hikes/gothic-basin");
+    expect(out).toMatchObject({
+      hike_name: "Gothic Basin",
+      lat: 48.0261166667,
+      lon: -121.4425,
+      length_miles: 9.2,
+      gain_ft: 2840,
+      highest_point_ft: 5200,
+    });
+  });
+
+  it("falls back to the lon-first trailhead array when JSON-LD geo is absent", () => {
+    const noGeo = HIKE_PAGE_FIXTURE.replace(/"geo":[^}]*\}\}/, '"x": 1}');
+    const out = parseHikePage(noGeo, "https://www.wta.org/go-hiking/hikes/gothic-basin");
+    expect(out.lat).toBeCloseTo(48.0261166667, 6);
+    expect(out.lon).toBeCloseTo(-121.4425, 6);
+  });
+
+  it("returns nulls, never throws, on unrecognized markup", () => {
+    const out = parseHikePage("<html><body>redesigned</body></html>", "https://www.wta.org/x");
+    expect(out.lat).toBeNull();
+    expect(out.lon).toBeNull();
+    expect(out.length_miles).toBeNull();
   });
 });

--- a/apps/trip-mcp/src/sources/wta.ts
+++ b/apps/trip-mcp/src/sources/wta.ts
@@ -504,6 +504,97 @@ export function parseHikeListing(html: string): HikeSummary[] {
   return out;
 }
 
+/* --------------------------- hike detail ---------------------------- */
+
+export interface HikeDetail {
+  url: string;
+  hike_name: string | null;
+  /** Trailhead coordinates (WTA's GeoCoordinates / trailhead marker). */
+  lat: number | null;
+  lon: number | null;
+  length_miles: number | null;
+  gain_ft: number | null;
+  highest_point_ft: number | null;
+  region: string | null;
+}
+
+export async function getHikeDetail(env: Env, hikeUrl: string): Promise<HikeDetail | null> {
+  const url = absUrl(hikeUrl);
+  const key = `wta:hike:${url}`;
+  return cached(env, key, TTL.WTA_LIST, async () => {
+    try {
+      const res = await rateLimitedFetch(env, url);
+      if (!res.ok) return null;
+      const html = await res.text();
+      return parseHikePage(html, url);
+    } catch (e) {
+      console.warn("[wta.getHikeDetail] failed:", (e as Error).message);
+      return null;
+    }
+  });
+}
+
+/**
+ * Parse a /go-hiking/hikes/SLUG page (probed 2026-08-02):
+ *
+ *   - Coordinates: JSON-LD `"geo": {"@type": "GeoCoordinates",
+ *     "latitude": 48.0261166667, "longitude": -121.4425}`; fallback to
+ *     the inline map payload `"trailhead": [-121.4425, 48.0261166667]`
+ *     (LON-first — GeoJSON ordering).
+ *   - Stats: `<dl class="hike-stats …">` with per-stat
+ *     `<dt>… Length </dt><dd>9.2 miles, roundtrip</dd>`,
+ *     `<dt>… Elevation Gain </dt><dd> 2,840 feet </dd>`,
+ *     `<dt>… Highest Point </dt><dd> 5,200 feet </dd>`.
+ */
+export function parseHikePage(html: string, url: string): HikeDetail {
+  const h1M = html.match(
+    /<h1[^>]*class="[^"]*documentFirstHeading[^"]*"[^>]*>([\s\S]*?)<\/h1>/i,
+  );
+
+  let lat: number | null = null;
+  let lon: number | null = null;
+  const geoM = html.match(
+    /"geo"\s*:\s*\{[^}]*"latitude"\s*:\s*(-?\d+(?:\.\d+)?)\s*,\s*"longitude"\s*:\s*(-?\d+(?:\.\d+)?)/i,
+  );
+  if (geoM) {
+    lat = Number.parseFloat(geoM[1]!);
+    lon = Number.parseFloat(geoM[2]!);
+  } else {
+    // Map payload is [lon, lat] (GeoJSON ordering).
+    const thM = html.match(
+      /"trailhead"\s*:\s*\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]/i,
+    );
+    if (thM) {
+      lon = Number.parseFloat(thM[1]!);
+      lat = Number.parseFloat(thM[2]!);
+    }
+  }
+
+  const statValue = (label: string): string | null => {
+    const re = new RegExp(
+      `<dt[^>]*>[\\s\\S]{0,400}?${label}\\s*<\\/dt>\\s*<dd[^>]*>([\\s\\S]*?)<\\/dd>`,
+      "i",
+    );
+    const m = html.match(re);
+    return m ? stripTags(m[1]!) : null;
+  };
+
+  const regionM =
+    html.match(/class="[^"]*hike-region[^"]*"[^>]*>[\s\S]{0,200}?<span[^>]*>([\s\S]*?)<\/span>/i) ??
+    html.match(/class="[^"]*region[^"]*"[^>]*>([\s\S]*?)<\//i);
+
+  return {
+    url,
+    hike_name: h1M ? stripTags(h1M[1]!) : null,
+    lat: Number.isFinite(lat ?? NaN) ? lat : null,
+    lon: Number.isFinite(lon ?? NaN) ? lon : null,
+    length_miles: parseNumber(statValue("Length")),
+    gain_ft: parseNumber(statValue("Elevation\\s+Gain")),
+    highest_point_ft: parseNumber(statValue("Highest\\s+Point")),
+    region: regionM ? stripTags(regionM[1]!) : null,
+  };
+}
+
 function parseNumber(raw: string | undefined | null): number | null {
   if (!raw) return null;
   const m = stripTags(raw).replace(/,/g, "").match(/-?\d+(\.\d+)?/);

--- a/apps/trip-mcp/src/tools/elevation_profile.ts
+++ b/apps/trip-mcp/src/tools/elevation_profile.ts
@@ -1,0 +1,165 @@
+/**
+ * get_elevation_profile: distance-indexed elevation series along a trail
+ * polyline. Resolves the polyline (points | osm_id | trail_name+hint),
+ * resamples to <=100 evenly spaced points, and fetches elevations in ONE
+ * Open-Meteo Elevation API batch (Copernicus GLO-90 DEM). Degrades to a
+ * distance-only profile with null elevations if the provider fails.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Confidence, Env, Source, ToolPayload } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import {
+  ELEVATION_BATCH_LIMIT,
+  OPEN_METEO_ATTRIBUTION,
+  getElevationsMeters,
+} from "../sources/openmeteo.js";
+import { metersToFeet, resamplePolyline, type ProfilePoint } from "../polyline.js";
+import { payloadResponse, titledTool } from "./utils.js";
+import { profileInputSchema, resolvePolyline } from "./profile_shared.js";
+
+export interface ElevationProfileEntry {
+  mile: number;
+  lat: number;
+  lon: number;
+  elevation_ft: number | null;
+}
+
+interface ElevationProfileData {
+  resolved_from: "points" | "osm_id" | "trail_name";
+  osm_id?: string;
+  matched_name?: string;
+  profile: ElevationProfileEntry[];
+  total_distance_mi: number;
+  total_gain_ft: number | null;
+  total_loss_ft: number | null;
+  min_elevation_ft: number | null;
+  max_elevation_ft: number | null;
+}
+
+export function buildProfileEntries(
+  sampled: ProfilePoint[],
+  elevationsM: Array<number | null>,
+): ElevationProfileEntry[] {
+  return sampled.map((p, i) => {
+    const m = elevationsM[i];
+    return {
+      mile: p.mile,
+      lat: Math.round(p.lat * 1e5) / 1e5,
+      lon: Math.round(p.lon * 1e5) / 1e5,
+      elevation_ft: typeof m === "number" ? Math.round(metersToFeet(m)) : null,
+    };
+  });
+}
+
+export function profileStats(entries: ElevationProfileEntry[]): {
+  total_gain_ft: number | null;
+  total_loss_ft: number | null;
+  min_elevation_ft: number | null;
+  max_elevation_ft: number | null;
+} {
+  const elevs = entries.map((e) => e.elevation_ft).filter((v): v is number => v !== null);
+  if (elevs.length === 0) {
+    return {
+      total_gain_ft: null,
+      total_loss_ft: null,
+      min_elevation_ft: null,
+      max_elevation_ft: null,
+    };
+  }
+  let gain = 0;
+  let loss = 0;
+  let prev: number | null = null;
+  for (const e of entries) {
+    if (e.elevation_ft === null) continue;
+    if (prev !== null) {
+      const d = e.elevation_ft - prev;
+      if (d > 0) gain += d;
+      else loss -= d;
+    }
+    prev = e.elevation_ft;
+  }
+  return {
+    total_gain_ft: Math.round(gain),
+    total_loss_ft: Math.round(loss),
+    min_elevation_ft: Math.min(...elevs),
+    max_elevation_ft: Math.max(...elevs),
+  };
+}
+
+export function registerElevationProfileTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_elevation_profile",
+    "Sampling elevation profile…",
+    "Distance-indexed elevation profile along a trail polyline — the missing piece for \"chart this trail's elevation\" asks. Input precedence: (1) `points` as [lat,lon] pairs (e.g. from a GPX the user supplied), (2) `osm_id` ('way/123' / 'relation/123' / bare way id), (3) `trail_name` + lat/lon hint resolved via OpenStreetMap (matches OSM name, alt_name, loc_name, official_name, and USFS trail number). Output: `profile[]` of {mile, lat, lon, elevation_ft} with cumulative miles from the first point, plus total distance/gain/loss and min/max elevation. Inputs longer than 100 points are resampled DOWN to `samples` evenly spaced points (never multiple serial upstream batches). Elevations come from the Open-Meteo Elevation API (Copernicus GLO-90 DEM, 90 m resolution, <~4 m vertical error) — profiles are approximations of the mapped line, NOT surveyed track data; short steep features between samples are smoothed out. If the elevation provider fails, the distance-resampled polyline is returned with elevation_ft null and a named caveat.",
+    {
+      ...profileInputSchema,
+      samples: z
+        .number()
+        .int()
+        .min(2)
+        .max(ELEVATION_BATCH_LIMIT)
+        .default(50)
+        .describe("Target sample count along the line (max 100 = one Open-Meteo batch). Default 50."),
+    },
+    async (args) => {
+      const resolved = await resolvePolyline(env, args);
+      if ("error" in resolved) {
+        return payloadResponse(empty<ElevationProfileData>([resolved.error]));
+      }
+
+      const sampled = resamplePolyline(resolved.points, args.samples);
+      const caveats = [
+        ...resolved.caveats,
+        "Elevations from a 90 m DEM (Copernicus GLO-90) — approximate; short steep features between samples are smoothed out.",
+      ];
+      const sources: Source[] = [];
+      if (resolved.resolved_from !== "points") {
+        sources.push(
+          makeSource(
+            "https://overpass-api.de/api/interpreter",
+            "OpenStreetMap (Overpass API) — trail geometry",
+            { license: "ODbL", confidence: "medium" },
+          ),
+        );
+      }
+
+      let elevations: Array<number | null>;
+      let elevationOk = true;
+      try {
+        elevations = await getElevationsMeters(env, sampled);
+        sources.push(
+          makeSource("https://open-meteo.com/en/docs/elevation-api", OPEN_METEO_ATTRIBUTION, {
+            license: "CC BY 4.0",
+            confidence: "medium",
+          }),
+        );
+      } catch (e) {
+        elevationOk = false;
+        elevations = sampled.map(() => null);
+        caveats.push(
+          `open_meteo_elevation: ${e instanceof Error ? e.message : String(e)} — returning distance-only profile with null elevations.`,
+        );
+      }
+
+      const profile = buildProfileEntries(sampled, elevations);
+      const stats = profileStats(profile);
+      const lastEntry = profile[profile.length - 1];
+
+      const data: ElevationProfileData = {
+        resolved_from: resolved.resolved_from,
+        ...(resolved.osm_id ? { osm_id: resolved.osm_id } : {}),
+        ...(resolved.matched_name ? { matched_name: resolved.matched_name } : {}),
+        profile,
+        total_distance_mi: lastEntry ? lastEntry.mile : 0,
+        ...stats,
+      };
+
+      const confidence: Confidence = elevationOk ? "medium" : "low";
+      const payload: ToolPayload<ElevationProfileData> = ok(data, sources, confidence, caveats);
+      return payloadResponse(payload);
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/find_areas.ts
+++ b/apps/trip-mcp/src/tools/find_areas.ts
@@ -1,9 +1,64 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { AREAS, findAreaById, findAreaWithMatch, type Area } from "../areas.js";
-import type { Env } from "../types.js";
-import { ok, makeSource } from "../types.js";
+import type { Env, Source } from "../types.js";
+import { ok, makeSource, nowIso } from "../types.js";
+import { getHikeDetail, searchHikes } from "../sources/wta.js";
 import { payloadResponse, titledTool } from "./utils.js";
+
+/**
+ * Off-registry record synthesized from WTA's hiking guide when the
+ * curated registry has no match. Per-request only — never added to the
+ * registry, and carries no `area_id` (downstream tools must be called
+ * with this record's lat/lon).
+ */
+interface WtaFallbackRecord {
+  source: "wta_fallback";
+  name: string;
+  lat: number;
+  lon: number;
+  length_miles: number | null;
+  elevation_gain_ft: number | null;
+  highest_point_ft: number | null;
+  region: string | null;
+  wta_url: string;
+  alternates: Array<{ hike_name: string; url: string; region: string | null }>;
+}
+
+/**
+ * Resolve an off-registry query against WTA's hiking guide (3,500+ WA
+ * trails). Scrape-backed, so this fails soft: any error or missing
+ * coordinate degrades to null and the caller keeps the empty-registry
+ * behavior.
+ */
+async function wtaFallback(env: Env, query: string): Promise<WtaFallbackRecord | null> {
+  try {
+    const hits = await searchHikes(env, query);
+    const top = hits[0];
+    if (!top) return null;
+    const detail = await getHikeDetail(env, top.url);
+    if (!detail || detail.lat === null || detail.lon === null) return null;
+    return {
+      source: "wta_fallback",
+      name: detail.hike_name ?? top.hike_name,
+      lat: detail.lat,
+      lon: detail.lon,
+      length_miles: detail.length_miles ?? top.length_miles,
+      elevation_gain_ft: detail.gain_ft ?? top.gain_ft,
+      highest_point_ft: detail.highest_point_ft,
+      region: detail.region ?? top.region,
+      wta_url: detail.url,
+      alternates: hits.slice(1, 4).map((h) => ({
+        hike_name: h.hike_name,
+        url: h.url,
+        region: h.region,
+      })),
+    };
+  } catch (e) {
+    console.warn("[find_areas.wtaFallback] failed:", (e as Error).message);
+    return null;
+  }
+}
 
 interface AreaSummary {
   id: string;
@@ -35,13 +90,12 @@ function summarize(area: Area, match_reason?: string): AreaSummary {
   };
 }
 
-export function registerFindAreasTools(server: McpServer, _env: Env): void {
-  void _env;
+export function registerFindAreasTools(server: McpServer, env: Env): void {
   titledTool(
     server,
     "find_areas",
     "Finding wilderness areas…",
-    "Resolve free-text area queries to canonical area records from the curated PNW registry (currently 12 hand-curated areas: Enchantments, Mt Rainier, North Cascades NP, Olympic NP, Glacier Peak Wilderness, Pasayten, Alpine Lakes Wilderness, Henry M. Jackson Wilderness, Goat Rocks, Mt St Helens, Mt Adams, Mt Baker). Returns area IDs that all other tools accept as `area_id`. This is the right first call for any vague PNW query like \"somewhere in the North Cascades\" or when you're not sure of the canonical area name. For areas outside the registry the response is empty — fall back to `web_research` for the trip details and use `get_weather` with explicit lat/lon. Match types: \"Exact name/alias match\" (high confidence), \"Substring/partial match\" (medium confidence — verify the resolved area is what the user actually meant before relying on it). If the resolved area looks wrong given the user's full query, surface that to the user and re-query with a more distinctive term.",
+    "Resolve free-text area queries to canonical area records from the curated PNW registry (currently 12 hand-curated areas: Enchantments, Mt Rainier, North Cascades NP, Olympic NP, Glacier Peak Wilderness, Pasayten, Alpine Lakes Wilderness, Henry M. Jackson Wilderness, Goat Rocks, Mt St Helens, Mt Adams, Mt Baker). Returns area IDs that all other tools accept as `area_id`. This is the right first call for any vague PNW query like \"somewhere in the North Cascades\" or when you're not sure of the canonical area name. Registry matches always take precedence. When the registry has NO match for a named query, the tool attempts a WTA hiking-guide fallback and, on success, returns a `wta_fallback` record (name, trailhead lat/lon, mileage, elevation gain, highest point, WTA URL) at medium-or-lower confidence. Fallback records have NO `area_id` — call downstream tools (get_weather, get_conditions, get_route_info, profile tools) with the record's lat/lon instead. If the WTA lookup also fails, fall back to `web_research`. Match types: \"Exact name/alias match\" (high confidence), \"Substring/partial match\" (medium confidence — verify the resolved area is what the user actually meant before relying on it). If the resolved area looks wrong given the user's full query, surface that to the user and re-query with a more distinctive term.",
     {
       query: z
         .string()
@@ -114,7 +168,7 @@ export function registerFindAreasTools(server: McpServer, _env: Env): void {
         summarize(area, match_reason),
       );
 
-      const sources = [
+      const sources: Source[] = [
         makeSource(
           "https://github.com/tusensii/mcp-stack/blob/main/apps/trip-mcp/src/areas.ts",
           "trip-mcp canonical PNW areas registry (hand-curated)",
@@ -123,10 +177,31 @@ export function registerFindAreasTools(server: McpServer, _env: Env): void {
       ];
 
       const caveats: string[] = [];
-      if (results.length === 0) {
+
+      // Off-registry fallback: only when a named query resolved to nothing
+      // in the registry (filter-driven empties are answers, not misses).
+      let fallback: WtaFallbackRecord | null = null;
+      if (args.query && pool.length === 0) {
+        fallback = await wtaFallback(env, args.query);
+        if (fallback) {
+          sources.push(
+            makeSource(fallback.wta_url, "Washington Trails Association hiking guide", {
+              license: "Washington Trails Association — content used with attribution",
+              confidence: "medium",
+              fetched_at: nowIso(),
+            }),
+          );
+          caveats.push(
+            "Result is a WTA hiking-guide fallback (scraped, medium confidence at best), not a registry area. " +
+              "It has no area_id — pass its lat/lon to downstream tools. Verify it matches the intended trail via the wta_url.",
+          );
+        }
+      }
+
+      if (results.length === 0 && !fallback) {
         caveats.push(
-          "No areas matched. The registry covers ~12 high-value PNW destinations. " +
-            "For obscure routes, call `web_research` directly.",
+          "No areas matched. The registry covers ~12 high-value PNW destinations, and the " +
+            "WTA hiking-guide fallback found nothing usable. For obscure routes, call `web_research` directly.",
         );
       }
       if (matchKind === "partial") {
@@ -144,12 +219,23 @@ export function registerFindAreasTools(server: McpServer, _env: Env): void {
 
       const confidence: "high" | "medium" | "low" =
         results.length === 0
-          ? "low"
+          ? fallback
+            ? "medium"
+            : "low"
           : matchKind === "id" || matchKind === "exact"
             ? "high"
             : "medium";
       return payloadResponse(
-        ok({ results, total_in_registry: AREAS.length }, sources, confidence, caveats),
+        ok(
+          {
+            results,
+            total_in_registry: AREAS.length,
+            ...(fallback ? { wta_fallback: fallback } : {}),
+          },
+          sources,
+          confidence,
+          caveats,
+        ),
       );
     },
   );

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerConditionsTools } from "./conditions.js";
 import { registerTripReportTools } from "./trip_reports.js";
 import { registerRouteInfoTools } from "./route_info.js";
 import { registerElevationProfileTools } from "./elevation_profile.js";
+import { registerTrailWeatherProfileTools } from "./trail_weather_profile.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -19,6 +20,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerTripReportTools(server, env);
   registerRouteInfoTools(server, env);
   registerElevationProfileTools(server, env);
+  registerTrailWeatherProfileTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -6,6 +6,7 @@ import { registerWeatherTools } from "./weather.js";
 import { registerConditionsTools } from "./conditions.js";
 import { registerTripReportTools } from "./trip_reports.js";
 import { registerRouteInfoTools } from "./route_info.js";
+import { registerElevationProfileTools } from "./elevation_profile.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -17,6 +18,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerConditionsTools(server, env);
   registerTripReportTools(server, env);
   registerRouteInfoTools(server, env);
+  registerElevationProfileTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/profile_shared.ts
+++ b/apps/trip-mcp/src/tools/profile_shared.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared polyline-input resolution for `get_elevation_profile` and
+ * `get_trail_weather_profile`. Both accept the same three input shapes,
+ * with this precedence:
+ *
+ *   1. `points` — caller-provided [lat, lon] array (e.g. parsed GPX)
+ *   2. `osm_id` — "way/123" / "relation/456" / bare way id
+ *   3. `trail_name` + lat/lon hint — Overpass name/alias/ref match
+ */
+
+import { z } from "zod";
+import type { Env } from "../types.js";
+import { findTrailGeometryByName, getOsmGeometry } from "../sources/osm.js";
+import { bboxAroundPoint, type PolyPoint } from "../polyline.js";
+
+export const profileInputSchema = {
+  points: z
+    .array(z.tuple([z.number().min(-90).max(90), z.number().min(-180).max(180)]))
+    .min(2)
+    .max(2000)
+    .optional()
+    .describe(
+      "Polyline as [lat, lon] pairs (e.g. parsed from a GPX). Takes precedence over osm_id and trail_name.",
+    ),
+  osm_id: z
+    .string()
+    .optional()
+    .describe(
+      "OSM element id — 'way/123456', 'relation/123456', or a bare way id. Used when `points` is absent.",
+    ),
+  trail_name: z
+    .string()
+    .optional()
+    .describe(
+      "Trail name to resolve via OpenStreetMap near the lat/lon hint. Matches OSM name, alt_name, loc_name, official_name, and USFS trail number (ref). Lowest precedence.",
+    ),
+  lat: z.number().min(-90).max(90).optional().describe("Latitude hint — required with trail_name."),
+  lon: z
+    .number()
+    .min(-180)
+    .max(180)
+    .optional()
+    .describe("Longitude hint — required with trail_name."),
+  radius_km: z
+    .number()
+    .min(0.5)
+    .max(25)
+    .default(5)
+    .describe("Search radius around the hint for trail_name resolution. Default 5."),
+};
+
+export interface ResolvedPolyline {
+  points: PolyPoint[];
+  resolved_from: "points" | "osm_id" | "trail_name";
+  /** Set when geometry came from OSM. */
+  osm_id?: string;
+  /** OSM name of the matched element, when resolved via OSM. */
+  matched_name?: string;
+  caveats: string[];
+}
+
+export interface ProfileArgs {
+  points?: Array<[number, number]>;
+  osm_id?: string;
+  trail_name?: string;
+  lat?: number;
+  lon?: number;
+  radius_km: number;
+}
+
+/** Returns the resolved polyline, or a caveat list explaining why not. */
+export async function resolvePolyline(
+  env: Env,
+  args: ProfileArgs,
+): Promise<ResolvedPolyline | { error: string }> {
+  if (args.points && args.points.length >= 2) {
+    return {
+      points: args.points.map(([lat, lon]) => ({ lat, lon })),
+      resolved_from: "points",
+      caveats: [],
+    };
+  }
+
+  if (args.osm_id) {
+    const geom = await getOsmGeometry(env, args.osm_id);
+    if (!geom) {
+      return { error: `OSM element not found or has no geometry: ${args.osm_id}` };
+    }
+    const out: ResolvedPolyline = {
+      points: geom.points,
+      resolved_from: "osm_id",
+      osm_id: geom.id,
+      caveats: geom.id.startsWith("relation/")
+        ? ["Relation geometry concatenated in member order; OSM does not guarantee ordering — mileage may be off if members are unsorted."]
+        : [],
+    };
+    if (geom.name) out.matched_name = geom.name;
+    return out;
+  }
+
+  if (args.trail_name) {
+    if (typeof args.lat !== "number" || typeof args.lon !== "number") {
+      return { error: "trail_name resolution requires both lat and lon as a location hint." };
+    }
+    const bbox = bboxAroundPoint(args.lat, args.lon, args.radius_km);
+    const geom = await findTrailGeometryByName(env, bbox, args.trail_name);
+    if (!geom) {
+      return {
+        error:
+          `No OSM trail matching "${args.trail_name}" within ${args.radius_km} km of ` +
+          `(${args.lat}, ${args.lon}). Try get_route_info without a name filter to list nearby trails, or pass points/osm_id directly.`,
+      };
+    }
+    const out: ResolvedPolyline = {
+      points: geom.points,
+      resolved_from: "trail_name",
+      osm_id: geom.id,
+      caveats: [
+        "Trail resolved to the single longest matching OSM way — long trails split across several ways may be truncated; pass osm_id or points for the full line.",
+      ],
+    };
+    if (geom.name) out.matched_name = geom.name;
+    return out;
+  }
+
+  return { error: "Provide one of: points ([lat,lon] pairs), osm_id, or trail_name with lat/lon." };
+}

--- a/apps/trip-mcp/src/tools/route_info.ts
+++ b/apps/trip-mcp/src/tools/route_info.ts
@@ -9,11 +9,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Confidence, Env, Source, ToolPayload } from "../types.js";
 import { empty, makeSource, ok } from "../types.js";
-import { findAreaById } from "../areas.js";
+import { expandTrailAliases, findAreaById } from "../areas.js";
 import {
   findTrails,
   findTrailheads,
   findWaterSources,
+  osmTrailMatchesQuery,
   type Bbox,
   type OsmTrail,
   type OsmTrailhead,
@@ -39,7 +40,7 @@ interface RouteInfoData {
 
 const STANDARD_CAVEATS = [
   "Trail data sourced from OpenStreetMap; verify with current trail map before trip.",
-  "Elevation profile not computed — request lat/lon polyline for full profile.",
+  "Only centroid elevation computed here — call get_elevation_profile (points, osm_id, or trail_name) for a distance-indexed profile.",
 ];
 
 /** Earth radius in km for crude lat/lon ↔ km conversion. */
@@ -77,7 +78,7 @@ export function registerRouteInfoTools(server: McpServer, env: Env): void {
     server,
     "get_route_info",
     "Reviewing route details…",
-    "Returns trailheads, trails, water sources, and centroid elevation around a PNW area or arbitrary point. Pulls from OpenStreetMap (trails, parking, springs, streams, rivers) and USGS 3DEP (elevation). Trails are trimmed to the longest 10 by estimated length. Returns both `water_sources_within_500m` (strict — for \"is there water near camp\") and `water_sources_in_area` (radius-wide — for \"what water do I cross on this trail\"). Use this for first-pass route scouting; ALWAYS verify with a real trail map (Green Trails, USGS quad, or CalTopo) before the trip — OSM trail data has gaps and labels can be wrong. If you already have an `area_id` from `find_areas` or a prior tool call, pass it directly to avoid re-resolution. USGS elevation is sometimes flaky; if `centroid_elevation_ft` is null the source is omitted from citations and a caveat is added — surface the missing elevation to the user rather than inventing one.",
+    "Returns trailheads, trails, water sources, and centroid elevation around a PNW area or arbitrary point. Pulls from OpenStreetMap (trails, parking, springs, streams, rivers) and USGS 3DEP (elevation). Trails are trimmed to the longest 10 by estimated length. `trail_name` matches case-insensitively against OSM name, alt_name, loc_name, official_name, AND the USFS trail number in `ref` — so \"724\" or \"Trail 724\" finds Weden Creek Trail #724, and seeded popular-name aliases (e.g. \"Gothic Basin\" → Weden Creek) are expanded automatically. If the name filter matches nothing but trails exist in the radius, the UNFILTERED trail list is returned with an explanatory caveat instead of an empty array — check caveats before concluding \"no trails here\". Returns both `water_sources_within_500m` (strict — for \"is there water near camp\") and `water_sources_in_area` (radius-wide — for \"what water do I cross on this trail\"). Use this for first-pass route scouting; ALWAYS verify with a real trail map (Green Trails, USGS quad, or CalTopo) before the trip — OSM trail data has gaps and labels can be wrong. If you already have an `area_id` from `find_areas` or a prior tool call, pass it directly to avoid re-resolution. USGS elevation is sometimes flaky; if `centroid_elevation_ft` is null the source is omitted from citations and a caveat is added — surface the missing elevation to the user rather than inventing one.",
     {
       area_id: z.string().optional().describe("Known PNW area id (e.g. 'enchantments'). Overrides lat/lon."),
       lat: z.number().min(-90).max(90).optional().describe("Latitude (decimal). Required if area_id absent."),
@@ -91,7 +92,9 @@ export function registerRouteInfoTools(server: McpServer, env: Env): void {
       trail_name: z
         .string()
         .optional()
-        .describe("Optional trail-name substring filter (case-insensitive)."),
+        .describe(
+          "Optional trail filter (case-insensitive). Matches OSM name/alt_name/loc_name/official_name substrings and USFS trail numbers ('724', 'Trail 724'). Zero matches fall back to the unfiltered nearby list with a caveat.",
+        ),
     },
     async ({ area_id, lat, lon, radius_km, trail_name }) => {
       let resolvedLat: number | undefined = lat;
@@ -139,8 +142,24 @@ export function registerRouteInfoTools(server: McpServer, env: Env): void {
 
       let trails: OsmTrail[] = trailsResult ?? [];
       if (trail_name) {
-        const needle = trail_name.toLowerCase();
-        trails = trails.filter((t) => t.name.toLowerCase().includes(needle));
+        // Match across OSM name/alt_name/loc_name/official_name and USFS
+        // trail number (ref), expanding seeded popular-name aliases
+        // ("Gothic Basin" → "weden creek"). An empty match against a
+        // non-empty trail list falls back to the unfiltered list with a
+        // caveat — an empty array reads as "no trails here", which is
+        // factually wrong when the name simply didn't match.
+        const queries = [trail_name, ...expandTrailAliases(trail_name)];
+        const matched = trails.filter((t) => queries.some((q) => osmTrailMatchesQuery(t, q)));
+        if (matched.length === 0 && trails.length > 0) {
+          caveats.push(
+            `No trail matched "${trail_name}" by name, alt name, or USFS trail number; ` +
+              `nearby trails listed UNFILTERED — verify names. Popular names often differ ` +
+              `from OSM's (e.g. Gothic Basin is "Weden Creek Trail" #724); try the USFS ` +
+              `trail number if you know it.`,
+          );
+        } else {
+          trails = matched;
+        }
       }
       // Trim to top 10 by length.
       trails = [...trails]

--- a/apps/trip-mcp/src/tools/trail_weather_profile.test.ts
+++ b/apps/trip-mcp/src/tools/trail_weather_profile.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { interpolateByMile, sampleIndices } from "./trail_weather_profile.js";
+
+describe("sampleIndices", () => {
+  it("caps at maxSamples with endpoints included", () => {
+    const idx = sampleIndices(50, 5);
+    expect(idx).toHaveLength(5);
+    expect(idx[0]).toBe(0);
+    expect(idx[4]).toBe(49);
+  });
+
+  it("handles fewer points than samples", () => {
+    expect(sampleIndices(3, 5)).toEqual([0, 1, 2]);
+    expect(sampleIndices(1, 5)).toEqual([0]);
+    expect(sampleIndices(0, 5)).toEqual([]);
+  });
+});
+
+describe("interpolateByMile", () => {
+  it("linearly interpolates between samples and clamps at the ends", () => {
+    const out = interpolateByMile([0, 1, 2, 3, 4], [1, 3], [40, 60]);
+    expect(out).toEqual([40, 40, 50, 60, 60]);
+  });
+
+  it("skips null samples", () => {
+    const out = interpolateByMile([0, 2], [0, 1, 2], [40, null, 60]);
+    expect(out).toEqual([40, 60]);
+  });
+
+  it("returns all nulls when no sample succeeded", () => {
+    const out = interpolateByMile([0, 1], [0, 1], [null, null]);
+    expect(out).toEqual([null, null]);
+  });
+});

--- a/apps/trip-mcp/src/tools/trail_weather_profile.ts
+++ b/apps/trip-mcp/src/tools/trail_weather_profile.ts
@@ -1,0 +1,302 @@
+/**
+ * get_trail_weather_profile: one chart-ready series merging mileage,
+ * elevation, temperature, and precipitation along a trail.
+ *
+ * Pipeline: resolve polyline (same inputs as get_elevation_profile) →
+ * resample → one Open-Meteo elevation batch → ≤5 elevation-corrected
+ * weather samples along the route (parallel, one day window each) →
+ * interpolate temperature between samples per profile point.
+ *
+ * Honesty contract (carried from doing this by hand): precipitation does
+ * NOT vary meaningfully in the source model at trail scale, and the
+ * temperature correction is a model adjustment, not a mountain-station
+ * observation. Per-field provenance is part of the payload so downstream
+ * consumers label charts accordingly.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Confidence, Env, Source, ToolPayload } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import {
+  OPEN_METEO_ATTRIBUTION,
+  getElevationsMeters,
+  getPointForecast,
+} from "../sources/openmeteo.js";
+import { resamplePolyline } from "../polyline.js";
+import { payloadResponse, titledTool } from "./utils.js";
+import { profileInputSchema, resolvePolyline } from "./profile_shared.js";
+import { buildProfileEntries, profileStats } from "./elevation_profile.js";
+
+const MAX_WEATHER_SAMPLES = 5;
+const PROFILE_POINTS = 50;
+
+interface TrailWeatherPoint {
+  mile: number;
+  elevation_ft: number | null;
+  temp_f: number | null;
+  precip_pct: number | null;
+}
+
+interface TrailWeatherData {
+  resolved_from: "points" | "osm_id" | "trail_name";
+  osm_id?: string;
+  matched_name?: string;
+  date: string;
+  window: { start_hour: number; end_hour: number };
+  series: TrailWeatherPoint[];
+  summary: {
+    total_distance_mi: number;
+    total_gain_ft: number | null;
+    min_elevation_ft: number | null;
+    max_elevation_ft: number | null;
+    route_min_temp_f: number | null;
+    route_max_temp_f: number | null;
+    any_point_at_or_below_freezing: boolean | null;
+    max_precip_probability_pct: number | null;
+  };
+  provenance: {
+    elevation: string;
+    temp: string;
+    precip: string;
+  };
+}
+
+function todayInPacific(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
+}
+
+/** Evenly spaced sample indices over [0, n-1], endpoints included. */
+export function sampleIndices(n: number, maxSamples: number): number[] {
+  if (n <= 0) return [];
+  const count = Math.min(maxSamples, n);
+  if (count === 1) return [0];
+  const out = new Set<number>();
+  for (let i = 0; i < count; i++) {
+    out.add(Math.round(((n - 1) * i) / (count - 1)));
+  }
+  return [...out].sort((a, b) => a - b);
+}
+
+/** Piecewise-linear interpolation of sample values by mile. */
+export function interpolateByMile(
+  miles: number[],
+  sampleMiles: number[],
+  sampleValues: Array<number | null>,
+): Array<number | null> {
+  const valid: Array<{ mile: number; value: number }> = [];
+  for (let i = 0; i < sampleMiles.length; i++) {
+    const v = sampleValues[i];
+    if (typeof v === "number") valid.push({ mile: sampleMiles[i]!, value: v });
+  }
+  if (valid.length === 0) return miles.map(() => null);
+  return miles.map((m) => {
+    if (m <= valid[0]!.mile) return round1(valid[0]!.value);
+    const last = valid[valid.length - 1]!;
+    if (m >= last.mile) return round1(last.value);
+    for (let i = 1; i < valid.length; i++) {
+      const a = valid[i - 1]!;
+      const b = valid[i]!;
+      if (m <= b.mile) {
+        const t = b.mile > a.mile ? (m - a.mile) / (b.mile - a.mile) : 0;
+        return round1(a.value + (b.value - a.value) * t);
+      }
+    }
+    return round1(last.value);
+  });
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function registerTrailWeatherProfileTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_trail_weather_profile",
+    "Modeling weather along the trail…",
+    "One merged, chart-ready series along a trail: {mile, elevation_ft, temp_f, precip_pct}[] — built for \"graph mileage, elevation, temperature and rain in one visual\" asks. Accepts the same polyline inputs as get_elevation_profile (`points` > `osm_id` > `trail_name`+lat/lon), plus optional `date` (YYYY-MM-DD, default today Pacific, up to ~16 days out) and an hour window (default 8–18). Internally: elevation from one Open-Meteo DEM batch, then at most 5 elevation-corrected weather samples along the route, temperatures interpolated between samples. READ THE PROVENANCE LABELS before charting: elevation is DEM-sampled (90 m Copernicus GLO-90); temp_f is a model elevation-correction (Open-Meteo hypsometric adjustment), not a mountain-station observation; precip_pct is GRID-SCALE — it does not vary meaningfully at trail scale, so never imply per-point precipitation precision. Partial failure degrades per-field: series returns with null temp/precip (or null elevation) and a named caveat.",
+    {
+      ...profileInputSchema,
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .optional()
+        .describe("Forecast date YYYY-MM-DD (default: today, America/Los_Angeles)."),
+      start_hour: z.number().int().min(0).max(23).default(8).describe("Window start hour, local (default 8)."),
+      end_hour: z.number().int().min(1).max(24).default(18).describe("Window end hour, local, exclusive (default 18)."),
+    },
+    async (args) => {
+      const date = args.date ?? todayInPacific();
+      if (args.end_hour <= args.start_hour) {
+        return payloadResponse(empty<TrailWeatherData>(["end_hour must be after start_hour."]));
+      }
+
+      const resolved = await resolvePolyline(env, args);
+      if ("error" in resolved) {
+        return payloadResponse(empty<TrailWeatherData>([resolved.error]));
+      }
+
+      const sampled = resamplePolyline(resolved.points, PROFILE_POINTS);
+      const caveats = [...resolved.caveats];
+      const sources: Source[] = [];
+      if (resolved.resolved_from !== "points") {
+        sources.push(
+          makeSource(
+            "https://overpass-api.de/api/interpreter",
+            "OpenStreetMap (Overpass API) — trail geometry",
+            { license: "ODbL", confidence: "medium" },
+          ),
+        );
+      }
+
+      // Elevation batch. Failure → null elevations, weather proceeds uncorrected.
+      let elevationsM: Array<number | null>;
+      try {
+        elevationsM = await getElevationsMeters(env, sampled);
+      } catch (e) {
+        elevationsM = sampled.map(() => null);
+        caveats.push(
+          `open_meteo_elevation: ${e instanceof Error ? e.message : String(e)} — elevations null; temperatures NOT elevation-corrected.`,
+        );
+      }
+      const profile = buildProfileEntries(sampled, elevationsM);
+      const stats = profileStats(profile);
+
+      // ≤5 weather samples along the route, fetched in parallel for the
+      // one-day window; each is elevation-corrected when a DEM value exists.
+      const indices = sampleIndices(profile.length, MAX_WEATHER_SAMPLES);
+      const sampleResults = await Promise.all(
+        indices.map(async (idx) => {
+          const p = sampled[idx]!;
+          const elevM = elevationsM[idx];
+          try {
+            const fc = await getPointForecast(env, {
+              lat: p.lat,
+              lon: p.lon,
+              ...(typeof elevM === "number" ? { elevationM: elevM } : {}),
+              startDate: date,
+              endDate: date,
+            });
+            const windowHours = fc.hourly.filter((h) => {
+              if (!h.time.startsWith(date)) return false;
+              const hour = Number.parseInt(h.time.slice(11, 13), 10);
+              return hour >= args.start_hour && hour < args.end_hour;
+            });
+            const temps = windowHours
+              .map((h) => h.temp_f)
+              .filter((v): v is number => v !== null);
+            const precips = windowHours
+              .map((h) => h.precip_probability_pct)
+              .filter((v): v is number => v !== null);
+            return {
+              mile: profile[idx]!.mile,
+              temp_f: mean(temps),
+              precip_pct: precips.length > 0 ? Math.max(...precips) : null,
+              ok: true,
+            };
+          } catch (e) {
+            return {
+              mile: profile[idx]!.mile,
+              temp_f: null,
+              precip_pct: null,
+              ok: false,
+              error: e instanceof Error ? e.message : String(e),
+            };
+          }
+        }),
+      );
+
+      const failed = sampleResults.filter((r) => !r.ok);
+      if (failed.length === sampleResults.length) {
+        caveats.push(
+          `open_meteo_forecast: all ${sampleResults.length} weather samples failed (${failed[0] && "error" in failed[0] ? failed[0].error : "unknown"}) — temp_f/precip_pct are null.`,
+        );
+      } else if (failed.length > 0) {
+        caveats.push(
+          `open_meteo_forecast: ${failed.length}/${sampleResults.length} weather samples failed; temperatures interpolated from the remaining samples.`,
+        );
+      }
+      if (sampleResults.some((r) => r.ok && r.temp_f === null)) {
+        caveats.push(
+          `No forecast hours in the ${args.start_hour}:00–${args.end_hour}:00 window for ${date} — date may be out of the ~16-day forecast range.`,
+        );
+      }
+
+      const miles = profile.map((p) => p.mile);
+      const temps = interpolateByMile(
+        miles,
+        sampleResults.map((r) => r.mile),
+        sampleResults.map((r) => r.temp_f),
+      );
+      const precipSampleValues = sampleResults.map((r) => r.precip_pct);
+      const maxPrecip = precipSampleValues.filter((v): v is number => v !== null);
+      // Precip is grid-scale: apply the nearest sample's value rather than
+      // pretending it varies per point.
+      const precips = miles.map((m) => {
+        let nearest: number | null = null;
+        let nearestDist = Infinity;
+        for (const r of sampleResults) {
+          if (r.precip_pct === null) continue;
+          const d = Math.abs(r.mile - m);
+          if (d < nearestDist) {
+            nearestDist = d;
+            nearest = r.precip_pct;
+          }
+        }
+        return nearest;
+      });
+
+      const series: TrailWeatherPoint[] = profile.map((p, i) => ({
+        mile: p.mile,
+        elevation_ft: p.elevation_ft,
+        temp_f: temps[i] ?? null,
+        precip_pct: precips[i] ?? null,
+      }));
+
+      sources.push(
+        makeSource("https://open-meteo.com/en/docs", OPEN_METEO_ATTRIBUTION, {
+          license: "CC BY 4.0",
+          confidence: "medium",
+        }),
+      );
+
+      const validTemps = temps.filter((v): v is number => v !== null);
+      const lastPoint = profile[profile.length - 1];
+      const data: TrailWeatherData = {
+        resolved_from: resolved.resolved_from,
+        ...(resolved.osm_id ? { osm_id: resolved.osm_id } : {}),
+        ...(resolved.matched_name ? { matched_name: resolved.matched_name } : {}),
+        date,
+        window: { start_hour: args.start_hour, end_hour: args.end_hour },
+        series,
+        summary: {
+          total_distance_mi: lastPoint ? lastPoint.mile : 0,
+          total_gain_ft: stats.total_gain_ft,
+          min_elevation_ft: stats.min_elevation_ft,
+          max_elevation_ft: stats.max_elevation_ft,
+          route_min_temp_f: validTemps.length > 0 ? Math.min(...validTemps) : null,
+          route_max_temp_f: validTemps.length > 0 ? Math.max(...validTemps) : null,
+          any_point_at_or_below_freezing:
+            validTemps.length > 0 ? validTemps.some((t) => t <= 32) : null,
+          max_precip_probability_pct: maxPrecip.length > 0 ? Math.max(...maxPrecip) : null,
+        },
+        provenance: {
+          elevation: "DEM-sampled (Copernicus GLO-90, 90 m resolution)",
+          temp: "model elevation-corrected (Open-Meteo hypsometric adjustment) — not a station observation",
+          precip: "grid-scale — weakest field; does not vary meaningfully at trail scale",
+        },
+      };
+
+      const confidence: Confidence =
+        validTemps.length > 0 && stats.min_elevation_ft !== null ? "medium" : "low";
+      const payload: ToolPayload<TrailWeatherData> = ok(data, sources, confidence, caveats);
+      return payloadResponse(payload);
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/weather.ts
+++ b/apps/trip-mcp/src/tools/weather.ts
@@ -17,7 +17,23 @@ import {
   type NwsAlert,
   type NwsForecastPeriod,
 } from "../sources/nws.js";
+import {
+  OPEN_METEO_ATTRIBUTION,
+  getPointForecast,
+  type OpenMeteoDaily,
+  type OpenMeteoHourly,
+} from "../sources/openmeteo.js";
 import { payloadResponse, roundCoord, titledTool } from "./utils.js";
+
+interface ElevationAdjustedBlock {
+  provider: "open-meteo";
+  /** Elevation the caller asked the model to correct to. */
+  elevation_ft: number;
+  /** Elevation the model actually applied (echoed back by the API). */
+  model_elevation_ft: number;
+  daily: OpenMeteoDaily[];
+  hourly?: OpenMeteoHourly[];
+}
 
 interface WeatherData {
   location: {
@@ -32,6 +48,8 @@ interface WeatherData {
   hourly?: NwsForecastPeriod[];
   alerts: NwsAlert[];
   afd_summary: string;
+  /** Present only when `elevation_ft` was supplied. */
+  elevation_adjusted?: ElevationAdjustedBlock;
 }
 
 const STANDARD_CAVEATS = [
@@ -54,7 +72,7 @@ export function registerWeatherTools(server: McpServer, env: Env): void {
     server,
     "get_weather",
     "Checking mountain weather…",
-    "Returns NWS forecast (daily + optional hourly), active alerts, and the latest Area Forecast Discussion for a point. Either supply `area_id` (resolves to that area's centroid) or explicit lat/lon. Use this to assess go/no-go for a backpacking trip. CRITICAL CAVEATS to surface in your answer: (1) forecast confidence drops materially past 72 hours — for trips further out, recommend re-checking within 24h of departure; (2) NWS point forecasts are at valley elevations; expect 5–10°F cooler and significantly more precipitation at 6,000+ ft passes; (3) for any backcountry go/no-go decision involving snow, river crossings, or storms, surface the ranger station phone from `get_safety_brief` alongside this forecast — the ranger has real-time ground truth the forecast doesn't. The Area Forecast Discussion (include_afd: true, default) contains the meteorologist's narrative confidence assessment and is often the most useful field — quote it when relevant.",
+    "Returns NWS forecast (daily + optional hourly), active alerts, and the latest Area Forecast Discussion for a point. Either supply `area_id` (resolves to that area's centroid) or explicit lat/lon. Use this to assess go/no-go for a backpacking trip. NWS point forecasts cannot distinguish elevations within a ~2.5 km grid cell — a trailhead and a basin 2,600 ft above it get the identical forecast. Pass `elevation_ft` (e.g. from get_elevation_profile) to ALSO get an `elevation_adjusted` block: an Open-Meteo forecast with the model's hypsometric altitude correction applied at that elevation, including freezing_level_height in feet — directly useful for snow-level questions. The adjusted block is a model correction, not a mountain-station observation, and precipitation type/amount remain grid-scale. The NWS payload is never replaced — alerts and the AFD narrative have no Open-Meteo equivalent. CRITICAL CAVEATS to surface in your answer: (1) forecast confidence drops materially past 72 hours — for trips further out, recommend re-checking within 24h of departure; (2) for any backcountry go/no-go decision involving snow, river crossings, or storms, surface the ranger station phone from `get_safety_brief` alongside this forecast — the ranger has real-time ground truth the forecast doesn't. The Area Forecast Discussion (include_afd: true, default) contains the meteorologist's narrative confidence assessment and is often the most useful field — quote it when relevant.",
     {
       lat: z.number().min(-90).max(90).optional().describe("Latitude (decimal). Ignored if area_id is supplied."),
       lon: z.number().min(-180).max(180).optional().describe("Longitude (decimal). Ignored if area_id is supplied."),
@@ -63,8 +81,16 @@ export function registerWeatherTools(server: McpServer, env: Env): void {
       include_alerts: z.boolean().default(true).describe("Fetch active NWS alerts for the point."),
       include_afd: z.boolean().default(true).describe("Fetch the latest Area Forecast Discussion."),
       include_hourly: z.boolean().default(false).describe("Include the hourly forecast (large)."),
+      elevation_ft: z
+        .number()
+        .min(-500)
+        .max(15000)
+        .optional()
+        .describe(
+          "Target elevation in feet. When set, adds an `elevation_adjusted` Open-Meteo block with altitude-corrected temperatures and freezing level; NWS output is unchanged.",
+        ),
     },
-    async ({ lat, lon, area_id, days, include_alerts, include_afd, include_hourly }) => {
+    async ({ lat, lon, area_id, days, include_alerts, include_afd, include_hourly, elevation_ft }) => {
       let resolvedLat: number | undefined = lat;
       let resolvedLon: number | undefined = lon;
       let areaName: string | undefined;
@@ -93,12 +119,27 @@ export function registerWeatherTools(server: McpServer, env: Env): void {
       try {
         const point = await getPoint(env, rlat, rlon);
 
-        const [forecast, hourly, alerts, afd] = await Promise.all([
+        const wantAdjusted = typeof elevation_ft === "number";
+        const [forecast, hourly, alerts, afd, adjustedResult] = await Promise.all([
           getForecast(env, rlat, rlon).catch(() => null),
           include_hourly ? getHourlyForecast(env, rlat, rlon).catch(() => null) : Promise.resolve(null),
           include_alerts ? getActiveAlerts(env, rlat, rlon).catch(() => [] as NwsAlert[]) : Promise.resolve([] as NwsAlert[]),
           include_afd && point.forecastOffice
             ? getAreaForecastDiscussion(env, point.forecastOffice).catch(() => null)
+            : Promise.resolve(null),
+          wantAdjusted
+            ? getPointForecast(env, {
+                lat: rlat,
+                lon: rlon,
+                elevationM: elevation_ft! / 3.28084,
+                days,
+              }).then(
+                (f) => ({ ok: true as const, forecast: f }),
+                (e: unknown) => ({
+                  ok: false as const,
+                  error: e instanceof Error ? e.message : String(e),
+                }),
+              )
             : Promise.resolve(null),
         ]);
 
@@ -156,6 +197,31 @@ export function registerWeatherTools(server: McpServer, env: Env): void {
           );
         }
 
+        let adjusted: ElevationAdjustedBlock | undefined;
+        let adjustedError: string | undefined;
+        if (adjustedResult) {
+          if (adjustedResult.ok) {
+            adjusted = {
+              provider: "open-meteo",
+              elevation_ft: Math.round(elevation_ft!),
+              model_elevation_ft: adjustedResult.forecast.model_elevation_ft,
+              daily: adjustedResult.forecast.daily,
+              ...(include_hourly
+                ? { hourly: adjustedResult.forecast.hourly.slice(0, days * 24) }
+                : {}),
+            };
+            sources.push(
+              makeSource(
+                "https://open-meteo.com/en/docs",
+                OPEN_METEO_ATTRIBUTION,
+                { license: "CC BY 4.0", confidence: "medium" },
+              ),
+            );
+          } else {
+            adjustedError = `open_meteo_forecast: ${adjustedResult.error} — elevation_adjusted block unavailable; NWS payload unaffected.`;
+          }
+        }
+
         // Confidence: high if alert data is fresh (<1h), otherwise medium.
         let confidence: Confidence = "medium";
         if (include_alerts && alerts.length > 0) {
@@ -186,11 +252,20 @@ export function registerWeatherTools(server: McpServer, env: Env): void {
           ...(hourlyPeriods ? { hourly: hourlyPeriods } : {}),
           alerts,
           afd_summary: afd ? summarizeAfd(afd.productText) : "",
+          ...(adjusted ? { elevation_adjusted: adjusted } : {}),
         };
 
-        const caveats = [...STANDARD_CAVEATS];
+        // With an adjusted block present, swap the generic "mountains may be
+        // colder" caveat for a specific description of what the block models.
+        const caveats = adjusted
+          ? [
+              STANDARD_CAVEATS[0]!,
+              `elevation_adjusted block models temperature at ${adjusted.elevation_ft} ft (Open-Meteo hypsometric correction; medium confidence — a model adjustment, not a station observation). Precipitation type/amount are still grid-scale.`,
+            ]
+          : [...STANDARD_CAVEATS];
         if (!forecast) caveats.push("NWS daily forecast unavailable.");
         if (include_afd && !afd) caveats.push("Area Forecast Discussion unavailable.");
+        if (adjustedError) caveats.push(adjustedError);
 
         const payload: ToolPayload<WeatherData> = ok(data, sources, confidence, caveats);
         return payloadResponse(payload);

--- a/packages/http-fetch/src/index.test.ts
+++ b/packages/http-fetch/src/index.test.ts
@@ -48,6 +48,39 @@ describe("createFetchClient", () => {
     expect(sent.get("User-Agent")).toBe("mcp-stack-test/1.0");
   });
 
+  it("preserves the base URL's path prefix for leading-slash paths", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const client = createFetchClient({ baseUrl: "https://api.example.com/api/v1" });
+    await client.json("/alerts?parkCode=mora");
+
+    const [calledUrl] = fetchMock.mock.calls[0] ?? [];
+    expect(calledUrl).toBe("https://api.example.com/api/v1/alerts?parkCode=mora");
+  });
+
+  it("joins relative paths and trailing-slash bases with a single slash", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const client = createFetchClient({ baseUrl: "https://api.example.com/api/v1/" });
+    await client.json("alerts");
+
+    const [calledUrl] = fetchMock.mock.calls[0] ?? [];
+    expect(calledUrl).toBe("https://api.example.com/api/v1/alerts");
+  });
+
+  it("passes absolute URLs through untouched even with a baseUrl set", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const client = createFetchClient({ baseUrl: "https://api.example.com/api/v1" });
+    await client.json("https://other.example.org/x");
+
+    const [calledUrl] = fetchMock.mock.calls[0] ?? [];
+    expect(calledUrl).toBe("https://other.example.org/x");
+  });
+
   it("throws HttpError on non-2xx with the body attached", async () => {
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockResolvedValue(new Response("nope", { status: 404, statusText: "Not Found" }));

--- a/packages/http-fetch/src/index.ts
+++ b/packages/http-fetch/src/index.ts
@@ -197,7 +197,12 @@ export function createFetchClient(options: FetchClientOptions = {}): FetchClient
 function resolveUrl(url: string, baseUrl?: string): string {
   if (!baseUrl) return url;
   if (/^https?:\/\//i.test(url)) return url;
-  return new URL(url, baseUrl).toString();
+  // Concatenate rather than `new URL(url, baseUrl)`: URL resolution drops
+  // the base's path segment for leading-slash inputs ("/alerts" against
+  // "https://host/api/v1" → "https://host/alerts"), which silently 404s
+  // any API whose base includes a path prefix (NPS, RIDB).
+  const base = baseUrl.replace(/\/+$/, "");
+  return url.startsWith("/") ? base + url : `${base}/${url}`;
 }
 
 function isAbortError(e: unknown): boolean {


### PR DESCRIPTION
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71

One commit per issue:

- **#66** — Fixed the real root cause of the NPS 404 in `packages/http-fetch`: `new URL(path, baseUrl)` drops the base's path prefix (`/api/v1`), so NPS (and latently RIDB) requests hit the wrong path. Replaced with slash-normalized concatenation + regression tests; missing `NPS_API_KEY` now yields a named caveat.
- **#65** — WSDOT 401s now name the problem: missing `WSDOT_API_KEY` secret → named caveat with where to get a code; rejected AccessCode → explicit expired/rotated message. The deployed 401 itself is a credential rotation (user action), documented in the README.
- **#67** — New `get_elevation_profile` tool: polyline from caller points / OSM id / trail name + hint, resampled to ≤100 points, one Open-Meteo DEM batch (CC BY 4.0 cited), graceful distance-only degradation.
- **#68** — `get_weather` accepts optional `elevation_ft` and adds an Open-Meteo `elevation_adjusted` block (altitude-corrected temps, freezing level in feet). NWS payload byte-for-byte unchanged when omitted.
- **#69** — New `get_trail_weather_profile` tool: merged `{mile, elevation_ft, temp_f, precip_pct}` series, ≤5 bounded weather samples, per-field provenance labels (precip explicitly grid-scale).
- **#70** — `find_areas` WTA hiking-guide fallback for off-registry queries: synthesized `wta_fallback` record with trailhead coords, mileage, gain, highest point; fails soft with a caveat.
- **#71** — `get_route_info` trail matching across name/alt_name/loc_name/official_name/USFS `ref`, zero-match fallback to the unfiltered list with a caveat, seeded popular-name alias map (Gothic Basin → Weden Creek).

Gate: `pnpm -r type-check` and `pnpm -r test` pass (new unit tests for the URL join, secret guards, polyline resampling, interpolation, trail matching, and the WTA hike-page parser).

Note: the shared `http-fetch` change means CI will deploy all four apps on merge; trip-mcp's deploy step still needs the `CLOUDFLARE_API_TOKEN_TRIP` repo secret (#28) or it will fail on KV permissions as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq

---
_Generated by [Claude Code](https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq)_