### PR TITLE
[trip-mcp] Fix WTA hike search endpoint; guard find_areas fallback against unrelated hits

### DIFF
--- a/apps/trip-mcp/src/sources/wta.ts
+++ b/apps/trip-mcp/src/sources/wta.ts
@@ -61,8 +61,13 @@
  *               <div class="related-hike-links"><ul><li><a href=".../hikes/SLUG">NAME</a>
  *   - Body:     <div id="tripreport-body"><div id="tripreport-body-text">...<p>...</p>...
  *
- * Hike SEARCH (/go-hiking/hikes?searchable_text=Q): server-rendered, this
- * one DOES respect `searchable_text=`.
+ * Hike SEARCH (re-probed 2026-08-02): /go-hiking/hikes now REDIRECTS to
+ * /go-outside/hikes and silently IGNORES `searchable_text=` — the query
+ * param the working endpoint respects is `searchabletext=` (no
+ * underscore) on /go-outside/hikes:
+ *
+ *     GET https://www.wta.org/go-outside/hikes?searchabletext=Q
+ *
  *   - Card:   <div class="search-result-item">
  *   - Title:  <h3 class="listitem-title"><a href="/go-hiking/hikes/SLUG"><span>NAME</span></a>
  *   - Region: <div class="region">REGION</div>      (sibling of listitem-title)
@@ -433,8 +438,10 @@ export async function searchHikes(env: Env, query: string): Promise<HikeSummary[
   const key = `wta:hikes:${query.toLowerCase()}`;
   return cached(env, key, TTL.WTA_LIST, async () => {
     try {
-      // The hikes listing DOES respect `searchable_text=` (unlike trip reports).
-      const url = `${BASE}/go-hiking/hikes?searchable_text=${encodeURIComponent(query)}`;
+      // /go-outside/hikes with `searchabletext=` (no underscore) — the old
+      // /go-hiking/hikes?searchable_text= now redirects to an UNFILTERED
+      // browse page, which silently returns unrelated hikes.
+      const url = `${BASE}/go-outside/hikes?searchabletext=${encodeURIComponent(query)}`;
       const res = await rateLimitedFetch(env, url);
       if (!res.ok) return [];
       const html = await res.text();

--- a/apps/trip-mcp/src/tools/find_areas.test.ts
+++ b/apps/trip-mcp/src/tools/find_areas.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { hikeNameSimilar } from "./find_areas.js";
+
+describe("hikeNameSimilar", () => {
+  it("accepts exact and containment matches", () => {
+    expect(hikeNameSimilar("Gothic Basin", "Gothic Basin")).toBe(true);
+    expect(hikeNameSimilar("Gothic Basin", "gothic basin trail")).toBe(true);
+    expect(hikeNameSimilar("Gothic Basin via Weden Creek", "Gothic Basin")).toBe(true);
+  });
+
+  it("accepts all-tokens-present matches", () => {
+    expect(hikeNameSimilar("Basin of Gothic Peaks", "gothic basin")).toBe(true);
+  });
+
+  it("rejects unrelated hikes (the browse-page regression)", () => {
+    expect(hikeNameSimilar("Big Beaver Trail", "Gothic Basin")).toBe(false);
+    expect(hikeNameSimilar("Pratt Lake Basin", "Gothic Basin")).toBe(false);
+    expect(hikeNameSimilar("", "Gothic Basin")).toBe(false);
+  });
+});

--- a/apps/trip-mcp/src/tools/find_areas.ts
+++ b/apps/trip-mcp/src/tools/find_areas.ts
@@ -26,14 +26,31 @@ interface WtaFallbackRecord {
 }
 
 /**
+ * Does a WTA hit's name actually resemble the query? WTA's search has
+ * redirected/ignored its query param before (returning a generic browse
+ * list), so never trust result ORDER alone — a fallback record must be
+ * name-similar or it's worse than an empty response.
+ */
+export function hikeNameSimilar(hikeName: string, query: string): boolean {
+  const name = hikeName.toLowerCase();
+  const q = query.toLowerCase().trim();
+  if (!q || !name) return false;
+  if (name.includes(q) || q.includes(name)) return true;
+  const qTokens = q.split(/[\s,;/—-]+/).filter((t) => t.length >= 3);
+  return qTokens.length > 0 && qTokens.every((t) => name.includes(t));
+}
+
+/**
  * Resolve an off-registry query against WTA's hiking guide (3,500+ WA
- * trails). Scrape-backed, so this fails soft: any error or missing
- * coordinate degrades to null and the caller keeps the empty-registry
- * behavior.
+ * trails). Scrape-backed, so this fails soft: any error, missing
+ * coordinate, or top hit whose name doesn't resemble the query degrades
+ * to null and the caller keeps the empty-registry behavior.
  */
 async function wtaFallback(env: Env, query: string): Promise<WtaFallbackRecord | null> {
   try {
-    const hits = await searchHikes(env, query);
+    const hits = (await searchHikes(env, query)).filter((h) =>
+      hikeNameSimilar(h.hike_name, query),
+    );
     const top = hits[0];
     if (!top) return null;
     const detail = await getHikeDetail(env, top.url);


### PR DESCRIPTION
Follow-up to #70 / PR #72, found during live post-deploy verification: `find_areas` with "Gothic Basin" confidently returned "Big Beaver Trail".

Two causes, both fixed:

1. **WTA redesigned hike search** since the selector notes were probed: `/go-hiking/hikes?searchable_text=` now 302s to `/go-outside/hikes` and silently drops the query, returning a generic browse list. `searchHikes` now uses `/go-outside/hikes?searchabletext=` (no underscore) — verified live: "gothic basin" returns the gothic-basin hike first.
2. **The fallback trusted `hits[0]` blindly.** `wtaFallback` now requires name similarity (containment or all query tokens present in the hike name) and fails soft to the documented empty+caveat behavior when nothing resembles the query — so a future WTA redirect regression degrades to empty results instead of a wrong answer. Unit tested with the exact regression case.

Gate: `pnpm -r type-check` and `pnpm -r test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq

---
_Generated by [Claude Code](https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq)_