### PR TITLE
[trip-mcp] Version the WTA hike-search cache key past the endpoint fix

### DIFF
--- a/apps/trip-mcp/src/sources/wta.ts
+++ b/apps/trip-mcp/src/sources/wta.ts
@@ -435,7 +435,10 @@ export function parseTripReport(html: string, url: string): TripReportDetail {
 /* ------------------------------ hikes ------------------------------ */
 
 export async function searchHikes(env: Env, query: string): Promise<HikeSummary[]> {
-  const key = `wta:hikes:${query.toLowerCase()}`;
+  // v2: the pre-endpoint-fix cache holds unfiltered browse-page results
+  // under the v1 key; a version bump orphans those rather than serving
+  // them for their remaining TTL.
+  const key = `wta:hikes:v2:${query.toLowerCase()}`;
   return cached(env, key, TTL.WTA_LIST, async () => {
     try {
       // /go-outside/hikes with `searchabletext=` (no underscore) — the old


### PR DESCRIPTION
Tiny follow-up to #73: the 24h KV cache still holds unfiltered browse-page results written by the broken endpoint under the old `wta:hikes:` key, which would make fixed fallbacks return empty until expiry. Bumping the key to `wta:hikes:v2:` orphans the stale entries so the endpoint fix takes effect immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq

---
_Generated by [Claude Code](https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq)_