### PR TITLE
[trip-mcp] Execute issue queue #75–#85: 7 new tools, geometry assembly, weather modes, report intelligence

### DIFF
--- a/apps/trip-mcp/DESIGN.md
+++ b/apps/trip-mcp/DESIGN.md
@@ -1,0 +1,65 @@
+# trip-mcp design principles
+
+Settled via user interview (Aug 2026), recorded in issue #77. These
+govern all trip-mcp work; new-tool issues reference this file instead of
+restating conventions.
+
+## 1. PNW-only, depth over breadth
+
+No geographic expansion. Investment goes into richer data per area —
+more curated fields, more sources, better composition — not more
+regions. Non-PNW queries route to `web_research` / plain web search.
+
+## 2. Impersonal
+
+No user modeling: no stored pace, fitness, gear inventory, or home
+location. Tools take explicit parameters (`pace_mph`, `origin`,
+`elevation_ft`) with documented defaults instead of profiles. A default
+like "seattle" is a convenience constant, not a memory of the user.
+
+## 3. Day hikes and multi-night trips are equal citizens
+
+No tool may assume overnight (permits, camps) or day-trip (single-day
+weather windows). Overnight-specific capability ships as its own tool
+(e.g. `get_camp_water_beta`) rather than as assumptions baked into
+shared tools.
+
+## 4. Chart-ready series everywhere
+
+Any tool returning multi-point quantitative data emits arrays of flat
+`{x-key, y-key(s)}` objects with consistent units — **feet, °F, miles,
+mph, cfs** — plus a `provenance` block labeling each field's source and
+confidence. A consumer should be able to hand a series directly to a
+charting library without reshaping. Pattern established by
+`get_trail_weather_profile` (`{mile, elevation_ft, temp_f, precip_pct}`).
+
+Payloads stay bounded: downsample rather than emitting unbounded series
+(≤ ~100 points per series; time-series capped per tool description).
+
+## 5. À la carte tools first
+
+New capability ships as a discrete tool before being folded into
+`research_trip` orchestration. Orchestrator improvements come after the
+tool layer is solid.
+
+## 6. Standing conventions
+
+- **Per-source graceful degradation**: one upstream failure degrades to
+  a named caveat (`source_label: reason`); other sources are unaffected;
+  handlers never throw.
+- **Sources block**: URL + fetch timestamp + license/attribution +
+  confidence for every upstream consulted. Open-Meteo requires CC BY 4.0
+  attribution; WTA and other scraped sources use the
+  content-used-with-attribution string.
+- **Ranger-station prominence**: safety-critical topics (crossings,
+  snow, avalanche, road washouts) surface ranger-station contact info
+  from the registry; no tool output ever declares conditions "safe."
+- **Curated data is labeled**: registry-style curation ships at
+  low-to-medium confidence with explicit staleness caveats ("typical
+  year", "call ahead"), never presented as live ground truth.
+- **Caches**: KV-tiered TTLs in `cache.ts`; scraped sources ≤ 24h.
+  Version cache keys (`:v2:`) when a parser/endpoint fix would otherwise
+  serve stale wrong data for its TTL.
+- **Keyless where possible**: prefer keyless public APIs (Open-Meteo,
+  USGS, avalanche.org, OSRM demo) over keyed ones; keys that exist are
+  Worker secrets with named-caveat degradation when missing.

--- a/apps/trip-mcp/README.md
+++ b/apps/trip-mcp/README.md
@@ -1,8 +1,10 @@
 # trip-mcp
 
 PNW backpacking & camping research MCP server. Single Cloudflare Worker exposing
-12 outcome-oriented tools that aggregate Recreation.gov, NWS, NPS, USFS, WSDOT,
-WFIGS, InciWeb, WTA, OSM, USGS, and Open-Meteo data.
+19 outcome-oriented tools that aggregate Recreation.gov, NWS, NPS, USFS, WSDOT,
+WFIGS, InciWeb, WTA, OSM, USGS, NWAC, OSRM, and Open-Meteo data plus a
+hand-curated PNW registry (areas, crossings, seasonal windows, approach
+logistics, permit strategy, camping rules, access roads).
 
 ## Tools
 
@@ -15,7 +17,14 @@ WFIGS, InciWeb, WTA, OSM, USGS, and Open-Meteo data.
 | `get_weather` | NWS daily/hourly forecast + active alerts + AFD; optional Open-Meteo elevation-adjusted block. |
 | `get_elevation_profile` | Distance-indexed elevation series along a trail polyline (points, OSM id, or trail name). |
 | `get_trail_weather_profile` | Chart-ready {mile, elevation, temp, precip} series along a trail. |
-| `get_trip_reports` | Recent WTA trip reports for an area or trail. |
+| `get_trip_reports` | Recent trip reports (WTA + NWHikers/Reddit secondary); optional structured condition extraction. |
+| `get_river_conditions` | USGS gauge discharge + 7-day series + percentile flow context for crossings. |
+| `get_avalanche_forecast` | NWAC zone forecasts with danger by elevation band (off-season aware). |
+| `get_seasonal_timing` | Curated typical-year windows: melt-out, larches, wildflowers, bugs, crowds. |
+| `get_approach_info` | Curated last-gas/gear/supplies, cell coverage, road notes per corridor. |
+| `get_permit_strategy` | Acquisition paths, lottery odds, walk-up beta + live availability probe. |
+| `get_camp_water_beta` | Camp regulations, named sites, water reliability + OSM campsite layer. |
+| `get_access_status` | Per-road access status (WSDOT/NPS/USFS) + drive times (static or OSRM). |
 | `get_conditions` | Combined NPS + USFS + WSDOT + WFIGS + InciWeb. |
 | `get_route_info` | OSM trails/trailheads/water + USGS elevation. |
 | `get_safety_brief` | Curated safety brief: bear canisters, river crossings, ranger stations. |

--- a/apps/trip-mcp/README.md
+++ b/apps/trip-mcp/README.md
@@ -45,6 +45,11 @@ URL pattern: `https://trip-mcp.<sub>.workers.dev/s/<MCP_PATH_SECRET>/mcp`
 
 Add as a custom connector in claude.ai → Settings → Connectors → Add custom connector.
 
+## Design
+
+Cross-cutting principles (PNW-only depth, impersonal, chart-ready
+series, à la carte tools) live in [DESIGN.md](./DESIGN.md).
+
 ## Architecture
 
 - `src/index.ts` — Worker entry, delegates to `@mcp-stack/mcp-core/worker`.

--- a/apps/trip-mcp/src/access_roads.ts
+++ b/apps/trip-mcp/src/access_roads.ts
@@ -1,0 +1,88 @@
+/**
+ * Access roads per registry area (issue #85). Data-only schema: each
+ * road names its managing agency, which decides how live status is
+ * resolved — WSDOT pass conditions (state highways), NPS alerts (park
+ * roads), or the USFS forest alerts-page mention scan (forest roads).
+ */
+
+export type RoadManager = "wsdot" | "nps" | "usfs";
+
+export interface AccessRoad {
+  name: string;
+  manager: RoadManager;
+  /** WSDOT mountain-pass name for findPassByName (manager: wsdot). */
+  wsdot_pass_name?: string;
+  /** NPS park code for alerts filtering (manager: nps). */
+  nps_park_code?: string;
+  /** Forest slug for the alerts-page scan (manager: usfs). */
+  usfs_forest_slug?: string;
+  note?: string;
+}
+
+export const ACCESS_ROADS: Record<string, AccessRoad[]> = {
+  enchantments: [
+    { name: "US-2 / Stevens Pass", manager: "wsdot", wsdot_pass_name: "Stevens Pass" },
+    { name: "Icicle Creek Rd", manager: "usfs", usfs_forest_slug: "okawen", note: "paved past Snow Lakes TH" },
+    { name: "Eightmile Rd (FR 7601)", manager: "usfs", usfs_forest_slug: "okawen", note: "gravel to Stuart/Colchuck TH; opens May–Jun" },
+  ],
+  mt_rainier: [
+    { name: "Longmire–Paradise Rd", manager: "nps", nps_park_code: "mora" },
+    { name: "Sunrise Rd (White River)", manager: "nps", nps_park_code: "mora", note: "typically open early Jul–early Oct" },
+    { name: "SR 410 / Chinook Pass", manager: "wsdot", wsdot_pass_name: "Chinook Pass" },
+    { name: "SR 123 / Cayuse Pass", manager: "wsdot", wsdot_pass_name: "Cayuse Pass" },
+  ],
+  north_cascades: [
+    { name: "SR 20 / North Cascades Highway", manager: "wsdot", wsdot_pass_name: "North Cascades Highway", note: "closed mid-Nov to late Apr between Ross Dam and Mazama" },
+    { name: "Cascade River Rd", manager: "nps", nps_park_code: "noca", note: "upper half gravel; typically opens late Jun" },
+    { name: "Stehekin Valley Rd", manager: "nps", nps_park_code: "noca", note: "boat/float access only to Stehekin" },
+  ],
+  olympic: [
+    { name: "Hurricane Ridge Rd", manager: "nps", nps_park_code: "olym", note: "winter schedule applies" },
+    { name: "Sol Duc Rd", manager: "nps", nps_park_code: "olym" },
+    { name: "Olympic Hot Springs Rd (Elwha)", manager: "nps", nps_park_code: "olym", note: "long-term washout — walk/bike beyond Madison Falls" },
+  ],
+  glacier_peak: [
+    { name: "Mountain Loop Hwy", manager: "usfs", usfs_forest_slug: "mbs", note: "gravel Barlow Pass–Darrington; seasonal closure ~Nov–May/Jun" },
+    { name: "Suiattle River Rd (FR 26)", manager: "usfs", usfs_forest_slug: "mbs", note: "washout history — verify before trusting" },
+    { name: "White Chuck Rd (FR 23)", manager: "usfs", usfs_forest_slug: "mbs" },
+  ],
+  pasayten: [
+    { name: "SR 20 / North Cascades Highway", manager: "wsdot", wsdot_pass_name: "North Cascades Highway" },
+    { name: "Harts Pass Rd (FR 5400)", manager: "usfs", usfs_forest_slug: "okawen", note: "narrow cliffside gravel; no trailers; ~Jul–Oct" },
+  ],
+  alpine_lakes: [
+    { name: "I-90 / Snoqualmie Pass", manager: "wsdot", wsdot_pass_name: "Snoqualmie Pass" },
+    { name: "US-2 / Stevens Pass", manager: "wsdot", wsdot_pass_name: "Stevens Pass" },
+    { name: "Middle Fork Rd (FR 56)", manager: "usfs", usfs_forest_slug: "mbs", note: "paved to Dingford gate" },
+  ],
+  henry_jackson: [
+    { name: "Index-Galena Rd", manager: "usfs", usfs_forest_slug: "mbs", note: "reopened after long washout closure" },
+    { name: "Blanca Lake Rd (FR 63)", manager: "usfs", usfs_forest_slug: "mbs" },
+  ],
+  goat_rocks: [
+    { name: "US-12 / White Pass", manager: "wsdot", wsdot_pass_name: "White Pass" },
+    { name: "FR 21 (Snowgrass/Berry Patch)", manager: "usfs", usfs_forest_slug: "giffordpinchot", note: "gravel; ~late Jun–Oct" },
+  ],
+  mt_st_helens: [
+    { name: "FR 83 (Climber's Bivouac)", manager: "usfs", usfs_forest_slug: "giffordpinchot", note: "paved; snow-free ~Jun" },
+    { name: "FR 99 (Windy Ridge)", manager: "usfs", usfs_forest_slug: "giffordpinchot", note: "opens later, closes earlier than the south side" },
+  ],
+  mt_adams: [
+    { name: "FR 23 (Trout Lake–Randle)", manager: "usfs", usfs_forest_slug: "giffordpinchot", note: "partly gravel, slow" },
+    { name: "South Climb Rd (FR 8040-500)", manager: "usfs", usfs_forest_slug: "giffordpinchot", note: "rough gravel; high clearance comfortable" },
+  ],
+  mt_baker: [
+    { name: "SR 542 / Mt. Baker Highway (Artist Point)", manager: "wsdot", wsdot_pass_name: "Mt. Baker Highway", note: "last ~3 mi typically open mid-Jul/Aug–Oct" },
+    { name: "Glacier Creek Rd (FR 39)", manager: "usfs", usfs_forest_slug: "mbs" },
+    { name: "Schreibers Meadow Rd (FR 13, Park Butte)", manager: "usfs", usfs_forest_slug: "mbs" },
+  ],
+};
+
+/** Named origins for the impersonal drive-time parameter. */
+export const NAMED_ORIGINS: Record<string, { lat: number; lon: number }> = {
+  seattle: { lat: 47.6062, lon: -122.3321 },
+  everett: { lat: 47.9789, lon: -122.2021 },
+  tacoma: { lat: 47.2529, lon: -122.4443 },
+  bellingham: { lat: 48.7519, lon: -122.4787 },
+  portland: { lat: 45.5152, lon: -122.6784 },
+};

--- a/apps/trip-mcp/src/approach.ts
+++ b/apps/trip-mcp/src/approach.ts
@@ -1,0 +1,220 @@
+/**
+ * Curated approach-logistics data per registry area (issue #82).
+ * Registry-style curation by design — NO live place-search APIs.
+ *
+ * SCHEMA (adding areas/corridors is a data-only change): each area maps
+ * to one or more approach corridors. All fields optional strings —
+ * honest prose beats fake structure for "what does it realistically
+ * stock". `cell_coverage` is community-knowledge anecdote (low
+ * confidence, carrier-dependent). `drive_time_from_seattle_min` is a
+ * typical no-traffic estimate (static curation, not live routing —
+ * see get_access_status for the live option).
+ *
+ * Curation lesson encoded here: small-town hardware stores often carry
+ * rain gear/workwear — the last "real" gear stop is usually far closer
+ * to the city than people assume.
+ */
+
+export interface ApproachCorridor {
+  corridor: string;
+  description?: string;
+  last_gas?: string;
+  /** Last store with actual technical gear. */
+  last_real_gear?: string;
+  /** Last stop of ANY kind, with an honest note on realistic stock. */
+  last_supplies?: string;
+  last_food?: string;
+  /** Qualitative, carrier-dependent, anecdotal — low confidence. */
+  cell_coverage?: string;
+  /** Seasonal gates, washout history, clearance requirements. */
+  road_notes?: string;
+  /** Typical no-traffic estimate. */
+  drive_time_from_seattle_min?: number;
+}
+
+export const APPROACHES: Record<string, ApproachCorridor[]> = {
+  enchantments: [
+    {
+      corridor: "US-2 via Leavenworth",
+      last_gas: "Leavenworth (several stations; also Cashmere eastbound)",
+      last_real_gear: "Der Sportsmann, Leavenworth — full outdoor shop, last real gear",
+      last_supplies: "Safeway / Dan's Food Market, Leavenworth",
+      last_food: "Leavenworth (everything); nothing up Icicle Creek Rd",
+      cell_coverage: "Good in Leavenworth; fades up Icicle Creek Rd; Stuart/Colchuck TH mostly dead",
+      road_notes:
+        "Icicle Creek Rd paved past Snow Lakes TH; Eightmile Rd (FR 7601) to Stuart/Colchuck is washboard gravel, passenger-car OK, typically opens May–Jun.",
+      drive_time_from_seattle_min: 160,
+    },
+  ],
+  mt_rainier: [
+    {
+      corridor: "Nisqually entrance (SR 706 via Ashford)",
+      last_gas: "Ashford / Elbe",
+      last_real_gear:
+        "Whittaker Mountaineering, Ashford (rentals + real gear); last big-box is Puyallup/South Hill",
+      last_supplies: "Ashford Valley Grocery",
+      last_food: "Ashford / Elbe (limited evenings)",
+      cell_coverage: "OK to Ashford; patchy Longmire; Paradise has intermittent coverage",
+      road_notes:
+        "Longmire–Paradise road maintained year-round (winter gate at Longmire overnight); chains required to carry Nov 1–May 1 regardless of vehicle.",
+      drive_time_from_seattle_min: 150,
+    },
+    {
+      corridor: "White River / Sunrise (SR 410 via Enumclaw)",
+      last_gas: "Enumclaw (Greenwater has no reliable gas)",
+      last_real_gear: "Enumclaw (limited) — REI/big-box before leaving the Sound",
+      last_supplies: "Greenwater (Wapiti Woolies + small store)",
+      last_food: "Greenwater / Enumclaw",
+      cell_coverage: "Dies past Greenwater for most carriers",
+      road_notes:
+        "Sunrise Rd typically open early Jul–early Oct; SR 410 over Chinook/Cayuse closed in winter.",
+      drive_time_from_seattle_min: 135,
+    },
+  ],
+  north_cascades: [
+    {
+      corridor: "SR 20 via Marblemount",
+      last_gas: "Marblemount — last gas for ~74 miles eastbound on SR 20",
+      last_real_gear: "Nothing east of Burlington/Mount Vernon big-boxes — buy before I-5",
+      last_supplies: "Marblemount general store (basics only)",
+      last_food: "Marblemount / Concrete",
+      cell_coverage: "Gone past Marblemount for most carriers; Newhalem has NPS wifi pockets",
+      road_notes:
+        "SR 20 closes ~mid-Nov to late Apr between Ross Dam and Mazama. Cascade River Rd: 23 mi, upper half gravel, passenger-car OK when dry, typically melts open late Jun.",
+      drive_time_from_seattle_min: 165,
+    },
+  ],
+  olympic: [
+    {
+      corridor: "US-101 via Port Angeles (north side)",
+      last_gas: "Port Angeles",
+      last_real_gear: "Swain's General Store + Brown's Outdoor, Port Angeles — genuinely good gear",
+      last_supplies: "Port Angeles Safeway",
+      last_food: "Port Angeles",
+      cell_coverage: "PA good; Elwha and Sol Duc valleys dead",
+      road_notes:
+        "Hurricane Ridge Rd runs a winter schedule. Elwha (Olympic Hot Springs) road remains washed out — walk/bike beyond Madison Falls. Sol Duc road paved to trailhead.",
+      drive_time_from_seattle_min: 165,
+    },
+  ],
+  glacier_peak: [
+    {
+      corridor: "Mountain Loop Hwy via Granite Falls",
+      description: "Verlot / Barlow Pass side — Gothic Basin, Monte Cristo, White Chuck",
+      last_gas: "Granite Falls",
+      last_real_gear:
+        "Everett (Sportsman's Warehouse / Big 5) — NOTHING with real technical gear past Lake Stevens",
+      last_supplies:
+        "Mountain Loop General Store, Granite Falls; Granite Falls Ace Hardware stocks rain ponchos and work jackets — small-town hardware stores often cover a forgotten shell",
+      last_food: "Granite Falls; Verlot store snacks only (seasonal hours)",
+      cell_coverage: "Spotty past Verlot, none at Barlow Pass (all carriers)",
+      road_notes:
+        "Mountain Loop Hwy is gravel between Barlow Pass and Darrington and closes seasonally (~Nov to May/Jun). Verify status before planning a loop.",
+      drive_time_from_seattle_min: 95,
+    },
+    {
+      corridor: "SR 530 via Darrington (north side)",
+      description: "Suiattle River / White Chuck access",
+      last_gas: "Darrington",
+      last_real_gear: "Everett — same as the Granite Falls corridor; nothing in Darrington",
+      last_supplies: "Darrington IGA",
+      last_food: "Darrington",
+      cell_coverage: "Darrington OK; none up Suiattle River Rd (FR 26)",
+      road_notes:
+        "Suiattle River Rd (FR 26) has a long washout history — confirm current status with Darrington RD before trusting any mileage that assumes the road.",
+      drive_time_from_seattle_min: 110,
+    },
+  ],
+  pasayten: [
+    {
+      corridor: "SR 20 via Winthrop/Mazama",
+      last_gas: "Winthrop (Mazama pumps limited)",
+      last_real_gear: "Goat's Beard Mountain Supplies, Mazama — excellent and genuinely the last gear",
+      last_supplies: "Mazama Store (boutique but real provisions); Evergreen IGA, Winthrop for groceries",
+      last_food: "Winthrop / Mazama",
+      cell_coverage: "Methow Valley decent; nothing up the Harts Pass road",
+      road_notes:
+        "Harts Pass Rd (FR 5400): narrow cliff-side gravel, no trailers, typically open ~Jul–Oct. SR 20 winter closure removes the west-side approach entirely.",
+      drive_time_from_seattle_min: 240,
+    },
+  ],
+  alpine_lakes: [
+    {
+      corridor: "I-90 via North Bend",
+      last_gas: "North Bend",
+      last_real_gear:
+        "Pro Ski & Mountain Service, North Bend (mountaineering-oriented); full selection needs Issaquah/Seattle REI",
+      last_supplies: "North Bend Safeway / QFC",
+      last_food: "North Bend (Twede's et al.); Snoqualmie Pass has a summit deli",
+      cell_coverage: "I-90 corridor OK; Middle Fork valley and most lake basins dead",
+      road_notes:
+        "Middle Fork Rd paved to the Dingford gate. I-90 trailhead lots (Alpental, exits 47/52) overflow early on summer weekends.",
+      drive_time_from_seattle_min: 45,
+    },
+  ],
+  henry_jackson: [
+    {
+      corridor: "US-2 via Sultan/Gold Bar/Index",
+      last_gas: "Gold Bar (Sultan cheaper); Skykomish beyond",
+      last_real_gear: "Monroe (Big 5) — nothing technical past Monroe",
+      last_supplies: "Sultan Red Apple; Gold Bar mini-marts; Index General Store (limited)",
+      last_food: "Sultan Bakery (institution), Zeke's Drive-In, Gold Bar",
+      cell_coverage: "US-2 towns OK; Index-Galena Rd and FR 63 (Blanca) dead",
+      road_notes:
+        "Index-Galena Rd reopened after the long washout closure. Blanca Lake TH via FR 63 gravel, passenger-car OK; roads typically clear ~Jun.",
+      drive_time_from_seattle_min: 75,
+    },
+  ],
+  goat_rocks: [
+    {
+      corridor: "US-12 via Packwood",
+      last_gas: "Packwood",
+      last_real_gear: "Nothing real on US-12 — last serious gear is the Chehalis/Olympia I-5 corridor",
+      last_supplies: "Blanton's Market, Packwood (solid full grocery)",
+      last_food: "Packwood (Cruiser's Pizza, Blue Spruce)",
+      cell_coverage: "Packwood OK; FR 21 and Snowgrass TH dead",
+      road_notes:
+        "FR 21 to Snowgrass/Berry Patch: washboard gravel, passenger-car OK when dry, typically open late Jun–Oct.",
+      drive_time_from_seattle_min: 165,
+    },
+  ],
+  mt_st_helens: [
+    {
+      corridor: "SR 503 via Woodland/Cougar (south side)",
+      last_gas: "Cougar",
+      last_real_gear: "Nothing past Woodland — Vancouver/Portland REI before leaving I-5",
+      last_supplies: "Cougar Store / Lone Fir Resort basics",
+      last_food: "Cougar",
+      cell_coverage: "Cougar spotty; Climber's Bivouac and Marble Mountain sno-park dead",
+      road_notes:
+        "FR 83 to Climber's Bivouac paved, typically snow-free ~Jun. Windy Ridge (east side, FR 99) opens later and closes earlier.",
+      drive_time_from_seattle_min: 180,
+    },
+  ],
+  mt_adams: [
+    {
+      corridor: "SR 141 via Trout Lake",
+      last_gas: "Trout Lake (limited hours — don't arrive on fumes)",
+      last_real_gear: "Hood River, OR / White Salmon — nothing technical in Trout Lake",
+      last_supplies: "Trout Lake Grocery",
+      last_food: "Trout Lake Station Café (seasonal hours)",
+      cell_coverage: "Trout Lake weak; FR 23/FR 80xx network dead",
+      road_notes:
+        "South Climb TH via FR 8040-500: rough gravel, high-clearance comfortable though careful passenger cars make it dry. FR 23 north to Randle is partly gravel and slow.",
+      drive_time_from_seattle_min: 240,
+    },
+  ],
+  mt_baker: [
+    {
+      corridor: "SR 542 via Glacier",
+      last_gas: "Maple Falls (Glacier pumps unreliable)",
+      last_real_gear: "Bellingham (Backcountry Essentials, REI) — nothing real past Bellingham",
+      last_supplies: "Glacier convenience stores",
+      last_food: "Glacier (Chair 9, Wake 'n Bakery)",
+      cell_coverage: "Glacier spotty; dead past the DOT shed / Heather Meadows",
+      road_notes:
+        "SR 542's last ~3 miles to Artist Point typically open only mid-Jul/Aug–Oct. Glacier Creek and Skyline Divide FR roads are gravel with pothole minefields.",
+      drive_time_from_seattle_min: 150,
+    },
+  ],
+};

--- a/apps/trip-mcp/src/areas.ts
+++ b/apps/trip-mcp/src/areas.ts
@@ -25,6 +25,19 @@ export interface RangerStation {
   hours?: string;
 }
 
+/**
+ * Named river crossing (or crossing corridor) mapped to the most
+ * relevant USGS NWIS gauge. Data-only: adding a crossing is a registry
+ * edit, no code change. `note` carries the honest relevance caveat when
+ * the gauge is downstream/distant from the actual crossing.
+ */
+export interface Crossing {
+  name: string;
+  /** USGS NWIS site id, e.g. "12186000". */
+  gauge_site_id: string;
+  note?: string;
+}
+
 export interface Area {
   id: string;
   name: string;
@@ -45,6 +58,8 @@ export interface Area {
   notes?: string;
   /** Forest Service forest slug for alert page scraping. */
   usfs_forest_slug?: string;
+  /** Curated crossing→USGS-gauge mappings for get_river_conditions. */
+  crossings?: Crossing[];
 }
 
 export const AREAS: Area[] = [
@@ -69,6 +84,13 @@ export const AREAS: Area[] = [
       "Advanced lottery Feb 15–Mar 1; results ~Mar 15; unclaimed permits release Apr 1. " +
       "Core Zone <5%, Snow Zone ~15%, Colchuck/Stuart higher. Daily Lottery via geofenced " +
       "mobile app for walk-up permits. Bear canister required.",
+    crossings: [
+      {
+        name: "Icicle Creek (Snow Lakes trailhead / Icicle road corridor)",
+        gauge_site_id: "12458000",
+        note: "Gauge above Snow Creek near Leavenworth — directly on the approach corridor.",
+      },
+    ],
   },
   {
     id: "mt_rainier",
@@ -92,6 +114,13 @@ export const AREAS: Area[] = [
       "Wilderness permit required year-round. Early-Access Lottery Feb 10–Mar 3 (2026); " +
       "general on-sale Apr 25; reservable through Oct 12. 2/3 advance, 1/3 walk-up. " +
       "Wonderland Trail demand outstrips supply.",
+    crossings: [
+      {
+        name: "Nisqually drainage (Longmire side, west Wonderland crossings)",
+        gauge_site_id: "12082500",
+        note: "Gauge near National, below the park — glacial afternoon pulses show here after the fact; cross glacial streams in the morning.",
+      },
+    ],
   },
   {
     id: "north_cascades",
@@ -113,6 +142,18 @@ export const AREAS: Area[] = [
     notes:
       "60% reservable / 40% walk-up. Early-Access Lottery Mar 2–Mar 13 (2026); general " +
       "on-sale Apr 29; reservable through Oct 10. SR 20 typically closed mid-Nov to mid-late April.",
+    crossings: [
+      {
+        name: "Stehekin valley crossings",
+        gauge_site_id: "12451000",
+        note: "Gauge at Stehekin townsite — mainstem trend for the valley corridor.",
+      },
+      {
+        name: "Cascade River (Cascade Pass approach)",
+        gauge_site_id: "12182500",
+        note: "Gauge at Marblemount, well below the trailhead — trend-level relevance.",
+      },
+    ],
   },
   {
     id: "olympic",
@@ -136,6 +177,18 @@ export const AREAS: Area[] = [
       "releases Apr 15 7AM PT. No early-access lottery. Bear canisters required everywhere. " +
       "High-demand quota areas: Sol Duc/7 Lakes, Royal Basin, Grand Valley, Lake Constance, " +
       "Upper Lena, Flapjack, Cape Alava.",
+    crossings: [
+      {
+        name: "Elwha River corridor (Elwha/Long Ridge, Press Expedition route)",
+        gauge_site_id: "12045500",
+        note: "Gauge at McDonald Bridge near Port Angeles — mainstem trend; tributary crossings differ.",
+      },
+      {
+        name: "Quinault River (Enchanted Valley approach)",
+        gauge_site_id: "12039500",
+        note: "Gauge at Quinault Lake, downstream of the valley — trend-level relevance.",
+      },
+    ],
   },
   {
     id: "glacier_peak",
@@ -157,6 +210,18 @@ export const AREAS: Area[] = [
     notes:
       "Self-issued wilderness permits at trailheads. Northwest Forest Pass required for " +
       "trailhead parking. FR 7400 (Suiattle River) closures common. Remote, low-traffic.",
+    crossings: [
+      {
+        name: "White Chuck / upper Sauk crossings (Kennedy Hot Springs, White Chuck corridor)",
+        gauge_site_id: "12186000",
+        note: "Gauge is Sauk R above White Chuck nr Darrington — upstream crossings run smaller but track the same snowmelt trend.",
+      },
+      {
+        name: "Suiattle River corridor (Image Lake, Miners Ridge approaches)",
+        gauge_site_id: "12189500",
+        note: "Gauge is Sauk R near Sauk, downstream of the Suiattle confluence — trend-level relevance only.",
+      },
+    ],
   },
   {
     id: "pasayten",
@@ -197,6 +262,13 @@ export const AREAS: Area[] = [
     notes:
       "Self-issued except for Enchantments Permit Area. Closest big wilderness to Seattle. " +
       "I-90 and US-2 trailheads.",
+    crossings: [
+      {
+        name: "Middle Fork Snoqualmie corridor",
+        gauge_site_id: "12141300",
+        note: "Gauge near Tanner — directly on the Middle Fork approach; upstream crossings run smaller.",
+      },
+    ],
   },
   {
     id: "henry_jackson",
@@ -216,6 +288,13 @@ export const AREAS: Area[] = [
     ],
     usfs_forest_slug: "mbs",
     notes: "Self-issued. US-2 and Mountain Loop Highway access.",
+    crossings: [
+      {
+        name: "Skykomish drainage (US-2 side approaches)",
+        gauge_site_id: "12134500",
+        note: "Gauge near Gold Bar, far downstream — trend-level context only for tributary crossings.",
+      },
+    ],
   },
   {
     id: "goat_rocks",
@@ -236,6 +315,13 @@ export const AREAS: Area[] = [
     notes:
       "Self-issued. PCT corridor through Knife's Edge between Old Snowy and Elk Pass. " +
       "Mountain goats (give them space and salty pee a wide berth).",
+    crossings: [
+      {
+        name: "Cowlitz drainage (Packwood-side approaches)",
+        gauge_site_id: "14226500",
+        note: "Gauge at Packwood, downstream — trend-level context for snowmelt timing.",
+      },
+    ],
   },
   {
     id: "mt_st_helens",

--- a/apps/trip-mcp/src/camping.ts
+++ b/apps/trip-mcp/src/camping.ts
@@ -1,0 +1,273 @@
+/**
+ * Curated camp + water beta per registry area (issue #84). Data-only
+ * schema; overnight-specific by design (day-hike parity means this
+ * lives in its own tool, not bolted onto get_route_info).
+ *
+ * Rules ALWAYS cite a governing source URL — fire and food-storage
+ * rules are never stated as bare fact. Bear/wildlife safety content
+ * stays in get_safety_brief; permits stay in get_permits — this file
+ * references, never duplicates.
+ */
+
+export interface NamedCamp {
+  name: string;
+  elevation_ft?: number;
+  note?: string;
+}
+
+export interface SourcedRule {
+  detail: string;
+  /** Governing source (forest order / park regulations page). */
+  source_url: string;
+}
+
+export interface WaterReliability {
+  source: string;
+  note: string;
+}
+
+export interface Camping {
+  regulation_model: "designated_sites_only" | "zone_quota" | "dispersed_with_rules";
+  regulation_detail: string;
+  named_camps?: NamedCamp[];
+  fire_rules: SourcedRule;
+  food_storage: SourcedRule & { cross_ref: string };
+  /** Late-season reliability notes — curated, LOW confidence. */
+  water_reliability?: WaterReliability[];
+  permits_pointer: string;
+}
+
+const MBS_URL = "https://www.fs.usda.gov/mbs";
+const OKAWEN_URL = "https://www.fs.usda.gov/okawen";
+const GP_URL = "https://www.fs.usda.gov/giffordpinchot";
+const SAFETY_XREF = "see get_safety_brief for bear/wildlife practice — not duplicated here";
+const PERMITS_XREF = "see get_permits / get_permit_strategy for permit requirements";
+
+export const CAMPING: Record<string, Camping> = {
+  enchantments: {
+    regulation_model: "zone_quota",
+    regulation_detail:
+      "Overnight permit zones (Core, Snow, Colchuck, Stuart, Eightmile); camp only in your permitted zone, established sites only in the Core.",
+    named_camps: [
+      { name: "Core zone established sites (Perfection/Inspiration basin)", elevation_ft: 7000, note: "durable-surface sites; no site reservations — first-come within the zone" },
+      { name: "Snow Lakes / Nada Lake sites", elevation_ft: 5400 },
+      { name: "Colchuck Lake sites", elevation_ft: 5600 },
+    ],
+    fire_rules: {
+      detail: "Campfires prohibited throughout the Enchantment Permit Area and above 5,000 ft in the Alpine Lakes Wilderness.",
+      source_url: OKAWEN_URL,
+    },
+    food_storage: {
+      detail: "Bear canisters REQUIRED for overnight stays in the permit area.",
+      source_url: OKAWEN_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Core zone tarns/lakes", note: "reliable all season (alpine lakes)" },
+      { source: "Aasgard Pass ascent", note: "dry climb after early-season snowmelt — carry from Colchuck" },
+      { source: "Snow Creek between Nada and the trailhead", note: "reliable but silty stretches late season" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  mt_rainier: {
+    regulation_model: "designated_sites_only",
+    regulation_detail:
+      "Trailside camping only in designated wilderness camps (itinerary locked to your permit); limited cross-country zones by special arrangement.",
+    named_camps: [
+      { name: "Summerland", elevation_ft: 5900 },
+      { name: "Indian Bar", elevation_ft: 5100 },
+      { name: "Mystic Camp", elevation_ft: 5700 },
+      { name: "Klapatche Park", elevation_ft: 5500 },
+    ],
+    fire_rules: {
+      detail: "Wood fires prohibited in the Mount Rainier wilderness (stoves only).",
+      source_url: "https://www.nps.gov/mora/planyourvisit/wilderness-camping.htm",
+    },
+    food_storage: {
+      detail: "Food storage poles/boxes at most designated camps; canisters recommended elsewhere and required for winter camping.",
+      source_url: "https://www.nps.gov/mora/planyourvisit/wilderness-camping.htm",
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Designated camps", note: "nearly all sit near reliable water (that's why they're there); Klapatche's lake gets stagnant late season — treat carefully" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  north_cascades: {
+    regulation_model: "designated_sites_only",
+    regulation_detail:
+      "Designated camps (trailside) plus permitted cross-country zones; itinerary fixed by permit.",
+    named_camps: [
+      { name: "Sahale Glacier Camp", elevation_ft: 7600, note: "highest designated camp in the park; wind-exposed rock rings" },
+      { name: "Pelton Basin", elevation_ft: 4800 },
+      { name: "Thunder Basin camps", elevation_ft: 3200 },
+    ],
+    fire_rules: {
+      detail: "Fires only in provided fire grates at low-elevation camps; prohibited in cross-country zones and above ~4,000 ft in most of the park.",
+      source_url: "https://www.nps.gov/noca/planyourvisit/wilderness-trip-planner.htm",
+    },
+    food_storage: {
+      detail: "Bear canisters required in cross-country zones and strongly encouraged everywhere; some camps have bear boxes.",
+      source_url: "https://www.nps.gov/noca/planyourvisit/wilderness-trip-planner.htm",
+      cross_ref: SAFETY_XREF,
+    },
+    permits_pointer: PERMITS_XREF,
+  },
+  olympic: {
+    regulation_model: "zone_quota",
+    regulation_detail:
+      "Quota zones with mixed designated sites (Seven Lakes Basin, Royal Basin) and dispersed zones elsewhere; coast has its own site rules.",
+    fire_rules: {
+      detail: "Fires prohibited above 3,500 ft parkwide and in several named basins; coast fires only below high-tide line where allowed.",
+      source_url: "https://www.nps.gov/olym/planyourvisit/wilderness-regulations.htm",
+    },
+    food_storage: {
+      detail: "Bear canisters required parkwide for wilderness camping (coast included — raccoons are the coast menace).",
+      source_url: "https://www.nps.gov/olym/planyourvisit/wilderness-regulations.htm",
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Coast strips", note: "creek mouths reliable but tannic; carry capacity between named creeks in dry stretches" },
+      { source: "High Divide / Seven Lakes", note: "lake water reliable; ridge stretches dry late season" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  glacier_peak: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail:
+      "Dispersed camping with standard wilderness rules: 100 ft from water and trails, durable surfaces, existing sites preferred.",
+    fire_rules: {
+      detail: "Fires discouraged above subalpine and prohibited within 100 ft of water; seasonal total bans common (check get_conditions).",
+      source_url: MBS_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; proper hangs or canisters expected — habituated bears around Image Lake historically.",
+      source_url: MBS_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Image Lake", note: "reliable, but the ridge approach from Suiattle is a long dry climb late season" },
+      { source: "White Chuck basin", note: "glacial sources silty — prefer clear tributaries" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  pasayten: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail: "Dispersed camping, 100-ft rules; stock parties have additional grazing rules.",
+    fire_rules: {
+      detail: "Fires generally allowed below treeline outside ban periods; prohibited in some heavily-used basins (posted).",
+      source_url: OKAWEN_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; hangs expected — this is grizzly-adjacent country by designation if not by sightings.",
+      source_url: OKAWEN_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Boundary Trail high stretches", note: "long dry sections late season — tank up at named lakes" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  alpine_lakes: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail:
+      "Dispersed with 100-ft rules; several popular lakes have posted no-camping shorelines or designated-site clusters (e.g. Snow Lake).",
+    fire_rules: {
+      detail: "No fires above 5,000 ft in the Alpine Lakes Wilderness; many lake basins posted no-fire at any elevation.",
+      source_url: MBS_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement outside the Enchantment Permit Area; hangs or canisters expected.",
+      source_url: MBS_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    permits_pointer: PERMITS_XREF,
+  },
+  henry_jackson: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail: "Dispersed with 100-ft rules; Blanca Lake has heavily-impacted posted sites — use existing ones.",
+    fire_rules: {
+      detail: "Fires prohibited at Blanca Lake and above 4,000 ft in posted basins.",
+      source_url: MBS_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; hangs expected.",
+      source_url: MBS_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    permits_pointer: PERMITS_XREF,
+  },
+  goat_rocks: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail:
+      "Dispersed with 100-ft rules; Shoe Lake basin CLOSED to camping (restoration); Snowgrass Flat camping restricted to posted sites.",
+    fire_rules: {
+      detail: "No fires in the Shoe Lake basin or above 5,000 ft; seasonal bans common.",
+      source_url: GP_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; hangs expected — mountain goats are the real camp raiders (salt).",
+      source_url: GP_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Knife's Edge / PCT crest", note: "bone dry — last reliable water at Snowgrass side creeks or Elk Pass snowfields early season" },
+      { source: "Snowgrass Flat creeks", note: "reliable all season" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  mt_st_helens: {
+    regulation_model: "zone_quota",
+    regulation_detail:
+      "Mount Margaret Backcountry: designated sites by permit only. Climbing route: no camping above treeline on the south side (day climbs); dispersed camping outside the restricted monument zones.",
+    named_camps: [
+      { name: "Mount Margaret backcountry camps (Dome, Ridge, etc.)", note: "tiny quota, book like a lottery" },
+    ],
+    fire_rules: {
+      detail: "No fires in the Mount Margaret Backcountry or the blast zone.",
+      source_url: GP_URL,
+    },
+    food_storage: {
+      detail: "Hangs/canisters expected; no formal requirement.",
+      source_url: GP_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "Loowit Trail circuit", note: "notoriously dry — long waterless stretches on pumice; plan carries and verify seasonal sources in trip reports" },
+      { source: "Mount Margaret ridge camps", note: "most are DRY camps — carry from lakes below" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  mt_adams: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail: "Dispersed with 100-ft rules; South Climb camps concentrate at Lunch Counter on durable rock.",
+    fire_rules: {
+      detail: "No fires above 7,000 ft (Cascades Volcano Pass zone); seasonal bans below.",
+      source_url: GP_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; hangs expected below treeline.",
+      source_url: GP_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    water_reliability: [
+      { source: "South Climb above Morrison Creek", note: "snowmelt only — after the snowfields recede it is a dry route; melt or carry" },
+      { source: "Round-the-Mountain meadows", note: "seasonal creeks fade by late Aug in dry years" },
+    ],
+    permits_pointer: PERMITS_XREF,
+  },
+  mt_baker: {
+    regulation_model: "dispersed_with_rules",
+    regulation_detail: "Dispersed with 100-ft rules; heather meadows areas have posted site restrictions.",
+    fire_rules: {
+      detail: "Fires prohibited in the heather zones (Chain Lakes, Park Butte) — stoves only.",
+      source_url: MBS_URL,
+    },
+    food_storage: {
+      detail: "No canister requirement; hangs expected.",
+      source_url: MBS_URL,
+      cross_ref: SAFETY_XREF,
+    },
+    permits_pointer: PERMITS_XREF,
+  },
+};

--- a/apps/trip-mcp/src/extraction.test.ts
+++ b/apps/trip-mcp/src/extraction.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { extractConditions, rollupConditions } from "./extraction.js";
+
+describe("extractConditions", () => {
+  it("extracts snow with a parsed snow line", () => {
+    const c = extractConditions(
+      "Trail in great shape. Hit continuous snow at 5,200 ft below the pass; microspikes helpful.",
+    );
+    expect(c.snow.mentioned).toBe(true);
+    expect(c.snow.snow_line_ft).toBe(5200);
+    expect(c.snow.detail).toContain("5,200");
+  });
+
+  it("extracts blowdowns, road status, water, and crowding", () => {
+    const c = extractConditions(
+      "Several blowdowns in the first mile. Road washed out at FR 49 — high clearance advised. " +
+        "Creeks are flowing well. Parking lot full by 8am.",
+    );
+    expect(c.blowdowns.mentioned).toBe(true);
+    expect(c.road_status.mentioned).toBe(true);
+    expect(c.water.mentioned).toBe(true);
+    expect(c.crowding.mentioned).toBe(true);
+  });
+
+  it("grades bug severity from surrounding language", () => {
+    expect(extractConditions("Mosquitoes were relentless at the lake.").bugs.severity).toBe("high");
+    expect(extractConditions("A few bugs but not bad at all.").bugs.severity).toBe("low");
+    expect(extractConditions("Some mosquitoes near camp.").bugs.severity).toBe("moderate");
+  });
+
+  it("never fabricates: silent text yields unmentioned fields with null detail", () => {
+    const c = extractConditions("Lovely wildflowers and clear views the whole way.");
+    expect(c.snow).toEqual({ mentioned: false, detail: null, snow_line_ft: null });
+    expect(c.blowdowns).toEqual({ mentioned: false, detail: null });
+    expect(c.bugs.severity).toBeNull();
+  });
+});
+
+describe("rollupConditions", () => {
+  it("counts mentions with per-claim report attribution", () => {
+    const mk = (url: string, text: string) => ({
+      url,
+      title: null,
+      date_hiked: null,
+      conditions: extractConditions(text),
+    });
+    const roll = rollupConditions([
+      mk("u1", "Snow at 5,500 ft. Mosquitoes thick."),
+      mk("u2", "Snow free below the basin... wait, snowfields above 5,600 ft remain."),
+      mk("u3", "Dry trail, no conditions to report."),
+    ]);
+    expect(roll.snow.mention_count).toBe(2);
+    expect(roll.snow.total_reports).toBe(3);
+    expect(roll.snow.report_urls).toEqual(["u1", "u2"]);
+    expect(roll.snow.snow_lines_ft).toContain(5500);
+    expect(roll.summary.some((s) => s.includes("2 of 3"))).toBe(true);
+  });
+});

--- a/apps/trip-mcp/src/extraction.ts
+++ b/apps/trip-mcp/src/extraction.ts
@@ -1,0 +1,166 @@
+/**
+ * Heuristic condition extraction from trip-report text (issue #81,
+ * design option 1: keyword/regex in the Worker — cheap, deterministic,
+ * decent recall on WTA's formulaic reports; labeled low confidence).
+ *
+ * Contract: NEVER fabricate specifics. A field absent from the text is
+ * {mentioned: false, detail: null} — nothing is inferred. The interface
+ * is shaped so an LLM extractor could swap in later (same output type,
+ * different `method` label).
+ */
+
+export interface ConditionMention {
+  mentioned: boolean;
+  /** Short verbatim-ish snippet around the match; null when unmentioned. */
+  detail: string | null;
+}
+
+export interface SnowMention extends ConditionMention {
+  snow_line_ft: number | null;
+}
+
+export interface BugMention extends ConditionMention {
+  severity: "low" | "moderate" | "high" | null;
+}
+
+export interface ExtractedConditions {
+  snow: SnowMention;
+  blowdowns: ConditionMention;
+  road_status: ConditionMention;
+  bugs: BugMention;
+  water: ConditionMention;
+  crowding: ConditionMention;
+}
+
+/** Grab a readable snippet around a regex match. */
+function snippet(text: string, index: number, matchLen: number): string {
+  const start = Math.max(0, index - 60);
+  const end = Math.min(text.length, index + matchLen + 80);
+  let s = text.slice(start, end).replace(/\s+/g, " ").trim();
+  if (start > 0) s = `…${s}`;
+  if (end < text.length) s = `${s}…`;
+  return s.slice(0, 200);
+}
+
+function findMention(text: string, re: RegExp): ConditionMention {
+  const m = re.exec(text);
+  if (!m || m.index === undefined) return { mentioned: false, detail: null };
+  return { mentioned: true, detail: snippet(text, m.index, m[0].length) };
+}
+
+const SNOW_RE = /\bsnow(?:y|field|fields|pack|line)?\b/i;
+const SNOW_LINE_RE =
+  /snow[^.]{0,40}?(?:at|above|around|near|starting|from|by)\s*~?\s*(\d{1,2}[,]?\d{3})\s*(?:ft|feet|')/i;
+const BLOWDOWN_RE = /blow[- ]?downs?|downed trees?|trees? (?:down|across)|deadfall|windfall/i;
+const ROAD_RE =
+  /road (?:is )?(?:closed|washed|rough|gated|open|fine)|washout|wash-out|high[- ]clearance|pot[- ]?holes?|\bFR[- ]?\d+|forest road/i;
+const BUG_RE = /mosquito(?:e?s)?|\bbugs?\b|black ?fl(?:y|ies)|biting insects/i;
+const BUG_HIGH_RE = /swarm|relentless|brutal|awful|terrible|thick|vicious|miserable|ate (?:me|us) alive/i;
+const BUG_LOW_RE = /no (?:bugs|mosquito)|bug[- ]free|few (?:bugs|mosquito)|not (?:too )?bad|minimal/i;
+const WATER_RE =
+  /water (?:sources?|available|running|flowing|is dry)|(?:streams?|creeks?|springs?|tarns?) (?:are |were |is |was )?(?:dry|flowing|running|full|low)|filtered water|no water/i;
+const CROWD_RE =
+  /crowd(?:ed|s)?|busy|packed|full parking|parking (?:lot|was) (?:full|overflowing)|overflowing|solitude|(?:trail|lake) to (?:my|our)sel(?:f|ves)|hardly (?:anyone|a soul)|quiet/i;
+
+export function extractConditions(text: string): ExtractedConditions {
+  const t = text ?? "";
+
+  const snowBase = findMention(t, SNOW_RE);
+  const lineM = SNOW_LINE_RE.exec(t);
+  const snow: SnowMention = {
+    ...snowBase,
+    snow_line_ft: lineM?.[1] ? Number.parseInt(lineM[1].replace(",", ""), 10) : null,
+  };
+  if (lineM && lineM.index !== undefined) {
+    snow.detail = snippet(t, lineM.index, lineM[0].length);
+  }
+
+  const bugBase = findMention(t, BUG_RE);
+  let severity: BugMention["severity"] = null;
+  if (bugBase.mentioned && bugBase.detail) {
+    if (BUG_LOW_RE.test(bugBase.detail)) severity = "low";
+    else if (BUG_HIGH_RE.test(bugBase.detail)) severity = "high";
+    else severity = "moderate";
+  }
+
+  return {
+    snow,
+    blowdowns: findMention(t, BLOWDOWN_RE),
+    road_status: findMention(t, ROAD_RE),
+    bugs: { ...bugBase, severity },
+    water: findMention(t, WATER_RE),
+    crowding: findMention(t, CROWD_RE),
+  };
+}
+
+export interface ReportExtraction {
+  url: string;
+  title: string | null;
+  date_hiked: string | null;
+  conditions: ExtractedConditions;
+}
+
+export interface CategoryRollup {
+  mention_count: number;
+  total_reports: number;
+  /** URLs of the reports behind each claim — rollups always cite. */
+  report_urls: string[];
+}
+
+export interface ConditionsRollup {
+  snow: CategoryRollup & { snow_lines_ft: number[] };
+  blowdowns: CategoryRollup;
+  road_status: CategoryRollup;
+  bugs: CategoryRollup & { severities: Array<"low" | "moderate" | "high"> };
+  water: CategoryRollup;
+  crowding: CategoryRollup;
+  summary: string[];
+}
+
+export function rollupConditions(extractions: ReportExtraction[]): ConditionsRollup {
+  const total = extractions.length;
+  const cat = (pick: (e: ReportExtraction) => ConditionMention): CategoryRollup => {
+    const hits = extractions.filter((e) => pick(e).mentioned);
+    return {
+      mention_count: hits.length,
+      total_reports: total,
+      report_urls: hits.map((h) => h.url),
+    };
+  };
+
+  const snow = {
+    ...cat((e) => e.conditions.snow),
+    snow_lines_ft: extractions
+      .map((e) => e.conditions.snow.snow_line_ft)
+      .filter((v): v is number => v !== null),
+  };
+  const bugs = {
+    ...cat((e) => e.conditions.bugs),
+    severities: extractions
+      .map((e) => e.conditions.bugs.severity)
+      .filter((v): v is "low" | "moderate" | "high" => v !== null),
+  };
+  const blowdowns = cat((e) => e.conditions.blowdowns);
+  const road_status = cat((e) => e.conditions.road_status);
+  const water = cat((e) => e.conditions.water);
+  const crowding = cat((e) => e.conditions.crowding);
+
+  const summary: string[] = [];
+  const say = (label: string, c: CategoryRollup, extra = "") => {
+    if (c.mention_count > 0) {
+      summary.push(`${c.mention_count} of ${total} recent reports mention ${label}${extra}.`);
+    }
+  };
+  say(
+    "snow",
+    snow,
+    snow.snow_lines_ft.length > 0 ? ` (snow lines: ${snow.snow_lines_ft.join(", ")} ft)` : "",
+  );
+  say("blowdowns/downed trees", blowdowns);
+  say("road conditions", road_status);
+  say("bugs", bugs, bugs.severities.length > 0 ? ` (severity: ${bugs.severities.join(", ")})` : "");
+  say("water availability", water);
+  say("crowding", crowding);
+
+  return { snow, blowdowns, road_status, bugs, water, crowding, summary };
+}

--- a/apps/trip-mcp/src/permit_strategy.ts
+++ b/apps/trip-mcp/src/permit_strategy.ts
@@ -1,0 +1,203 @@
+/**
+ * Curated permit-acquisition strategy per registry area (issue #83) —
+ * the layer get_permits' metadata doesn't carry: realistic paths in,
+ * walk-up beta, cancellation patterns. Odds are historical/approximate
+ * (year noted where known) and shift yearly; recreation.gov + the
+ * ranger station stay authoritative. Data-only schema.
+ */
+
+export interface PermitPath {
+  method: string;
+  window: string;
+  odds_context: string;
+  effort: "low" | "moderate" | "high";
+  notes?: string;
+}
+
+export interface PermitStrategy {
+  paths: PermitPath[];
+  /** Where/when cancellations rebook — low confidence, curated. */
+  cancellation_beta?: string;
+  /** For areas with real walk-up quotas: who issues, when lines form. */
+  walk_up_beta?: string;
+  /** Per-zone difficulty differences where relevant. */
+  zone_notes?: string;
+}
+
+const SELF_ISSUED: PermitStrategy = {
+  paths: [
+    {
+      method: "self-issued permit at the trailhead kiosk",
+      window: "any time",
+      odds_context: "unlimited — no quota",
+      effort: "low",
+      notes: "No strategy needed. Northwest Forest Pass (or interagency pass) for trailhead parking where posted.",
+    },
+  ],
+};
+
+export const PERMIT_STRATEGIES: Record<string, PermitStrategy> = {
+  enchantments: {
+    paths: [
+      {
+        method: "main overnight lottery (recreation.gov)",
+        window: "applications Feb 15–Mar 1; results ~Mar 15",
+        odds_context: "historical (2024–25): Core Zone <5%, Snow Zone ~15%, Colchuck/Stuart/Eightmile somewhat higher",
+        effort: "low",
+        notes: "Flexible dates and the smaller zones meaningfully improve odds; Core weekends are the worst case.",
+      },
+      {
+        method: "unclaimed/cancelled date release + rolling cancellations",
+        window: "unclaimed lottery dates release ~Apr 1; cancellations rebook all season",
+        odds_context: "genuine but grabby — dates appear and vanish in minutes",
+        effort: "moderate",
+        notes: "Weekday shoulder-season dates reappear most often.",
+      },
+      {
+        method: "daily continuation lottery (geofenced mobile app)",
+        window: "day-before drawing during the permit season",
+        odds_context: "long odds for Core, workable for Colchuck/Stuart midweek",
+        effort: "moderate",
+        notes: "Must be physically in-region to enter; plan a backup night.",
+      },
+      {
+        method: "day-use (no permit) thru-hike",
+        window: "any day in season",
+        odds_context: "unlimited — day use needs no permit",
+        effort: "high",
+        notes: "The ~19 mi Snow Lakes↔Stuart TH traverse over Aasgard in a day is legal and popular but a serious physical undertaking.",
+      },
+      {
+        method: "off-season overnight (no permit required)",
+        window: "Nov 1–May 31",
+        odds_context: "unlimited",
+        effort: "high",
+        notes: "Honest caveat: that window is winter conditions — snow travel, avalanche exposure, short days.",
+      },
+    ],
+    cancellation_beta:
+      "Cancellations repost at unpredictable times; evening refreshes near the 1–2 week cancellation-fee cutoffs are anecdotally most productive. Low confidence.",
+    zone_notes:
+      "Core Zone is the prize and the bottleneck; Snow/Colchuck/Stuart/Eightmile zones grant legal access to day-trip the Core from camp.",
+  },
+  mt_rainier: {
+    paths: [
+      {
+        method: "early-access lottery (recreation.gov)",
+        window: "Feb 10–Mar 3 (2026); awarded slots book first",
+        odds_context: "lottery only orders booking access — itinerary success depends on flexibility",
+        effort: "low",
+      },
+      {
+        method: "general on-sale",
+        window: "opens Apr 25 (2026) for the season through Oct 12",
+        odds_context: "non-Wonderland itineraries remain reasonably gettable; full Wonderland circuits go instantly",
+        effort: "moderate",
+      },
+      {
+        method: "walk-up (1/3 of permits held back)",
+        window: "day-before or day-of at Wilderness Information Centers",
+        odds_context: "genuinely workable midweek; segment-by-segment Wonderland linking beats asking for a full circuit",
+        effort: "high",
+      },
+    ],
+    walk_up_beta:
+      "Longmire and White River WICs issue from opening (~7:30–8am in summer); lines form 30–60 min earlier on weekends. Flexible start trailheads are the lever. Low-to-medium confidence.",
+    cancellation_beta: "Summer cancellations repost steadily; morning checks catch the overnight batch. Low confidence.",
+    zone_notes: "Wonderland camps are the constraint — cross-country zones and lesser camps hold availability much longer.",
+  },
+  north_cascades: {
+    paths: [
+      {
+        method: "early-access lottery (recreation.gov)",
+        window: "Mar 2–13 (2026); general on-sale Apr 29",
+        odds_context: "60% of capacity is reservable; marquee camps (Sahale Glacier) vanish at on-sale",
+        effort: "low",
+      },
+      {
+        method: "walk-up (40% of capacity held back)",
+        window: "day-before + day-of at the Marblemount Wilderness Information Center",
+        odds_context: "the best walk-up ratio of the big parks — midweek success is common outside the marquee camps",
+        effort: "moderate",
+      },
+    ],
+    walk_up_beta:
+      "Marblemount WIC issues from opening (7am peak season); arrive early for Sahale/Cascade Pass camps, relax for everything else. Medium confidence.",
+    zone_notes: "Boston Basin and Sahale are permit unicorns; Stehekin-side and east-bank camps are routinely available.",
+  },
+  olympic: {
+    paths: [
+      {
+        method: "general on-sale (recreation.gov, no lottery)",
+        window: "Apr 15 7:00 AM PT release for the May 15–Oct 15 season",
+        odds_context: "quota areas (Seven Lakes Basin, Royal Basin, Grand Valley…) sell out within minutes-to-hours for weekends",
+        effort: "moderate",
+        notes: "Set a calendar alarm — this is a fastest-fingers release, not a lottery.",
+      },
+      {
+        method: "rolling cancellations",
+        window: "all season",
+        odds_context: "steady churn; midweek quota nights reappear regularly",
+        effort: "moderate",
+      },
+      {
+        method: "non-quota zones",
+        window: "any time",
+        odds_context: "most of the park's wilderness is non-quota and bookable same-day online",
+        effort: "low",
+        notes: "Coast strips and valley routes often have space when the alpine quota areas are full.",
+      },
+    ],
+    cancellation_beta: "No formal walk-up hold-back — cancellation watching is the fallback for quota zones. Low confidence.",
+  },
+  glacier_peak: SELF_ISSUED,
+  pasayten: SELF_ISSUED,
+  alpine_lakes: {
+    ...SELF_ISSUED,
+    zone_notes:
+      "Self-issued everywhere EXCEPT the Enchantment Permit Area — use the enchantments area entry for that zone's lottery reality.",
+  },
+  henry_jackson: SELF_ISSUED,
+  goat_rocks: SELF_ISSUED,
+  mt_st_helens: {
+    paths: [
+      {
+        method: "climbing permit on-sale (recreation.gov)",
+        window: "season quota (Apr–Oct) releases in early-year batches; ~$15",
+        odds_context: "summer weekends sell out almost immediately; weekdays linger longer",
+        effort: "moderate",
+      },
+      {
+        method: "cancellation watching",
+        window: "all season",
+        odds_context: "nightly churn is real — persistent checking lands weekday slots",
+        effort: "moderate",
+      },
+      {
+        method: "winter self-issued (free)",
+        window: "Dec 1–Mar 31",
+        odds_context: "unlimited",
+        effort: "high",
+        notes: "Winter/spring snow climb — many prefer it to the summer scree slog, with commensurate skills required.",
+      },
+    ],
+    zone_notes: "Mount Margaret Backcountry camps run a separate small quota — book like a quota area, not like the climb.",
+  },
+  mt_adams: {
+    paths: [
+      {
+        method: "Cascades Volcano Pass (above 7,000 ft)",
+        window: "in season (~Jun–Sep), purchased via recreation.gov or Trout Lake RD",
+        odds_context: "no quota — a fee pass, not a competition (~$15 weekday / $30 weekend historical)",
+        effort: "low",
+      },
+      {
+        method: "below 7,000 ft: self-issued",
+        window: "any time",
+        odds_context: "unlimited",
+        effort: "low",
+      },
+    ],
+  },
+  mt_baker: SELF_ISSUED,
+};

--- a/apps/trip-mcp/src/polyline.test.ts
+++ b/apps/trip-mcp/src/polyline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cumulativeM, haversineM, resamplePolyline } from "./polyline.js";
+import { chainSegments, cumulativeM, haversineM, resamplePolyline } from "./polyline.js";
 
 // ~1.1km due-north segment near Barlow Pass.
 const A = { lat: 48.02, lon: -121.44 };
@@ -47,5 +47,57 @@ describe("polyline", () => {
     const out = resamplePolyline([A, A, A], 10);
     expect(out).toHaveLength(3);
     expect(out.every((p) => p.mile === 0)).toBe(true);
+  });
+});
+
+describe("chainSegments", () => {
+  // Three collinear segments heading north, each ~1.1 km, sharing endpoints.
+  const p = (lat: number) => ({ lat, lon: -121.44 });
+  const seg1 = [p(48.0), p(48.01)];
+  const seg2 = [p(48.01), p(48.02)];
+  const seg3 = [p(48.02), p(48.03)];
+
+  it("chains connected segments in order from the hint endpoint", () => {
+    const out = chainSegments([seg2, seg3, seg1], p(48.0));
+    expect(out.segments_used).toBe(3);
+    expect(out.bridged_gaps_m).toEqual([]);
+    expect(out.leftover_segments).toBe(0);
+    expect(out.points[0]!.lat).toBeCloseTo(48.0, 6);
+    expect(out.points[out.points.length - 1]!.lat).toBeCloseTo(48.03, 6);
+  });
+
+  it("reverses segments stored in the opposite direction", () => {
+    const seg2rev = [...seg2].reverse();
+    const out = chainSegments([seg1, seg2rev, seg3], p(48.0));
+    expect(out.segments_used).toBe(3);
+    expect(out.points[out.points.length - 1]!.lat).toBeCloseTo(48.03, 6);
+  });
+
+  it("bridges small gaps and records them; leaves distant segments out", () => {
+    // ~44m gap between seg1 end (48.01) and gapSeg start.
+    const gapSeg = [p(48.0104), p(48.02)];
+    // Far segment ~1.1km away from anything.
+    const farSeg = [p(48.05), p(48.06)];
+    const out = chainSegments([seg1, gapSeg, farSeg], p(48.0));
+    expect(out.segments_used).toBe(2);
+    expect(out.bridged_gaps_m).toHaveLength(1);
+    expect(out.bridged_gaps_m[0]!).toBeGreaterThan(30);
+    expect(out.bridged_gaps_m[0]!).toBeLessThanOrEqual(50);
+    expect(out.leftover_segments).toBe(1);
+  });
+
+  it("caps runaway chains at the max length", () => {
+    // 60 segments x ~1.1km = ~66km > 48.28km cap.
+    const segs = Array.from({ length: 60 }, (_, i) => [p(48 + i * 0.01), p(48 + (i + 1) * 0.01)]);
+    const out = chainSegments(segs, p(48.0));
+    expect(out.capped).toBe(true);
+    expect(out.segments_used).toBeLessThan(60);
+  });
+
+  it("single segment behaves as before", () => {
+    const out = chainSegments([seg1], p(48.0));
+    expect(out.segments_used).toBe(1);
+    expect(out.points).toHaveLength(2);
+    expect(out.leftover_segments).toBe(0);
   });
 });

--- a/apps/trip-mcp/src/polyline.ts
+++ b/apps/trip-mcp/src/polyline.ts
@@ -79,6 +79,123 @@ export function resamplePolyline(points: PolyPoint[], targetCount: number): Prof
   return out;
 }
 
+/** Result of chaining multiple polyline segments end-to-end. */
+export interface ChainResult {
+  points: PolyPoint[];
+  /** Segments incorporated into the chain. */
+  segments_used: number;
+  /** Gap sizes (meters) that were straight-line bridged (> join tol, <= gap max). */
+  bridged_gaps_m: number[];
+  /** Matching segments that could not be connected to the chain. */
+  leftover_segments: number;
+  /** True when the chain stopped because it hit the length cap. */
+  capped: boolean;
+}
+
+const JOIN_TOLERANCE_M = 30;
+const GAP_BRIDGE_MAX_M = 50;
+/** 30 miles — guard against runaway matches on long-distance routes. */
+const CHAIN_MAX_LENGTH_M = 48_280;
+
+function segLengthM(seg: PolyPoint[]): number {
+  const cum = cumulativeM(seg);
+  return cum[cum.length - 1] ?? 0;
+}
+
+/**
+ * Chain polyline segments (OSM ways) end-to-end into one line. Long
+ * trails are typically split across multiple OSM ways; a profile built
+ * from a single way silently truncates.
+ *
+ * Deterministic: starts from the segment endpoint nearest `start` (the
+ * trailhead hint), then greedily appends the unused segment whose
+ * endpoint is closest to the running chain end — joined seamlessly
+ * within `joinTolM`, or straight-line bridged (recorded per-gap) up to
+ * `gapMaxM`. Stops when nothing is within `gapMaxM` or the length cap
+ * is reached.
+ */
+export function chainSegments(
+  segments: PolyPoint[][],
+  start: PolyPoint,
+  joinTolM = JOIN_TOLERANCE_M,
+  gapMaxM = GAP_BRIDGE_MAX_M,
+  maxTotalM = CHAIN_MAX_LENGTH_M,
+): ChainResult {
+  const usable = segments.filter((s) => s.length >= 2);
+  if (usable.length === 0) {
+    return { points: [], segments_used: 0, bridged_gaps_m: [], leftover_segments: 0, capped: false };
+  }
+
+  // Starting segment: endpoint nearest the hint, oriented away from it.
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  let bestReversed = false;
+  usable.forEach((seg, i) => {
+    const dFirst = haversineM(start, seg[0]!);
+    const dLast = haversineM(start, seg[seg.length - 1]!);
+    if (dFirst < bestDist) {
+      bestDist = dFirst;
+      bestIdx = i;
+      bestReversed = false;
+    }
+    if (dLast < bestDist) {
+      bestDist = dLast;
+      bestIdx = i;
+      bestReversed = true;
+    }
+  });
+
+  const used = new Set<number>([bestIdx]);
+  const first = usable[bestIdx]!;
+  const chain: PolyPoint[] = bestReversed ? [...first].reverse() : [...first];
+  let totalM = segLengthM(chain);
+  const bridged: number[] = [];
+  let capped = false;
+
+  while (totalM < maxTotalM) {
+    const end = chain[chain.length - 1]!;
+    let nextIdx = -1;
+    let nextDist = Infinity;
+    let nextReversed = false;
+    usable.forEach((seg, i) => {
+      if (used.has(i)) return;
+      const dFirst = haversineM(end, seg[0]!);
+      const dLast = haversineM(end, seg[seg.length - 1]!);
+      if (dFirst < nextDist) {
+        nextDist = dFirst;
+        nextIdx = i;
+        nextReversed = false;
+      }
+      if (dLast < nextDist) {
+        nextDist = dLast;
+        nextIdx = i;
+        nextReversed = true;
+      }
+    });
+    if (nextIdx < 0 || nextDist > gapMaxM) break;
+
+    used.add(nextIdx);
+    const seg = usable[nextIdx]!;
+    const oriented = nextReversed ? [...seg].reverse() : [...seg];
+    if (nextDist > joinTolM) bridged.push(Math.round(nextDist));
+    // Drop the duplicate join vertex when seamless.
+    chain.push(...(nextDist <= joinTolM ? oriented.slice(1) : oriented));
+    totalM += segLengthM(oriented) + nextDist;
+    if (totalM >= maxTotalM) {
+      capped = true;
+      break;
+    }
+  }
+
+  return {
+    points: chain,
+    segments_used: used.size,
+    bridged_gaps_m: bridged,
+    leftover_segments: usable.length - used.size,
+    capped,
+  };
+}
+
 /** Bounding box [minLon, minLat, maxLon, maxLat] around a point. */
 export function bboxAroundPoint(
   lat: number,

--- a/apps/trip-mcp/src/seasonal.ts
+++ b/apps/trip-mcp/src/seasonal.ts
@@ -1,0 +1,158 @@
+/**
+ * Curated seasonal-timing data per registry area (issue #80).
+ *
+ * SCHEMA (adding/editing areas is a data-only change):
+ *  - Windows are "MM-DD".."MM-DD" ranges describing a TYPICAL year —
+ *    actual timing swings ±2–3 weeks with snowpack. Never a guarantee.
+ *  - `snow_free_typical`: main trails melted out → first persistent snow.
+ *  - `larch_window`: golden larch viewing (only areas where larches are
+ *    a real draw).
+ *  - `wildflower_peak`, `stream_crossing_peak`: self-describing.
+ *  - `bug_pressure`: months + severity; lakeside basins run worse.
+ *  - `crowds`: peak-crowding windows worth planning around.
+ *
+ * Sources: WTA seasonal guidance and guidebook consensus — curated
+ * regional knowledge, confidence low-to-medium by design.
+ */
+
+export interface SeasonalWindow {
+  /** "MM-DD" inclusive. */
+  start: string;
+  /** "MM-DD" inclusive. */
+  end: string;
+}
+
+export interface BugPressure {
+  months: string;
+  severity: "low" | "moderate" | "high";
+  note?: string;
+}
+
+export interface CrowdWindow {
+  window: string;
+  note: string;
+}
+
+export interface Seasonal {
+  snow_free_typical?: SeasonalWindow;
+  larch_window?: SeasonalWindow;
+  wildflower_peak?: SeasonalWindow;
+  bug_pressure: BugPressure[];
+  stream_crossing_peak?: SeasonalWindow;
+  crowds?: CrowdWindow[];
+  notes?: string;
+}
+
+export const SEASONAL: Record<string, Seasonal> = {
+  enchantments: {
+    snow_free_typical: { start: "07-15", end: "10-15" },
+    larch_window: { start: "09-25", end: "10-15" },
+    wildflower_peak: { start: "07-15", end: "08-15" },
+    bug_pressure: [
+      { months: "Jul–Aug", severity: "high", note: "worst around Snow Lakes and Core zone tarns" },
+    ],
+    stream_crossing_peak: { start: "05-15", end: "06-30" },
+    crowds: [
+      { window: "late Sep–mid Oct weekends", note: "larch madness — Colchuck/Core day traffic extreme" },
+      { window: "Jul–Aug weekends", note: "Colchuck Lake and Aasgard day traffic heavy" },
+    ],
+    notes: "Core zone holds snow well into July most years; Aasgard Pass snow lingers and is a fall-line hazard when icy.",
+  },
+  mt_rainier: {
+    snow_free_typical: { start: "07-15", end: "10-01" },
+    wildflower_peak: { start: "07-20", end: "08-15" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "high", note: "notorious in Spray Park and Indian Bar" }],
+    stream_crossing_peak: { start: "06-01", end: "07-15" },
+    crowds: [
+      { window: "late Jul–mid Aug", note: "wildflower peak — Paradise/Sunrise lots full by mid-morning" },
+    ],
+    notes: "Glacial rivers (Nisqually, White, Carbon drainages) pulse in the afternoon all summer — plan crossings for morning.",
+  },
+  north_cascades: {
+    snow_free_typical: { start: "07-15", end: "10-01" },
+    larch_window: { start: "09-25", end: "10-12" },
+    wildflower_peak: { start: "07-20", end: "08-20" },
+    bug_pressure: [{ months: "Jul", severity: "high", note: "Thunder Creek and low valley approaches" }],
+    stream_crossing_peak: { start: "05-15", end: "06-30" },
+    crowds: [
+      { window: "late Sep–early Oct weekends", note: "larch traffic on Maple Pass and Cascade Pass corridors" },
+    ],
+    notes: "SR 20 typically closed mid-Nov to mid/late April — early and late season access is the binding constraint.",
+  },
+  olympic: {
+    snow_free_typical: { start: "07-15", end: "10-15" },
+    wildflower_peak: { start: "07-10", end: "08-10" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "moderate", note: "worse in Seven Lakes Basin" }],
+    stream_crossing_peak: { start: "05-01", end: "06-30" },
+    crowds: [{ window: "Jul–Aug", note: "High Divide quota fills instantly; coast strips busy at minus tides" }],
+    notes: "Coast routes are year-round (tide-dependent, not snow-dependent); alpine interior follows the normal melt calendar.",
+  },
+  glacier_peak: {
+    snow_free_typical: { start: "07-20", end: "09-30" },
+    wildflower_peak: { start: "07-25", end: "08-20" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "high", note: "notorious across the White Chuck and Image Lake basins" }],
+    stream_crossing_peak: { start: "05-15", end: "07-10" },
+    crowds: [{ window: "Aug weekends", note: "modest by west-side standards; Image Lake camps fill" }],
+    notes: "Glacial drainages pulse in the afternoon all summer. Road washouts (Suiattle FR 26) reshuffle access — check before trusting mileage.",
+  },
+  pasayten: {
+    snow_free_typical: { start: "07-05", end: "10-10" },
+    larch_window: { start: "09-22", end: "10-08" },
+    wildflower_peak: { start: "07-01", end: "07-31" },
+    bug_pressure: [{ months: "Jun–Jul", severity: "high", note: "boggy plateaus; improves markedly by August" }],
+    stream_crossing_peak: { start: "05-15", end: "06-25" },
+    crowds: [{ window: "late Sep–early Oct", note: "larch traffic concentrates on Horseshoe Basin; elsewhere stays empty" }],
+    notes: "Driest of the big wildernesses — melts out earlier than the west side and stays hikeable into October.",
+  },
+  alpine_lakes: {
+    snow_free_typical: { start: "07-01", end: "10-25" },
+    wildflower_peak: { start: "07-05", end: "08-05" },
+    bug_pressure: [
+      { months: "Jun–Aug", severity: "high", note: "lake basins (Snow Lake, Necklace Valley) are the worst" },
+    ],
+    stream_crossing_peak: { start: "05-01", end: "06-20" },
+    crowds: [{ window: "Jun–Sep weekends", note: "I-90 corridor trailheads overflow by 8am; weekdays transform the experience" }],
+    notes: "Huge elevation spread: low valley trails open May–June while high passes hold snow past mid-July.",
+  },
+  henry_jackson: {
+    snow_free_typical: { start: "07-15", end: "10-10" },
+    wildflower_peak: { start: "07-15", end: "08-15" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "high", note: "Blanca Lake and Monte Cristo valley" }],
+    stream_crossing_peak: { start: "05-15", end: "06-30" },
+    crowds: [{ window: "Jul–Sep weekends", note: "Blanca Lake is a social-media magnet — arrive early or go midweek" }],
+  },
+  goat_rocks: {
+    snow_free_typical: { start: "07-15", end: "10-01" },
+    wildflower_peak: { start: "07-25", end: "08-15" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "moderate", note: "Snowgrass Flat evenings" }],
+    stream_crossing_peak: { start: "06-01", end: "07-10" },
+    crowds: [{ window: "late Jul–mid Aug weekends", note: "Snowgrass/Goat Lake loop at wildflower peak" }],
+    notes: "Knife's Edge holds snow into early August some years — check trip reports before committing the PCT traverse.",
+  },
+  mt_st_helens: {
+    snow_free_typical: { start: "06-15", end: "10-15" },
+    wildflower_peak: { start: "06-15", end: "07-20" },
+    bug_pressure: [{ months: "Jun–Jul", severity: "moderate", note: "Loowit plains after snowmelt" }],
+    stream_crossing_peak: { start: "05-01", end: "06-15" },
+    crowds: [{ window: "Jun–Sep weekends", note: "climbing permits sell out; Monitor Ridge steady traffic" }],
+    notes: "Many climbers prefer late spring on consolidated snow over the summer scree slog; blast-zone trails melt out weeks before the cone's flanks.",
+  },
+  mt_adams: {
+    snow_free_typical: { start: "07-10", end: "09-25" },
+    wildflower_peak: { start: "07-15", end: "08-15" },
+    bug_pressure: [{ months: "Jul", severity: "high", note: "Round-the-Mountain meadows" }],
+    stream_crossing_peak: { start: "06-01", end: "07-10" },
+    crowds: [{ window: "Jul–Aug weekends", note: "South Climb camps at Lunch Counter busy" }],
+    notes: "South Climb is best in early season on snow — late summer turns to loose scree and rockfall risk rises.",
+  },
+  mt_baker: {
+    snow_free_typical: { start: "07-25", end: "10-05" },
+    wildflower_peak: { start: "07-25", end: "08-20" },
+    bug_pressure: [{ months: "Jul–Aug", severity: "moderate" }],
+    stream_crossing_peak: { start: "05-15", end: "07-01" },
+    crowds: [
+      { window: "Aug–Sep weekends", note: "Artist Point / Chain Lakes when SR 542's last miles finally open" },
+    ],
+    notes: "Deepest snowpack in the registry — Artist Point road often doesn't open until late July/August; verify SR 542 status.",
+  },
+};

--- a/apps/trip-mcp/src/sources/nwac.test.ts
+++ b/apps/trip-mcp/src/sources/nwac.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { dangerLabel, pointInRings } from "./nwac.js";
+import { AREA_NWAC_ZONES } from "../tools/avalanche.js";
+import { AREAS } from "../areas.js";
+
+describe("dangerLabel", () => {
+  it("maps the 1-5 scale and treats missing as No Rating", () => {
+    expect(dangerLabel(1)).toBe("Low");
+    expect(dangerLabel(3)).toBe("Considerable");
+    expect(dangerLabel(5)).toBe("Extreme");
+    expect(dangerLabel(0)).toBe("No Rating");
+    expect(dangerLabel(-1)).toBe("No Rating");
+    expect(dangerLabel(null)).toBe("No Rating");
+  });
+});
+
+describe("pointInRings", () => {
+  // Square around (48, -121.5): lon -122..-121, lat 47.5..48.5.
+  const square: Array<Array<[number, number]>> = [
+    [
+      [-122, 47.5],
+      [-121, 47.5],
+      [-121, 48.5],
+      [-122, 48.5],
+      [-122, 47.5],
+    ],
+  ];
+
+  it("detects inside and outside points", () => {
+    expect(pointInRings(48, -121.5, square)).toBe(true);
+    expect(pointInRings(49, -121.5, square)).toBe(false);
+    expect(pointInRings(48, -123, square)).toBe(false);
+  });
+});
+
+describe("AREA_NWAC_ZONES", () => {
+  it("covers all 12 registry areas", () => {
+    for (const area of AREAS) {
+      expect(AREA_NWAC_ZONES[area.id], `missing zone mapping for ${area.id}`).toBeDefined();
+      expect(AREA_NWAC_ZONES[area.id]!.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/trip-mcp/src/sources/nwac.ts
+++ b/apps/trip-mcp/src/sources/nwac.ts
@@ -1,0 +1,242 @@
+/**
+ * NWAC avalanche forecasts via the National Avalanche Center's
+ * avalanche.org v2 public API (keyless; the same API nwac.us's own site
+ * consumes — informally documented, so parsing is defensive and any
+ * failure degrades to a caveat pointing at nwac.us).
+ *
+ * Endpoints (verified live 2026-08-02):
+ *  - map-layer: zone polygons + current danger + off_season flag
+ *  - product?type=forecast&center_id=NWAC&zone_id=N: full forecast
+ *    (danger by elevation band, problems, discussion). Off-season this
+ *    returns a "summary" product (spring/fall statement).
+ */
+
+import { createFetchClient } from "@mcp-stack/http-fetch";
+import type { Env } from "../types.js";
+import { cached, TTL } from "../cache.js";
+import { userAgent } from "../tools/utils.js";
+
+const MAP_LAYER_URL = "https://api.avalanche.org/v2/public/products/map-layer/NWAC";
+const PRODUCT_URL = "https://api.avalanche.org/v2/public/product";
+
+export const DANGER_LABELS: Record<number, string> = {
+  1: "Low",
+  2: "Moderate",
+  3: "Considerable",
+  4: "High",
+  5: "Extreme",
+};
+
+export function dangerLabel(level: number | null): string {
+  if (level === null || level < 1) return "No Rating";
+  return DANGER_LABELS[level] ?? "No Rating";
+}
+
+function client(env: Env) {
+  return createFetchClient({
+    userAgent: userAgent(env.CONTACT),
+    defaultHeaders: { Accept: "application/json" },
+    timeoutMs: 15_000,
+    retries: 1,
+  });
+}
+
+export interface NwacZone {
+  zone_id: number;
+  name: string;
+  off_season: boolean;
+  danger: string;
+  danger_level: number;
+  link: string;
+  travel_advice: string | null;
+  /** MultiPolygon rings in [lon, lat] order, flattened to outer rings. */
+  rings: Array<Array<[number, number]>>;
+}
+
+interface MapLayerFeature {
+  id?: number;
+  properties?: {
+    name?: string;
+    off_season?: boolean;
+    danger?: string;
+    danger_level?: number;
+    link?: string;
+    travel_advice?: string;
+  };
+  geometry?: { type?: string; coordinates?: unknown };
+}
+
+interface MapLayerResponse {
+  features?: MapLayerFeature[];
+}
+
+function extractRings(geometry: MapLayerFeature["geometry"]): Array<Array<[number, number]>> {
+  if (!geometry?.coordinates) return [];
+  const rings: Array<Array<[number, number]>> = [];
+  const coords = geometry.coordinates as unknown[];
+  const pushRing = (ring: unknown) => {
+    if (Array.isArray(ring) && ring.length > 2 && Array.isArray(ring[0])) {
+      rings.push(ring as Array<[number, number]>);
+    }
+  };
+  if (geometry.type === "Polygon") {
+    pushRing(coords[0]);
+  } else if (geometry.type === "MultiPolygon") {
+    for (const poly of coords) {
+      if (Array.isArray(poly)) pushRing((poly as unknown[])[0]);
+    }
+  }
+  return rings;
+}
+
+export async function getNwacZones(env: Env): Promise<NwacZone[]> {
+  const key = "nwac:zones";
+  return cached(env, key, TTL.USFS_ALERTS, async () => {
+    const res = await client(env).json<MapLayerResponse>(MAP_LAYER_URL);
+    return (res.features ?? [])
+      .filter((f) => typeof f.id === "number" && f.properties?.name)
+      .map((f) => ({
+        zone_id: f.id!,
+        name: f.properties!.name!,
+        off_season: Boolean(f.properties?.off_season),
+        danger: f.properties?.danger ?? "no rating",
+        danger_level: f.properties?.danger_level ?? -1,
+        link: f.properties?.link ?? "https://nwac.us/",
+        travel_advice: f.properties?.travel_advice ?? null,
+        rings: extractRings(f.geometry),
+      }));
+  });
+}
+
+/** Ray-casting point-in-polygon over [lon, lat] rings. */
+export function pointInRings(
+  lat: number,
+  lon: number,
+  rings: Array<Array<[number, number]>>,
+): boolean {
+  for (const ring of rings) {
+    let inside = false;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      const xi = ring[i]![0];
+      const yi = ring[i]![1];
+      const xj = ring[j]![0];
+      const yj = ring[j]![1];
+      const intersects =
+        yi > lat !== yj > lat && lon < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+      if (intersects) inside = !inside;
+    }
+    if (inside) return true;
+  }
+  return false;
+}
+
+export interface NwacDangerBand {
+  valid_day: string;
+  band: "below_treeline" | "near_treeline" | "above_treeline";
+  danger_level: number | null;
+  danger_label: string;
+}
+
+export interface NwacProblem {
+  name: string | null;
+  likelihood: string | null;
+  aspects_elevations: string[];
+  size: string | null;
+}
+
+export interface NwacForecast {
+  product_type: string | null;
+  published_time: string | null;
+  expires_time: string | null;
+  bottom_line: string | null;
+  hazard_discussion: string | null;
+  danger_by_band: NwacDangerBand[];
+  problems: NwacProblem[];
+}
+
+interface RawProduct {
+  product_type?: string;
+  published_time?: string;
+  expires_time?: string;
+  bottom_line?: string | null;
+  hazard_discussion?: string | null;
+  travel_advice?: string | null;
+  danger?: Array<{
+    lower?: number | null;
+    middle?: number | null;
+    upper?: number | null;
+    valid_day?: string;
+  }>;
+  forecast_avalanche_problems?: Array<{
+    name?: string;
+    likelihood?: string;
+    location?: string[];
+    size?: string | string[];
+  }>;
+}
+
+function stripHtml(s: string | null | undefined): string | null {
+  if (!s) return null;
+  return s
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 2000);
+}
+
+function bandLevel(v: number | null | undefined): number | null {
+  return typeof v === "number" && v >= 0 ? v : null;
+}
+
+export async function getNwacForecast(env: Env, zoneId: number): Promise<NwacForecast | null> {
+  const key = `nwac:product:${zoneId}`;
+  return cached(env, key, TTL.NWS_FORECAST, async () => {
+    const url = `${PRODUCT_URL}?type=forecast&center_id=NWAC&zone_id=${zoneId}`;
+    const res = await client(env).fetch(url);
+    if (!res.ok) throw new Error(`nwac_http_${res.status}`);
+    const text = await res.text();
+    if (!text || text === "null") return null;
+    let raw: RawProduct;
+    try {
+      raw = JSON.parse(text) as RawProduct;
+    } catch {
+      throw new Error("nwac_non_json");
+    }
+
+    const danger_by_band: NwacDangerBand[] = [];
+    for (const d of raw.danger ?? []) {
+      const day = d.valid_day ?? "current";
+      const entries: Array<[NwacDangerBand["band"], number | null | undefined]> = [
+        ["below_treeline", d.lower],
+        ["near_treeline", d.middle],
+        ["above_treeline", d.upper],
+      ];
+      for (const [band, v] of entries) {
+        const level = bandLevel(v);
+        danger_by_band.push({
+          valid_day: day,
+          band,
+          danger_level: level,
+          danger_label: dangerLabel(level),
+        });
+      }
+    }
+
+    return {
+      product_type: raw.product_type ?? null,
+      published_time: raw.published_time ?? null,
+      expires_time: raw.expires_time ?? null,
+      bottom_line: stripHtml(raw.bottom_line),
+      hazard_discussion: stripHtml(raw.hazard_discussion),
+      danger_by_band,
+      problems: (raw.forecast_avalanche_problems ?? []).map((p) => ({
+        name: p.name ?? null,
+        likelihood: p.likelihood ?? null,
+        aspects_elevations: Array.isArray(p.location) ? p.location : [],
+        size: Array.isArray(p.size) ? p.size.join("–") : (p.size ?? null),
+      })),
+    };
+  });
+}

--- a/apps/trip-mcp/src/sources/nwhikers.ts
+++ b/apps/trip-mcp/src/sources/nwhikers.ts
@@ -1,0 +1,98 @@
+/**
+ * NWHikers.net (phpBB forum) trip-report search — scrape-with-attribution
+ * like WTA (issue #81 Part B).
+ *
+ * Honesty note (probed 2026-08-02): nwhikers.net fronts a JavaScript
+ * anti-bot challenge ("Please refresh this page") for non-browser
+ * clients, which a Worker cannot execute. The parser detects the
+ * challenge and degrades to [] with a named error so the trip-report
+ * flow caveats it rather than failing. If NWHikers relaxes the
+ * challenge, this starts working with no code change.
+ */
+
+import type { Env } from "../types.js";
+import { TTL, cached } from "../cache.js";
+
+const BASE = "https://www.nwhikers.net";
+const MIN_INTERVAL_MS = 1500;
+
+let lastFetchAt = 0;
+
+async function throttled(env: Env, url: string): Promise<Response> {
+  const wait = MIN_INTERVAL_MS - (Date.now() - lastFetchAt);
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  lastFetchAt = Date.now();
+  return fetch(url, {
+    headers: {
+      "User-Agent": `pnw-trip-mcp/0.1 (research aggregator; ${env.CONTACT})`,
+      Accept: "text/html,*/*;q=0.5",
+    },
+  });
+}
+
+export interface NwhikersReport {
+  title: string;
+  url: string;
+  date_posted: string | null;
+}
+
+function looksBlocked(html: string): boolean {
+  return (
+    html.length < 4000 &&
+    (/refresh.{0,20}this page/i.test(html) || /challenge|captcha|just a moment/i.test(html))
+  );
+}
+
+/** Parse phpBB search results: `<a href="viewtopic.php?t=N" class="topictitle">`. */
+export function parseNwhikersSearch(html: string): NwhikersReport[] {
+  const out: NwhikersReport[] = [];
+  const rowRe =
+    /<a[^>]*href="(?:\.\/)?(viewtopic\.php\?[^"]*t=\d+[^"]*)"[^>]*class="[^"]*topictitle[^"]*"[^>]*>([\s\S]*?)<\/a>([\s\S]{0,1200}?)(?=<a[^>]*class="[^"]*topictitle|$)/gi;
+  for (const m of html.matchAll(rowRe)) {
+    const href = m[1];
+    const title = (m[2] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    if (!href || !title) continue;
+    const tail = m[3] ?? "";
+    const dateM = tail.match(
+      /\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)?\s*((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},?\s+\d{4})/i,
+    );
+    let date: string | null = null;
+    if (dateM?.[1]) {
+      const t = Date.parse(dateM[1]);
+      if (!Number.isNaN(t)) date = new Date(t).toISOString().slice(0, 10);
+    }
+    out.push({
+      title,
+      url: `${BASE}/forums/${href.replace(/&amp;/g, "&")}`,
+      date_posted: date,
+    });
+  }
+  return out;
+}
+
+export async function searchNwhikersReports(
+  env: Env,
+  query: string,
+  limit = 5,
+): Promise<{ reports: NwhikersReport[]; errors: string[] }> {
+  const key = `nwhikers:search:${query.toLowerCase()}:${limit}`;
+  return cached(env, key, TTL.WEB, async () => {
+    try {
+      const url = `${BASE}/forums/search.php?search_keywords=${encodeURIComponent(query)}&mode=results`;
+      const res = await throttled(env, url);
+      const html = await res.text();
+      if (!res.ok) {
+        return { reports: [], errors: [`nwhikers: http_${res.status}`] };
+      }
+      if (looksBlocked(html)) {
+        return {
+          reports: [],
+          errors: ["nwhikers: anti-bot challenge page served — forum unreachable from server-side clients"],
+        };
+      }
+      return { reports: parseNwhikersSearch(html).slice(0, limit), errors: [] };
+    } catch (e) {
+      return { reports: [], errors: [`nwhikers: ${e instanceof Error ? e.message : String(e)}`] };
+    }
+  });
+}

--- a/apps/trip-mcp/src/sources/openmeteo.ts
+++ b/apps/trip-mcp/src/sources/openmeteo.ts
@@ -93,6 +93,8 @@ export interface OpenMeteoHourly {
   precip_in: number | null;
   wind_speed_mph: number | null;
   freezing_level_ft: number | null;
+  cloud_cover_pct: number | null;
+  uv_index: number | null;
 }
 
 export interface OpenMeteoForecast {
@@ -119,6 +121,8 @@ interface RawForecastResponse {
     precipitation?: Array<number | null>;
     wind_speed_10m?: Array<number | null>;
     freezing_level_height?: Array<number | null>;
+    cloud_cover?: Array<number | null>;
+    uv_index?: Array<number | null>;
   };
 }
 
@@ -153,7 +157,8 @@ export async function getPointForecast(
     latitude: String(round5(lat)),
     longitude: String(round5(lon)),
     daily: "temperature_2m_max,temperature_2m_min,precipitation_probability_max,precipitation_sum",
-    hourly: "temperature_2m,precipitation_probability,precipitation,wind_speed_10m,freezing_level_height",
+    hourly:
+      "temperature_2m,precipitation_probability,precipitation,wind_speed_10m,freezing_level_height,cloud_cover,uv_index",
     temperature_unit: "fahrenheit",
     wind_speed_unit: "mph",
     precipitation_unit: "inch",
@@ -182,6 +187,8 @@ export async function getPointForecast(
       precip_in: num(res.hourly?.precipitation?.[i]),
       wind_speed_mph: num(res.hourly?.wind_speed_10m?.[i]),
       freezing_level_ft: roundOrNull(toFt(num(res.hourly?.freezing_level_height?.[i]))),
+      cloud_cover_pct: num(res.hourly?.cloud_cover?.[i]),
+      uv_index: num(res.hourly?.uv_index?.[i]),
     }));
 
     const daily: OpenMeteoDaily[] = (res.daily?.time ?? []).map((date, i) => {

--- a/apps/trip-mcp/src/sources/osm.ts
+++ b/apps/trip-mcp/src/sources/osm.ts
@@ -460,6 +460,49 @@ export async function findTrailheads(env: Env, bbox: Bbox): Promise<OsmTrailhead
   });
 }
 
+export interface OsmCampsite {
+  id: string;
+  lat: number;
+  lon: number;
+  name?: string;
+  kind: "camp_site" | "camp_pitch";
+  backcountry: boolean;
+}
+
+/** Mapped camp sites/pitches in a bbox — incomplete and unofficial by nature. */
+export async function findCampsites(env: Env, bbox: Bbox): Promise<OsmCampsite[]> {
+  const key = `osm:camps:${bboxKey(bbox)}`;
+  return cached(env, key, TTL.OSM, async () => {
+    const swne = bboxAsSwne(bbox);
+    const query =
+      `[out:json][timeout:25];` +
+      `(` +
+      `node["tourism"="camp_site"](${swne});` +
+      `way["tourism"="camp_site"](${swne});` +
+      `node["tourism"="camp_pitch"](${swne});` +
+      `way["tourism"="camp_pitch"](${swne});` +
+      `);` +
+      `out tags center;`;
+    const elements = await runOverpass(env, query);
+    return elements
+      .map((el) => {
+        const lat = el.lat ?? el.center?.lat;
+        const lon = el.lon ?? el.center?.lon;
+        if (typeof lat !== "number" || typeof lon !== "number") return null;
+        const site: OsmCampsite = {
+          id: `${el.type}/${el.id}`,
+          lat,
+          lon,
+          kind: el.tags?.tourism === "camp_pitch" ? "camp_pitch" : "camp_site",
+          backcountry: el.tags?.backcountry === "yes",
+        };
+        if (el.tags?.name) site.name = el.tags.name;
+        return site;
+      })
+      .filter((s): s is OsmCampsite => s !== null);
+  });
+}
+
 export async function findWaterSources(env: Env, bbox: Bbox): Promise<OsmWaterSource[]> {
   const key = `osm:water:${bboxKey(bbox)}`;
   return cached(env, key, TTL.OSM, async () => {

--- a/apps/trip-mcp/src/sources/osm.ts
+++ b/apps/trip-mcp/src/sources/osm.ts
@@ -11,6 +11,7 @@
 import { createFetchClient } from "@mcp-stack/http-fetch";
 import type { Env } from "../types.js";
 import { cached, TTL } from "../cache.js";
+import { chainSegments } from "../polyline.js";
 import { roundCoord, userAgent } from "../tools/utils.js";
 
 const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
@@ -205,38 +206,70 @@ export function osmTrailMatchesQuery(trail: OsmTrail, query: string): boolean {
 
 // --- Public API ----------------------------------------------------------
 
+export interface OsmGeometryAssembly {
+  /** Ways/segments incorporated into the returned line. */
+  segments_used: number;
+  /** Gap sizes (m) straight-line bridged between segments. */
+  bridged_gaps_m: number[];
+  /** Name-matching segments that could not be connected. */
+  leftover_segments: number;
+  /** Chain stopped at the 30 mi length cap. */
+  capped: boolean;
+  /** "relation" when assembled from a route relation, else "ways". */
+  assembled_from: "relation" | "ways" | "single_way";
+}
+
 export interface OsmGeometry {
   /** e.g. "way/123" or "relation/456" */
   id: string;
   name: string;
   ref?: string;
   points: Array<{ lat: number; lon: number }>;
+  /** Present when the line was assembled from multiple segments. */
+  assembly?: OsmGeometryAssembly;
+}
+
+function memberSegments(el: OverpassElement): Array<Array<{ lat: number; lon: number }>> {
+  return (el.members ?? [])
+    .filter((m) => m.type === "way" && m.geometry && m.geometry.length >= 2)
+    .map((m) => m.geometry!);
 }
 
 /**
  * Fetch the polyline geometry of one OSM element. Accepts "way/123",
- * "relation/456", or a bare numeric id (assumed way). For relations,
- * member-way geometries are concatenated in member order — OSM does not
- * guarantee ordering, so treat relation output as approximate.
+ * "relation/456", or a bare numeric id (assumed way). Relation member
+ * ways are chained by endpoint proximity (OSM does not guarantee member
+ * order); the assembly block reports segment count and bridged gaps.
  */
 export async function getOsmGeometry(env: Env, osmId: string): Promise<OsmGeometry | null> {
   const m = osmId.trim().match(/^(?:(way|relation)\/)?(\d+)$/i);
   if (!m) return null;
   const type = (m[1] ?? "way").toLowerCase();
   const id = m[2]!;
-  const key = `osm:geom:${type}/${id}`;
+  const key = `osm:geom:v2:${type}/${id}`;
   return cached(env, key, TTL.OSM, async () => {
     const query = `[out:json][timeout:25];${type}(${id});out tags geom;`;
     const elements = await runOverpass(env, query);
     const el = elements[0];
     if (!el) return null;
-    const points: Array<{ lat: number; lon: number }> = [];
+
+    let points: Array<{ lat: number; lon: number }> = [];
+    let assembly: OsmGeometryAssembly | undefined;
     if (el.geometry && el.geometry.length > 0) {
-      points.push(...el.geometry);
-    } else if (el.members) {
-      for (const member of el.members) {
-        if (member.type === "way" && member.geometry) points.push(...member.geometry);
-      }
+      points = el.geometry;
+      assembly = undefined;
+    } else {
+      const segs = memberSegments(el);
+      if (segs.length === 0) return null;
+      const chained = chainSegments(segs, segs[0]![0]!);
+      points = chained.points;
+      assembly = {
+        segments_used: chained.segments_used,
+        bridged_gaps_m: chained.bridged_gaps_m,
+        leftover_segments: chained.leftover_segments,
+        capped: chained.capped,
+        assembled_from: "relation",
+      };
     }
     if (points.length === 0) return null;
     const result: OsmGeometry = {
@@ -244,52 +277,115 @@ export async function getOsmGeometry(env: Env, osmId: string): Promise<OsmGeomet
       name: el.tags?.name ?? el.tags?.ref ?? "",
       points,
     };
+    if (assembly) result.assembly = assembly;
     if (el.tags?.ref) result.ref = el.tags.ref;
     return result;
   });
 }
 
 /**
- * Find the trail near a point whose naming tags match `query` and return
- * the longest matching way's geometry. Used by the profile tools to turn
- * "trail_name + lat/lon hint" into a polyline.
+ * Resolve `trail_name` near a point to a full assembled polyline.
+ *
+ * Relation-first: a matching `route=hiking|foot` relation is the
+ * canonical multi-way representation — among matching relations the
+ * SHORTEST complete one wins (guards against super-relations like the
+ * PCT swallowing a local trail name). Otherwise ALL matching ways are
+ * chained end-to-end by endpoint proximity, ordered from the endpoint
+ * nearest the caller's lat/lon hint, with small gaps (<50 m) bridged
+ * and recorded. Single-way matches behave as before.
  */
 export async function findTrailGeometryByName(
   env: Env,
   bbox: Bbox,
   query: string,
+  hint?: { lat: number; lon: number },
 ): Promise<OsmGeometry | null> {
-  const key = `osm:trailgeom:${bboxKey(bbox)}:${query.toLowerCase().trim()}`;
+  const key = `osm:trailgeom:v3:${bboxKey(bbox)}:${query.toLowerCase().trim()}`;
   return cached(env, key, TTL.OSM, async () => {
     const swne = bboxAsSwne(bbox);
     const q =
       `[out:json][timeout:25];` +
       `(` +
       `way["highway"~"path|footway|track"]["foot"!~"no"](${swne});` +
-      `relation["route"="hiking"](${swne});` +
+      `relation["route"~"hiking|foot"](${swne});` +
       `);` +
       `out tags geom;`;
     const elements = await runOverpass(env, q);
-    let best: OverpassElement | null = null;
-    let bestLen = 0;
-    for (const el of elements) {
-      if (!trailMatchesQuery(el.tags, query)) continue;
-      const geom =
-        el.geometry ??
-        el.members?.flatMap((mem) => (mem.type === "way" && mem.geometry ? mem.geometry : []));
-      const len = geomLengthM(geom);
-      if (geom && geom.length > 1 && len > bestLen) {
-        best = { ...el, geometry: geom };
-        bestLen = len;
+    const start = hint ?? {
+      lat: (bbox[1] + bbox[3]) / 2,
+      lon: (bbox[0] + bbox[2]) / 2,
+    };
+
+    // Relation-first: shortest complete matching relation.
+    const relations = elements.filter(
+      (el) => el.type === "relation" && trailMatchesQuery(el.tags, query),
+    );
+    let bestRel: { el: OverpassElement; segs: Array<Array<{ lat: number; lon: number }>>; len: number } | null =
+      null;
+    for (const el of relations) {
+      const segs = memberSegments(el);
+      if (segs.length === 0) continue;
+      const len = segs.reduce((sum, s) => sum + geomLengthM(s), 0);
+      if (!bestRel || len < bestRel.len) bestRel = { el, segs, len };
+    }
+    if (bestRel) {
+      const chained = chainSegments(bestRel.segs, start);
+      if (chained.points.length >= 2) {
+        const result: OsmGeometry = {
+          id: `relation/${bestRel.el.id}`,
+          name: bestRel.el.tags?.name ?? bestRel.el.tags?.ref ?? "",
+          points: chained.points,
+          assembly: {
+            segments_used: chained.segments_used,
+            bridged_gaps_m: chained.bridged_gaps_m,
+            leftover_segments: chained.leftover_segments,
+            capped: chained.capped,
+            assembled_from: "relation",
+          },
+        };
+        if (bestRel.el.tags?.ref) result.ref = bestRel.el.tags.ref;
+        return result;
       }
     }
-    if (!best || !best.geometry) return null;
+
+    // Way-chaining: assemble ALL matching ways.
+    const ways = elements.filter(
+      (el) =>
+        el.type === "way" &&
+        trailMatchesQuery(el.tags, query) &&
+        el.geometry &&
+        el.geometry.length >= 2,
+    );
+    if (ways.length === 0) return null;
+    const chained = chainSegments(
+      ways.map((w) => w.geometry!),
+      start,
+    );
+    if (chained.points.length < 2) return null;
+
+    // Attribute the result to the longest contributing way for id/name.
+    let primary = ways[0]!;
+    let primaryLen = 0;
+    for (const w of ways) {
+      const len = geomLengthM(w.geometry);
+      if (len > primaryLen) {
+        primary = w;
+        primaryLen = len;
+      }
+    }
     const result: OsmGeometry = {
-      id: `${best.type}/${best.id}`,
-      name: best.tags?.name ?? best.tags?.ref ?? "",
-      points: best.geometry,
+      id: `way/${primary.id}`,
+      name: primary.tags?.name ?? primary.tags?.ref ?? "",
+      points: chained.points,
+      assembly: {
+        segments_used: chained.segments_used,
+        bridged_gaps_m: chained.bridged_gaps_m,
+        leftover_segments: chained.leftover_segments,
+        capped: chained.capped,
+        assembled_from: chained.segments_used > 1 ? "ways" : "single_way",
+      },
     };
-    if (best.tags?.ref) result.ref = best.tags.ref;
+    if (primary.tags?.ref) result.ref = primary.tags.ref;
     return result;
   });
 }

--- a/apps/trip-mcp/src/sources/osrm.ts
+++ b/apps/trip-mcp/src/sources/osrm.ts
@@ -1,0 +1,48 @@
+/**
+ * OSRM demo-server routing (issue #85 live drive times). Keyless, but
+ * explicitly NO SLA and rate-limited — acceptable for personal use with
+ * the caveat surfaced; degrade to the curated static estimate on any
+ * failure. No Google/Mapbox keys by design.
+ */
+
+import { createFetchClient } from "@mcp-stack/http-fetch";
+import type { Env } from "../types.js";
+import { cached, TTL } from "../cache.js";
+import { userAgent } from "../tools/utils.js";
+
+const OSRM_URL = "https://router.project-osrm.org/route/v1/driving";
+
+interface OsrmResponse {
+  code?: string;
+  routes?: Array<{ duration?: number; distance?: number }>;
+}
+
+export interface DriveEstimate {
+  duration_min: number;
+  distance_mi: number;
+}
+
+export async function getDriveTime(
+  env: Env,
+  from: { lat: number; lon: number },
+  to: { lat: number; lon: number },
+): Promise<DriveEstimate | null> {
+  const r3 = (n: number) => Math.round(n * 1000) / 1000;
+  const key = `osrm:${r3(from.lat)},${r3(from.lon)}:${r3(to.lat)},${r3(to.lon)}`;
+  return cached(env, key, TTL.USFS_ALERTS, async () => {
+    const c = createFetchClient({
+      userAgent: userAgent(env.CONTACT),
+      defaultHeaders: { Accept: "application/json" },
+      timeoutMs: 10_000,
+      retries: 1,
+    });
+    const url = `${OSRM_URL}/${r3(from.lon)},${r3(from.lat)};${r3(to.lon)},${r3(to.lat)}?overview=false`;
+    const res = await c.json<OsrmResponse>(url);
+    const route = res.routes?.[0];
+    if (res.code !== "Ok" || !route || typeof route.duration !== "number") return null;
+    return {
+      duration_min: Math.round(route.duration / 60),
+      distance_mi: Math.round(((route.distance ?? 0) / 1609.344) * 10) / 10,
+    };
+  });
+}

--- a/apps/trip-mcp/src/sources/reddit.ts
+++ b/apps/trip-mcp/src/sources/reddit.ts
@@ -1,0 +1,107 @@
+/**
+ * Reddit trip-report search (r/WashingtonHikers, r/PNWhiking) via the
+ * public listing JSON (issue #81 Part B).
+ *
+ * Honesty note (probed 2026-08-02): Reddit aggressively blocks
+ * unauthenticated JSON from datacenter IP ranges (403 with an HTML
+ * challenge), which very likely includes Cloudflare Workers egress. This
+ * client sets a proper User-Agent, detects the block, and degrades to []
+ * so the trip-report flow caveats it as a named failure. If the
+ * degradation proves permanent in production, the fix is a Reddit OAuth
+ * app (client-credentials) — the interface here won't need to change.
+ */
+
+import type { Env } from "../types.js";
+import { TTL, cached } from "../cache.js";
+
+const SUBREDDITS = ["WashingtonHikers", "PNWhiking"];
+const MIN_INTERVAL_MS = 1100;
+
+let lastFetchAt = 0;
+
+async function throttled(env: Env, url: string): Promise<Response> {
+  const wait = MIN_INTERVAL_MS - (Date.now() - lastFetchAt);
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  lastFetchAt = Date.now();
+  return fetch(url, {
+    headers: {
+      "User-Agent": `pnw-trip-mcp/0.1 (research aggregator; ${env.CONTACT})`,
+      Accept: "application/json",
+    },
+  });
+}
+
+export interface RedditReport {
+  title: string;
+  url: string;
+  author: string | null;
+  subreddit: string;
+  date_posted: string | null; // ISO YYYY-MM-DD
+  blurb: string | null;
+}
+
+interface RedditListing {
+  data?: {
+    children?: Array<{
+      data?: {
+        title?: string;
+        permalink?: string;
+        author?: string;
+        subreddit?: string;
+        created_utc?: number;
+        selftext?: string;
+      };
+    }>;
+  };
+}
+
+/** Search both hiking subreddits; returns [] (never throws) on failure. */
+export async function searchRedditReports(
+  env: Env,
+  query: string,
+  limitPerSub = 5,
+): Promise<{ reports: RedditReport[]; errors: string[] }> {
+  const key = `reddit:search:${query.toLowerCase()}:${limitPerSub}`;
+  return cached(env, key, TTL.WEB, async () => {
+    const reports: RedditReport[] = [];
+    const errors: string[] = [];
+    for (const sub of SUBREDDITS) {
+      try {
+        const url =
+          `https://old.reddit.com/r/${sub}/search.json?q=${encodeURIComponent(query)}` +
+          `&restrict_sr=1&sort=new&t=year&limit=${limitPerSub}`;
+        const res = await throttled(env, url);
+        const text = await res.text();
+        if (!res.ok) {
+          errors.push(`reddit r/${sub}: http_${res.status}${res.status === 403 ? " (likely datacenter-IP block; OAuth app would fix)" : ""}`);
+          continue;
+        }
+        let listing: RedditListing;
+        try {
+          listing = JSON.parse(text) as RedditListing;
+        } catch {
+          errors.push(`reddit r/${sub}: non-JSON response (blocked or markup change)`);
+          continue;
+        }
+        for (const child of listing.data?.children ?? []) {
+          const d = child.data;
+          if (!d?.title || !d.permalink) continue;
+          reports.push({
+            title: d.title,
+            url: `https://www.reddit.com${d.permalink}`,
+            author: d.author ?? null,
+            subreddit: sub,
+            date_posted:
+              typeof d.created_utc === "number"
+                ? new Date(d.created_utc * 1000).toISOString().slice(0, 10)
+                : null,
+            blurb: d.selftext ? d.selftext.replace(/\s+/g, " ").trim().slice(0, 400) : null,
+          });
+        }
+      } catch (e) {
+        errors.push(`reddit r/${sub}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+    return { reports, errors };
+  });
+}

--- a/apps/trip-mcp/src/sources/usfs.ts
+++ b/apps/trip-mcp/src/sources/usfs.ts
@@ -1,0 +1,83 @@
+/**
+ * USFS forest alerts/notices page scrape (issue #85 road-status slice).
+ * fs.usda.gov has no API for road conditions; the alerts-notices page
+ * per forest is the closest scrapeable surface. Standard scrape rules:
+ * ≤24h cache, attribution, degrade to null on any failure.
+ *
+ * The extraction is deliberately modest: we report whether a road is
+ * MENTIONED in current alerts (with a snippet), not a parsed
+ * open/closed state — absence of a mention is NOT confirmation a road
+ * is open, and callers must say so.
+ */
+
+import type { Env } from "../types.js";
+import { TTL, cached } from "../cache.js";
+
+const MIN_INTERVAL_MS = 1100;
+let lastFetchAt = 0;
+
+export function forestAlertsUrl(slug: string): string {
+  return `https://www.fs.usda.gov/alerts/${slug}/alerts-notices`;
+}
+
+async function throttledFetch(env: Env, url: string): Promise<Response> {
+  const wait = MIN_INTERVAL_MS - (Date.now() - lastFetchAt);
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  lastFetchAt = Date.now();
+  return fetch(url, {
+    headers: {
+      "User-Agent": `pnw-trip-mcp/0.1 (research aggregator; ${env.CONTACT})`,
+      Accept: "text/html,*/*;q=0.5",
+    },
+  });
+}
+
+/** Fetch + flatten a forest's alerts page to plain text (24h cache). */
+export async function getForestAlertsText(env: Env, slug: string): Promise<string | null> {
+  const key = `usfs:alerts:${slug}`;
+  return cached(env, key, TTL.WTA_LIST, async () => {
+    try {
+      const res = await throttledFetch(env, forestAlertsUrl(slug));
+      if (!res.ok) return null;
+      const html = await res.text();
+      return html
+        .replace(/<script[\s\S]*?<\/script>/gi, " ")
+        .replace(/<style[\s\S]*?<\/style>/gi, " ")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/&nbsp;|&amp;|&#\d+;/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    } catch {
+      return null;
+    }
+  });
+}
+
+/**
+ * Case-insensitive road-name mention lookup in flattened alerts text.
+ * Tries the full name, then a simplified form ("Suiattle River Rd
+ * (FR 26)" → "Suiattle"), returning a snippet around the first hit.
+ */
+export function findRoadMention(text: string, roadName: string): string | null {
+  const t = text.toLowerCase();
+  const noParens = roadName.replace(/\s*\([^)]*\)/g, "").trim();
+  const candidates = [
+    roadName,
+    noParens,
+    // "Suiattle River Rd" and "Suiattle River Road" must both match —
+    // drop the road-type suffix entirely and search the base name.
+    noParens.replace(/\s+(?:rd|road|hwy|highway|dr|drive)\.?$/i, ""),
+    roadName.split(/[(/]| FR | fr /)[0] ?? roadName,
+  ]
+    .map((c) => c.trim().toLowerCase())
+    .filter((c) => c.length >= 5);
+  for (const c of candidates) {
+    const idx = t.indexOf(c);
+    if (idx >= 0) {
+      const start = Math.max(0, idx - 80);
+      const end = Math.min(text.length, idx + c.length + 220);
+      return `${start > 0 ? "…" : ""}${text.slice(start, end).trim()}${end < text.length ? "…" : ""}`;
+    }
+  }
+  return null;
+}

--- a/apps/trip-mcp/src/sources/usgs_water.test.ts
+++ b/apps/trip-mcp/src/sources/usgs_water.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { flowContext } from "./usgs_water.js";
+
+const stat = { p25: 100, p50: 200, p75: 400, p90: 800, mean: 300 };
+
+describe("flowContext", () => {
+  it("bands current discharge against the day's percentiles", () => {
+    expect(flowContext(50, stat).context).toBe("low");
+    expect(flowContext(250, stat).context).toBe("normal");
+    expect(flowContext(500, stat).context).toBe("elevated");
+    expect(flowContext(900, stat).context).toBe("high");
+  });
+
+  it("returns unknown without a reading or stats", () => {
+    expect(flowContext(null, stat).context).toBe("unknown");
+    expect(flowContext(250, undefined).context).toBe("unknown");
+    expect(flowContext(250, { ...stat, p25: null }).context).toBe("unknown");
+  });
+});

--- a/apps/trip-mcp/src/sources/usgs_water.ts
+++ b/apps/trip-mcp/src/sources/usgs_water.ts
@@ -1,0 +1,238 @@
+/**
+ * USGS NWIS water clients for river-crossing assessment:
+ *  - Instantaneous Values (IV): current + 7-day discharge/gage height.
+ *  - Daily Statistics: historical percentiles to contextualize flow
+ *    ("85th percentile for this date" beats raw cfs).
+ *
+ * Both keyless. NWIS is migrating to api.waterdata.usgs.gov; the legacy
+ * services below remain the widely used stable surface (verified live
+ * 2026-08-02) — revisit when USGS announces shutdown dates.
+ */
+
+import { createFetchClient } from "@mcp-stack/http-fetch";
+import type { Env } from "../types.js";
+import { cached, TTL } from "../cache.js";
+import { userAgent } from "../tools/utils.js";
+
+const IV_URL = "https://waterservices.usgs.gov/nwis/iv/";
+const STAT_URL = "https://waterservices.usgs.gov/nwis/stat/";
+
+export type FlowContext = "low" | "normal" | "elevated" | "high" | "unknown";
+
+export interface GaugeSeriesPoint {
+  time_iso: string;
+  discharge_cfs: number | null;
+}
+
+export interface GaugeData {
+  site_id: string;
+  site_name: string;
+  lat: number | null;
+  lon: number | null;
+  discharge_cfs: number | null;
+  gage_height_ft: number | null;
+  reading_time: string | null;
+  /** 7-day discharge series, downsampled to ≤100 points (chart-ready). */
+  series: GaugeSeriesPoint[];
+}
+
+function client(env: Env) {
+  return createFetchClient({
+    userAgent: userAgent(env.CONTACT),
+    defaultHeaders: { Accept: "application/json" },
+    timeoutMs: 20_000,
+    retries: 1,
+  });
+}
+
+interface IvTimeSeries {
+  sourceInfo?: {
+    siteName?: string;
+    siteCode?: Array<{ value?: string }>;
+    geoLocation?: { geogLocation?: { latitude?: number; longitude?: number } };
+  };
+  variable?: { variableCode?: Array<{ value?: string }> };
+  values?: Array<{ value?: Array<{ value?: string; dateTime?: string }> }>;
+}
+
+interface IvResponse {
+  value?: { timeSeries?: IvTimeSeries[] };
+}
+
+function parseNum(v: string | undefined): number | null {
+  if (v === undefined) return null;
+  const n = Number.parseFloat(v);
+  // NWIS uses large negative sentinels (-999999) for missing/ice-affected.
+  return Number.isFinite(n) && n > -99999 ? n : null;
+}
+
+function downsample<T>(arr: T[], max: number): T[] {
+  if (arr.length <= max) return arr;
+  const out: T[] = [];
+  for (let i = 0; i < max; i++) {
+    out.push(arr[Math.round((i * (arr.length - 1)) / (max - 1))]!);
+  }
+  return out;
+}
+
+/** Fetch current values + 7-day discharge series for up to ~20 sites. */
+export async function getGauges(env: Env, siteIds: string[]): Promise<GaugeData[]> {
+  if (siteIds.length === 0) return [];
+  const sites = [...siteIds].sort().join(",");
+  const key = `usgs:iv:${sites}`;
+  return cached(env, key, TTL.RIDB_AVAIL, async () => {
+    const url = `${IV_URL}?format=json&sites=${encodeURIComponent(sites)}&parameterCd=00060,00065&period=P7D&siteStatus=active`;
+    const res = await client(env).json<IvResponse>(url);
+    const bySite = new Map<string, GaugeData>();
+    for (const ts of res.value?.timeSeries ?? []) {
+      const siteId = ts.sourceInfo?.siteCode?.[0]?.value;
+      const param = ts.variable?.variableCode?.[0]?.value;
+      if (!siteId || !param) continue;
+      let g = bySite.get(siteId);
+      if (!g) {
+        g = {
+          site_id: siteId,
+          site_name: ts.sourceInfo?.siteName ?? siteId,
+          lat: ts.sourceInfo?.geoLocation?.geogLocation?.latitude ?? null,
+          lon: ts.sourceInfo?.geoLocation?.geogLocation?.longitude ?? null,
+          discharge_cfs: null,
+          gage_height_ft: null,
+          reading_time: null,
+          series: [],
+        };
+        bySite.set(siteId, g);
+      }
+      const values = ts.values?.[0]?.value ?? [];
+      const latest = values[values.length - 1];
+      if (param === "00060") {
+        g.discharge_cfs = parseNum(latest?.value);
+        g.reading_time = latest?.dateTime ?? g.reading_time;
+        g.series = downsample(values, 100).map((v) => ({
+          time_iso: v.dateTime ?? "",
+          discharge_cfs: parseNum(v.value),
+        }));
+      } else if (param === "00065") {
+        g.gage_height_ft = parseNum(latest?.value);
+        g.reading_time = g.reading_time ?? latest?.dateTime ?? null;
+      }
+    }
+    return [...bySite.values()];
+  });
+}
+
+export interface DiscoveredGauge {
+  site_id: string;
+  site_name: string;
+  lat: number | null;
+  lon: number | null;
+  discharge_cfs: number | null;
+}
+
+/** Discover active discharge gauges inside a bbox [minLon,minLat,maxLon,maxLat]. */
+export async function discoverGauges(
+  env: Env,
+  bbox: [number, number, number, number],
+): Promise<DiscoveredGauge[]> {
+  // NWIS caps bbox extents; round to 3 decimals per API requirements.
+  const r3 = (n: number) => Math.round(n * 1000) / 1000;
+  const bb = `${r3(bbox[0])},${r3(bbox[1])},${r3(bbox[2])},${r3(bbox[3])}`;
+  const key = `usgs:discover:${bb}`;
+  return cached(env, key, TTL.USFS_ALERTS, async () => {
+    const url = `${IV_URL}?format=json&bBox=${bb}&parameterCd=00060&period=P1D&siteStatus=active`;
+    const res = await client(env).json<IvResponse>(url);
+    const seen = new Set<string>();
+    const out: DiscoveredGauge[] = [];
+    for (const ts of res.value?.timeSeries ?? []) {
+      const siteId = ts.sourceInfo?.siteCode?.[0]?.value;
+      if (!siteId || seen.has(siteId)) continue;
+      seen.add(siteId);
+      const values = ts.values?.[0]?.value ?? [];
+      out.push({
+        site_id: siteId,
+        site_name: ts.sourceInfo?.siteName ?? siteId,
+        lat: ts.sourceInfo?.geoLocation?.geogLocation?.latitude ?? null,
+        lon: ts.sourceInfo?.geoLocation?.geogLocation?.longitude ?? null,
+        discharge_cfs: parseNum(values[values.length - 1]?.value),
+      });
+    }
+    return out;
+  });
+}
+
+export interface DailyStat {
+  p25: number | null;
+  p50: number | null;
+  p75: number | null;
+  p90: number | null;
+  mean: number | null;
+}
+
+/**
+ * Daily discharge statistics for a site, keyed "M-D" (no zero padding —
+ * matches NWIS month_nu/day_nu columns). RDB (tab-separated) format.
+ */
+export async function getDailyStats(env: Env, siteId: string): Promise<Map<string, DailyStat>> {
+  const key = `usgs:stat:${siteId}`;
+  const obj = await cached(env, key, TTL.RIDB_META, async () => {
+    const url = `${STAT_URL}?format=rdb&sites=${encodeURIComponent(siteId)}&statReportType=daily&statTypeCd=all&parameterCd=00060`;
+    const res = await client(env).fetch(url);
+    if (!res.ok) throw new Error(`usgs_stat_http_${res.status}`);
+    const text = await res.text();
+    const lines = text.split("\n").filter((l) => l && !l.startsWith("#"));
+    const header = lines[0]?.split("\t") ?? [];
+    const col = (name: string) => header.indexOf(name);
+    const [iMonth, iDay, iMean, iP25, iP50, iP75, iP90] = [
+      col("month_nu"),
+      col("day_nu"),
+      col("mean_va"),
+      col("p25_va"),
+      col("p50_va"),
+      col("p75_va"),
+      col("p90_va"),
+    ];
+    const out: Record<string, DailyStat> = {};
+    // Skip header + the RDB format row ("5s 15s ..."), then data rows.
+    for (const line of lines.slice(2)) {
+      const f = line.split("\t");
+      const month = f[iMonth];
+      const day = f[iDay];
+      if (!month || !day) continue;
+      out[`${Number(month)}-${Number(day)}`] = {
+        p25: parseNum(f[iP25]),
+        p50: parseNum(f[iP50]),
+        p75: parseNum(f[iP75]),
+        p90: parseNum(f[iP90]),
+        mean: parseNum(f[iMean]),
+      };
+    }
+    return out;
+  });
+  return new Map(Object.entries(obj));
+}
+
+/**
+ * Contextualize a current discharge against the day's historical
+ * percentiles. Bands: <p25 low, p25–p75 normal, p75–p90 elevated,
+ * >p90 high.
+ */
+export function flowContext(
+  current: number | null,
+  stat: DailyStat | undefined,
+): { context: FlowContext; detail: string | null } {
+  if (current === null || !stat || stat.p25 === null || stat.p75 === null) {
+    return { context: "unknown", detail: null };
+  }
+  if (stat.p90 !== null && current > stat.p90) {
+    return { context: "high", detail: `above the 90th percentile for this date (p90 ${stat.p90} cfs)` };
+  }
+  if (current > stat.p75) {
+    return { context: "elevated", detail: `above the 75th percentile for this date (p75 ${stat.p75} cfs)` };
+  }
+  if (current < stat.p25) {
+    return { context: "low", detail: `below the 25th percentile for this date (p25 ${stat.p25} cfs)` };
+  }
+  return {
+    context: "normal",
+    detail: `within the interquartile range for this date (p25 ${stat.p25}–p75 ${stat.p75} cfs)`,
+  };
+}

--- a/apps/trip-mcp/src/tools/access_status.test.ts
+++ b/apps/trip-mcp/src/tools/access_status.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { ACCESS_ROADS, NAMED_ORIGINS } from "../access_roads.js";
+import { findRoadMention } from "../sources/usfs.js";
+import { AREAS } from "../areas.js";
+
+describe("ACCESS_ROADS registry (#85 acceptance)", () => {
+  it("maps all 12 areas to at least one access road with a manager", () => {
+    for (const area of AREAS) {
+      const roads = ACCESS_ROADS[area.id];
+      expect(roads, `missing access roads for ${area.id}`).toBeDefined();
+      expect(roads!.length).toBeGreaterThan(0);
+      for (const r of roads!) {
+        expect(["wsdot", "nps", "usfs"]).toContain(r.manager);
+        if (r.manager === "wsdot") expect(r.wsdot_pass_name).toBeTruthy();
+        if (r.manager === "nps") expect(r.nps_park_code).toBeTruthy();
+        if (r.manager === "usfs") expect(r.usfs_forest_slug).toBeTruthy();
+      }
+    }
+  });
+
+  it("includes the seattle default origin", () => {
+    expect(NAMED_ORIGINS["seattle"]).toBeDefined();
+  });
+});
+
+describe("findRoadMention", () => {
+  const page =
+    "Alerts and Notices. Suiattle River Road (FR 26) closed at milepost 12 due to washout damage. " +
+    "Mountain Loop Highway seasonal gate at Deer Creek remains closed until further notice.";
+
+  it("finds full and simplified road-name mentions with snippets", () => {
+    expect(findRoadMention(page, "Suiattle River Rd (FR 26)")).toMatch(/washout/);
+    expect(findRoadMention(page, "Mountain Loop Hwy")).toMatch(/seasonal gate/);
+  });
+
+  it("returns null when the road is not mentioned", () => {
+    expect(findRoadMention(page, "Cascade River Rd")).toBeNull();
+  });
+});

--- a/apps/trip-mcp/src/tools/access_status.ts
+++ b/apps/trip-mcp/src/tools/access_status.ts
@@ -1,0 +1,300 @@
+/**
+ * get_access_status: trailhead-reachability — per-access-road status by
+ * managing agency (WSDOT passes / NPS alerts / USFS alerts-page mention
+ * scan) plus drive time (curated static, or live OSRM on request).
+ * Supersedes get_conditions' never-implemented usfs_alerts stub for the
+ * road-status slice.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Confidence, Env, Source, ToolPayload } from "../types.js";
+import { empty, makeSource, nowIso, ok } from "../types.js";
+import { findAreaById, type RangerStation } from "../areas.js";
+import { ACCESS_ROADS, NAMED_ORIGINS, type AccessRoad } from "../access_roads.js";
+import { APPROACHES } from "../approach.js";
+import { findPassByName, getMountainPassConditions } from "../sources/wsdot.js";
+import { getNpsAlerts, type NpsAlert } from "../sources/nps.js";
+import { findRoadMention, forestAlertsUrl, getForestAlertsText } from "../sources/usfs.js";
+import { getDriveTime } from "../sources/osrm.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+type RoadStatus =
+  | "open"
+  | "advisory"
+  | "mentioned_in_alerts"
+  | "no_current_alerts"
+  | "unknown";
+
+interface RoadReport {
+  name: string;
+  manager: AccessRoad["manager"];
+  status: RoadStatus;
+  detail: string | null;
+  source_url: string;
+  as_of: string;
+  note?: string;
+}
+
+interface DriveTime {
+  origin: string;
+  mode: "static_curated" | "live_osrm";
+  duration_min: number | null;
+  distance_mi?: number;
+  note: string;
+}
+
+interface AccessStatusData {
+  area_id: string;
+  area_name: string;
+  roads: RoadReport[];
+  drive_time: DriveTime | null;
+  ranger_stations: RangerStation[];
+}
+
+const STALE_CAVEAT =
+  "Forest-road data is often stale at every source — the ranger district phone is the only real-time ground truth for gates and washouts.";
+
+function resolveOrigin(origin: string): { lat: number; lon: number; label: string } | null {
+  const named = NAMED_ORIGINS[origin.toLowerCase().trim()];
+  if (named) return { ...named, label: origin.toLowerCase().trim() };
+  const m = origin.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
+  if (m) {
+    const lat = Number.parseFloat(m[1]!);
+    const lon = Number.parseFloat(m[2]!);
+    if (Math.abs(lat) <= 90 && Math.abs(lon) <= 180) return { lat, lon, label: `${lat},${lon}` };
+  }
+  return null;
+}
+
+function npsRoadAlerts(alerts: NpsAlert[], roadName: string): NpsAlert[] {
+  const tokens = roadName
+    .toLowerCase()
+    .split(/[\s/()–-]+/)
+    .filter((t) => t.length >= 4 && !["road", "pass", "highway"].includes(t));
+  return alerts.filter((a) => {
+    const hay = `${a.title ?? ""} ${a.description ?? ""}`.toLowerCase();
+    return tokens.some((t) => hay.includes(t));
+  });
+}
+
+export function registerAccessStatusTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_access_status",
+    "Checking road access…",
+    "Trailhead reachability for a registry area: every mapped access road returns {status, detail, source_url, as_of} — never silent absence. Resolution by managing agency: state highways via WSDOT pass conditions (open/advisory); NPS park roads via NPS alerts (road-matching alerts surfaced, else no_current_alerts); USFS forest roads via a mention-scan of the forest's alerts page — 'mentioned_in_alerts' carries the snippet, and 'unknown' explicitly means NO information, NOT that the road is open (absence of an alert proves nothing; call the ranger district — contacts included). DRIVE TIME: impersonal `origin` parameter (named city — seattle default, everett/tacoma/bellingham/portland — or 'lat,lon'); static curated minutes by default, `live: true` for OSRM demo-server routing to the area centroid (no SLA, clearly labeled; centroid ≠ trailhead). Supersedes get_conditions' empty usfs_alerts stub for road status.",
+    {
+      area_id: z.string().describe("Registry area id (e.g. 'glacier_peak')."),
+      origin: z
+        .string()
+        .default("seattle")
+        .describe("Drive-time origin: named city (seattle/everett/tacoma/bellingham/portland) or 'lat,lon'. Default seattle."),
+      live: z
+        .boolean()
+        .default(false)
+        .describe("Route the drive time live via the OSRM demo server (no SLA) instead of the curated static estimate."),
+    },
+    async ({ area_id, origin, live }) => {
+      const area = findAreaById(area_id);
+      if (!area) {
+        return payloadResponse(empty<AccessStatusData>([`Unknown area_id: ${area_id}`]));
+      }
+      const roads = ACCESS_ROADS[area_id];
+      if (!roads || roads.length === 0) {
+        return payloadResponse(
+          empty<AccessStatusData>([`No access-road mapping for ${area_id} yet.`]),
+        );
+      }
+
+      const fetchedAt = nowIso();
+      const caveats: string[] = [STALE_CAVEAT];
+      const sources: Source[] = [];
+
+      // Fetch each upstream at most once, isolated.
+      const needsWsdot = roads.some((r) => r.manager === "wsdot");
+      const npsCodes = [...new Set(roads.map((r) => r.nps_park_code).filter((c): c is string => Boolean(c)))];
+      const forestSlugs = [...new Set(roads.map((r) => r.usfs_forest_slug).filter((s): s is string => Boolean(s)))];
+
+      const [wsdotResult, npsResults, forestTexts] = await Promise.all([
+        needsWsdot
+          ? getMountainPassConditions(env).then(
+              (passes) => ({ ok: true as const, passes }),
+              (e: unknown) => ({ ok: false as const, error: e instanceof Error ? e.message : String(e) }),
+            )
+          : Promise.resolve(null),
+        Promise.all(
+          npsCodes.map(async (code) => {
+            try {
+              return { code, alerts: (await getNpsAlerts(env, [code])).data, ok: true };
+            } catch (e) {
+              return { code, alerts: [] as NpsAlert[], ok: false, error: e instanceof Error ? e.message : String(e) };
+            }
+          }),
+        ),
+        Promise.all(
+          forestSlugs.map(async (slug) => ({ slug, text: await getForestAlertsText(env, slug) })),
+        ),
+      ]);
+
+      if (wsdotResult && !wsdotResult.ok) {
+        caveats.push(`wsdot_passes: ${wsdotResult.error} — WSDOT-managed roads report unknown.`);
+      }
+      for (const n of npsResults) {
+        if (!n.ok) caveats.push(`nps_alerts (${n.code}): ${"error" in n ? n.error : "failed"} — NPS-managed roads report unknown.`);
+      }
+      for (const f of forestTexts) {
+        if (f.text === null) {
+          caveats.push(`usfs_alerts_page (${f.slug}): fetch failed — that forest's roads report unknown.`);
+        }
+      }
+
+      const reports: RoadReport[] = roads.map((road): RoadReport => {
+        const base = { name: road.name, manager: road.manager, as_of: fetchedAt, ...(road.note ? { note: road.note } : {}) };
+        if (road.manager === "wsdot") {
+          const url = "https://wsdot.wa.gov/travel/real-time/mountainpasses";
+          if (wsdotResult?.ok) {
+            const pass = road.wsdot_pass_name ? findPassByName(wsdotResult.passes, road.wsdot_pass_name) : undefined;
+            if (pass) {
+              const restricted =
+                pass.TravelAdvisoryActive ||
+                Boolean(pass.RestrictionOne?.RestrictionText && !/no restriction/i.test(pass.RestrictionOne.RestrictionText));
+              return {
+                ...base,
+                status: restricted ? "advisory" : "open",
+                detail:
+                  `${pass.RoadCondition || "conditions unreported"}` +
+                  (pass.RestrictionOne?.RestrictionText ? `; ${pass.RestrictionOne.RestrictionText}` : ""),
+                source_url: url,
+                as_of: pass.DateUpdated || fetchedAt,
+              };
+            }
+            return { ...base, status: "unknown", detail: "pass not found in the WSDOT feed (some highways are unlisted off-season)", source_url: url };
+          }
+          return { ...base, status: "unknown", detail: "WSDOT feed unavailable", source_url: url };
+        }
+        if (road.manager === "nps") {
+          const parkUrl = `https://www.nps.gov/${road.nps_park_code ?? ""}/planyourvisit/conditions.htm`;
+          const parkRes = npsResults.find((n) => n.code === road.nps_park_code);
+          if (parkRes?.ok) {
+            const matches = npsRoadAlerts(parkRes.alerts, road.name);
+            if (matches.length > 0) {
+              return {
+                ...base,
+                status: "mentioned_in_alerts",
+                detail: matches.map((m) => m.title).filter(Boolean).join(" | ").slice(0, 400),
+                source_url: matches[0]?.url || parkUrl,
+              };
+            }
+            return { ...base, status: "no_current_alerts", detail: "no road-matching alerts in the NPS feed (verify seasonal schedules separately)", source_url: parkUrl };
+          }
+          return { ...base, status: "unknown", detail: "NPS alerts unavailable", source_url: parkUrl };
+        }
+        // usfs
+        const slug = road.usfs_forest_slug ?? "";
+        const pageUrl = forestAlertsUrl(slug);
+        const forest = forestTexts.find((f) => f.slug === slug);
+        if (forest?.text) {
+          const mention = findRoadMention(forest.text, road.name);
+          if (mention) {
+            return { ...base, status: "mentioned_in_alerts", detail: mention, source_url: pageUrl };
+          }
+          return {
+            ...base,
+            status: "unknown",
+            detail: "no mention on the forest alerts page — NOT confirmation the road is open; call the ranger district",
+            source_url: pageUrl,
+          };
+        }
+        return { ...base, status: "unknown", detail: "forest alerts page unavailable", source_url: pageUrl };
+      });
+
+      // Sources per consulted upstream.
+      if (needsWsdot) {
+        sources.push(
+          makeSource("https://wsdot.wa.gov/travel/real-time/mountainpasses", "WSDOT Mountain Pass Conditions", {
+            license: "public-domain",
+            confidence: "high",
+            fetched_at: fetchedAt,
+          }),
+        );
+      }
+      for (const code of npsCodes) {
+        sources.push(
+          makeSource(`https://developer.nps.gov/api/v1/alerts?parkCode=${code}`, "NPS Alerts API", {
+            license: "public-domain",
+            confidence: "high",
+            fetched_at: fetchedAt,
+          }),
+        );
+      }
+      for (const slug of forestSlugs) {
+        sources.push(
+          makeSource(forestAlertsUrl(slug), `USFS forest alerts page (${slug})`, {
+            license: "public-domain",
+            confidence: "low",
+            fetched_at: fetchedAt,
+          }),
+        );
+      }
+
+      // Drive time.
+      let driveTime: DriveTime | null = null;
+      const resolved = resolveOrigin(origin);
+      if (!resolved) {
+        caveats.push(`Unrecognized origin "${origin}" — use a named city (${Object.keys(NAMED_ORIGINS).join(", ")}) or 'lat,lon'. Drive time omitted.`);
+      } else if (live) {
+        try {
+          const est = await getDriveTime(env, resolved, area.centroid);
+          if (est) {
+            driveTime = {
+              origin: resolved.label,
+              mode: "live_osrm",
+              duration_min: est.duration_min,
+              distance_mi: est.distance_mi,
+              note: "OSRM demo server (no SLA); routed to the area CENTROID, not a specific trailhead — treat as approximate.",
+            };
+            sources.push(
+              makeSource("https://router.project-osrm.org/", "OSRM demo server (OpenStreetMap routing)", {
+                license: "ODbL",
+                confidence: "medium",
+                fetched_at: fetchedAt,
+              }),
+            );
+          } else {
+            caveats.push("osrm: routing failed — falling back to the curated static estimate.");
+          }
+        } catch (e) {
+          caveats.push(`osrm: ${e instanceof Error ? e.message : String(e)} — falling back to the curated static estimate.`);
+        }
+      }
+      if (!driveTime && resolved) {
+        const corridors = APPROACHES[area_id] ?? [];
+        const mins = corridors
+          .map((c) => c.drive_time_from_seattle_min)
+          .filter((v): v is number => typeof v === "number");
+        driveTime = {
+          origin: resolved.label,
+          mode: "static_curated",
+          duration_min: mins.length > 0 ? Math.min(...mins) : null,
+          note:
+            resolved.label === "seattle"
+              ? "curated typical no-traffic estimate from Seattle (shortest corridor); pass live: true for routed time"
+              : "curated estimates are Seattle-based — for a different origin pass live: true for a routed time",
+        };
+      }
+
+      const anyResolved = reports.some((r) => r.status !== "unknown");
+      const data: AccessStatusData = {
+        area_id,
+        area_name: area.name,
+        roads: reports,
+        drive_time: driveTime,
+        ranger_stations: area.ranger_stations,
+      };
+      const confidence: Confidence = anyResolved ? "medium" : "low";
+      const payload: ToolPayload<AccessStatusData> = ok(data, sources, confidence, caveats);
+      return payloadResponse(payload);
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/approach_info.test.ts
+++ b/apps/trip-mcp/src/tools/approach_info.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { APPROACHES } from "../approach.js";
+import { AREAS } from "../areas.js";
+
+describe("APPROACHES registry coverage (#82 acceptance)", () => {
+  it("seeds all 12 areas with >=1 corridor carrying gas, supplies, and road notes", () => {
+    for (const area of AREAS) {
+      const corridors = APPROACHES[area.id];
+      expect(corridors, `missing approach data for ${area.id}`).toBeDefined();
+      expect(corridors!.length).toBeGreaterThan(0);
+      const c = corridors![0]!;
+      expect(c.last_gas, `${area.id} missing last_gas`).toBeTruthy();
+      expect(c.last_supplies, `${area.id} missing last_supplies`).toBeTruthy();
+      expect(c.road_notes, `${area.id} missing road_notes`).toBeTruthy();
+    }
+  });
+
+  it("Mountain Loop corridor records the Everett-is-last-real-gear fact", () => {
+    const loop = APPROACHES["glacier_peak"]!.find((c) => /mountain loop/i.test(c.corridor));
+    expect(loop).toBeDefined();
+    expect(loop!.last_real_gear).toMatch(/Everett/);
+    expect(loop!.last_supplies).toMatch(/hardware/i);
+  });
+});

--- a/apps/trip-mcp/src/tools/approach_info.ts
+++ b/apps/trip-mcp/src/tools/approach_info.ts
@@ -1,0 +1,79 @@
+/**
+ * get_approach_info: curated approach logistics per registry area —
+ * last gas / real gear / supplies / food, cell coverage, road notes,
+ * typical drive time. Registry curation by design (no live place APIs).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Env } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById } from "../areas.js";
+import { APPROACHES, type ApproachCorridor } from "../approach.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+const STANDING_CAVEATS = [
+  "Store hours and stock change — call ahead before counting on any single stop (small-town stores keep seasonal hours).",
+  "Cell coverage entries are anecdotal community knowledge and carrier-dependent — treat as low confidence.",
+  "Road notes are curated, not live — verify current gate/washout status via get_access_status or the ranger district.",
+];
+
+interface ApproachInfoData {
+  area_id: string;
+  area_name: string;
+  corridors: ApproachCorridor[] | null;
+}
+
+export function registerApproachInfoTools(server: McpServer, env: Env): void {
+  void env;
+  titledTool(
+    server,
+    "get_approach_info",
+    "Checking approach logistics…",
+    "Curated approach logistics for a registry area, by corridor (areas with multiple entrances list each): last_gas, last_real_gear (the last store with actual technical gear — usually much closer to the city than assumed), last_supplies (with honest notes on what small stores realistically stock — hardware stores often carry rain gear), last_food, cell_coverage (anecdotal, low confidence), road_notes (seasonal gates, washouts, clearance), and a typical no-traffic drive_time_from_seattle_min (static curation; get_access_status offers live routing). Registry-curated only — WTA-fallback areas return an explicit no-data status. Data-only registry in src/approach.ts; corrections and new corridors are data edits.",
+    {
+      area_id: z.string().describe("Registry area id (e.g. 'glacier_peak')."),
+    },
+    async ({ area_id }) => {
+      const area = findAreaById(area_id);
+      if (!area) {
+        return payloadResponse(
+          empty<ApproachInfoData>([
+            `Unknown area_id: ${area_id}. Approach info is registry-curated — WTA-fallback areas are not covered.`,
+          ]),
+        );
+      }
+
+      const sources = [
+        makeSource(
+          "https://github.com/tusensii/mcp-stack/blob/main/apps/trip-mcp/src/approach.ts",
+          "trip-mcp curated approach registry",
+          { confidence: "medium" },
+        ),
+      ];
+      const corridors = APPROACHES[area_id];
+      if (!corridors || corridors.length === 0) {
+        return payloadResponse(
+          ok<ApproachInfoData>(
+            { area_id, area_name: area.name, corridors: null },
+            sources,
+            "low",
+            [
+              `No curated approach data for ${area_id} yet — explicit empty status, not an error.`,
+              ...STANDING_CAVEATS,
+            ],
+          ),
+        );
+      }
+
+      return payloadResponse(
+        ok<ApproachInfoData>(
+          { area_id, area_name: area.name, corridors },
+          sources,
+          "medium",
+          STANDING_CAVEATS,
+        ),
+      );
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/avalanche.ts
+++ b/apps/trip-mcp/src/tools/avalanche.ts
@@ -1,0 +1,216 @@
+/**
+ * get_avalanche_forecast: NWAC zone forecasts with danger by elevation
+ * band. Registry areas map statically to NWAC zone names (primary
+ * first); point queries resolve via the map-layer polygons. Off-season
+ * (roughly May–Oct) returns an explicit no-forecast status, never an
+ * error.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Confidence, Env, Source, ToolPayload } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById, type RangerStation } from "../areas.js";
+import {
+  getNwacForecast,
+  getNwacZones,
+  pointInRings,
+  type NwacDangerBand,
+  type NwacProblem,
+  type NwacZone,
+} from "../sources/nwac.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+/**
+ * Registry area → NWAC zone names, primary first. Names are matched
+ * against the live map-layer at call time so numeric zone ids can churn
+ * without breaking this table.
+ */
+export const AREA_NWAC_ZONES: Record<string, string[]> = {
+  enchantments: ["East Slopes Central", "Stevens Pass"],
+  mt_rainier: ["West Slopes South"],
+  north_cascades: ["West Slopes North", "East Slopes North"],
+  olympic: ["Olympics"],
+  glacier_peak: ["West Slopes North", "East Slopes North"],
+  pasayten: ["East Slopes North"],
+  alpine_lakes: ["Snoqualmie Pass", "Stevens Pass"],
+  henry_jackson: ["Stevens Pass", "West Slopes Central"],
+  goat_rocks: ["West Slopes South", "East Slopes South"],
+  mt_st_helens: ["West Slopes South"],
+  mt_adams: ["East Slopes South"],
+  mt_baker: ["West Slopes North"],
+};
+
+interface ZoneReport {
+  zone_name: string;
+  zone_id: number;
+  status: "forecast" | "off_season" | "unavailable";
+  link: string;
+  published_time?: string | null;
+  expires_time?: string | null;
+  bottom_line?: string | null;
+  travel_advice?: string | null;
+  hazard_discussion?: string | null;
+  /** Chart-ready: one row per valid_day × elevation band. */
+  danger_by_band?: NwacDangerBand[];
+  problems?: NwacProblem[];
+}
+
+interface AvalancheData {
+  area_id: string | null;
+  zones: ZoneReport[];
+  season_note: string;
+  ranger_stations: RangerStation[];
+}
+
+const SEASON_NOTE =
+  "NWAC forecasts are issued roughly Nov–Apr. Outside the season, avalanche hazard still exists on steep snow (early/late-season storm slabs, spring wet slides, glacial terrain) — assess on the ground and check nwac.us for statements.";
+
+export function registerAvalancheTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_avalanche_forecast",
+    "Checking avalanche forecast…",
+    "NWAC avalanche zone forecast(s) with danger by elevation band. Pass a registry `area_id` (mapped to its NWAC zone(s), primary first — some areas span two zones) or lat/lon (resolved via zone polygons). In season (~Nov–Apr): danger ratings per band as chart-ready rows {valid_day, band, danger_level (1–5 or null), danger_label (Low/Moderate/Considerable/High/Extreme)}, avalanche problems (type, aspects/elevations, likelihood, size), bottom line, and discussion. Ratings are never invented — bands the forecast omits come back null/'No Rating'. OFF-SEASON: returns status 'off_season' with the season note rather than an error — steep snow can still slide in summer; that status is not an all-clear. Safety framing: this surfaces the forecast, it does not make go/no-go calls — pair with get_safety_brief's ranger contacts for terrain-specific questions.",
+    {
+      area_id: z.string().optional().describe("Registry area id (e.g. 'mt_baker'). Overrides lat/lon."),
+      lat: z.number().min(-90).max(90).optional().describe("Latitude — resolved via NWAC zone polygons."),
+      lon: z.number().min(-180).max(180).optional().describe("Longitude."),
+    },
+    async ({ area_id, lat, lon }) => {
+      const fetchedAt = new Date().toISOString();
+      const caveats: string[] = [];
+      const sources: Source[] = [
+        makeSource(
+          "https://api.avalanche.org/v2/public/products/map-layer/NWAC",
+          "Northwest Avalanche Center via avalanche.org",
+          { license: "public", confidence: "high", fetched_at: fetchedAt },
+        ),
+      ];
+
+      let zones: NwacZone[];
+      try {
+        zones = await getNwacZones(env);
+      } catch (e) {
+        return payloadResponse(
+          empty<AvalancheData>(
+            [
+              `nwac_map_layer: ${e instanceof Error ? e.message : String(e)} — check nwac.us/avalanche-forecast directly.`,
+            ],
+            sources,
+          ),
+        );
+      }
+
+      let matched: NwacZone[] = [];
+      let rangerStations: RangerStation[] = [];
+      if (area_id) {
+        const area = findAreaById(area_id);
+        if (!area) {
+          return payloadResponse(empty<AvalancheData>([`Unknown area_id: ${area_id}`]));
+        }
+        rangerStations = area.ranger_stations;
+        const wanted = AREA_NWAC_ZONES[area_id];
+        if (!wanted) {
+          caveats.push(`No NWAC zone mapping for ${area_id} — falling back to polygon lookup at the area centroid.`);
+          matched = zones.filter((zone) =>
+            pointInRings(area.centroid.lat, area.centroid.lon, zone.rings),
+          );
+        } else {
+          // Preserve mapping order (primary first).
+          matched = wanted
+            .map((name) => zones.find((zone) => zone.name.toLowerCase() === name.toLowerCase()))
+            .filter((zone): zone is NwacZone => zone !== undefined);
+          const missing = wanted.filter(
+            (name) => !zones.some((zone) => zone.name.toLowerCase() === name.toLowerCase()),
+          );
+          if (missing.length > 0) {
+            caveats.push(`Mapped NWAC zone(s) not found in the live zone list: ${missing.join(", ")}.`);
+          }
+        }
+      } else if (typeof lat === "number" && typeof lon === "number") {
+        matched = zones.filter((zone) => pointInRings(lat, lon, zone.rings));
+        if (matched.length === 0) {
+          caveats.push("Point is outside all NWAC zone polygons — NWAC covers WA and the Mt Hood area only.");
+        }
+      } else {
+        return payloadResponse(empty<AvalancheData>(["Provide area_id or both lat and lon."]));
+      }
+
+      if (matched.length === 0) {
+        return payloadResponse(
+          empty<AvalancheData>([...caveats, "No NWAC zone resolved for this query."], sources),
+        );
+      }
+
+      const reports: ZoneReport[] = await Promise.all(
+        matched.map(async (zone): Promise<ZoneReport> => {
+          if (zone.off_season) {
+            // Still try the product endpoint — off-season it often carries
+            // the spring/fall statement worth surfacing.
+            let discussion: string | null = null;
+            try {
+              const product = await getNwacForecast(env, zone.zone_id);
+              discussion = product?.hazard_discussion ?? null;
+            } catch {
+              // statement is a bonus; off_season status stands on its own
+            }
+            return {
+              zone_name: zone.name,
+              zone_id: zone.zone_id,
+              status: "off_season",
+              link: zone.link,
+              ...(discussion ? { hazard_discussion: discussion } : {}),
+            };
+          }
+          try {
+            const product = await getNwacForecast(env, zone.zone_id);
+            if (!product) {
+              return { zone_name: zone.name, zone_id: zone.zone_id, status: "unavailable", link: zone.link };
+            }
+            return {
+              zone_name: zone.name,
+              zone_id: zone.zone_id,
+              status: "forecast",
+              link: zone.link,
+              published_time: product.published_time,
+              expires_time: product.expires_time,
+              bottom_line: product.bottom_line,
+              travel_advice: zone.travel_advice,
+              hazard_discussion: product.hazard_discussion,
+              danger_by_band: product.danger_by_band,
+              problems: product.problems,
+            };
+          } catch (e) {
+            caveats.push(
+              `nwac_forecast (${zone.name}): ${e instanceof Error ? e.message : String(e)} — see ${zone.link}.`,
+            );
+            return { zone_name: zone.name, zone_id: zone.zone_id, status: "unavailable", link: zone.link };
+          }
+        }),
+      );
+
+      sources.push(
+        makeSource("https://nwac.us/avalanche-forecast/", "NWAC forecast pages", {
+          license: "public",
+          confidence: "high",
+          fetched_at: fetchedAt,
+        }),
+      );
+
+      const anyForecast = reports.some((r) => r.status === "forecast");
+      const data: AvalancheData = {
+        area_id: area_id ?? null,
+        zones: reports,
+        season_note: SEASON_NOTE,
+        ranger_stations: rangerStations,
+      };
+      const confidence: Confidence = anyForecast
+        ? "high"
+        : reports.every((r) => r.status === "off_season")
+          ? "medium"
+          : "low";
+      return payloadResponse(ok(data, sources, confidence, caveats));
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/camp_water.test.ts
+++ b/apps/trip-mcp/src/tools/camp_water.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { CAMPING } from "../camping.js";
+
+describe("CAMPING registry (#84 acceptance)", () => {
+  it("Enchantments: designated-site zone model, named camps, canister requirement", () => {
+    const c = CAMPING["enchantments"]!;
+    expect(c.regulation_model).toBe("zone_quota");
+    expect(c.named_camps!.length).toBeGreaterThan(0);
+    expect(c.food_storage.detail).toMatch(/canister/i);
+  });
+
+  it("Glacier Peak: dispersed model with 100-ft rules", () => {
+    const c = CAMPING["glacier_peak"]!;
+    expect(c.regulation_model).toBe("dispersed_with_rules");
+    expect(c.regulation_detail).toMatch(/100 ?ft/);
+  });
+
+  it("water reliability notes present for at least 4 areas", () => {
+    const withWater = Object.values(CAMPING).filter(
+      (c) => c.water_reliability && c.water_reliability.length > 0,
+    );
+    expect(withWater.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("every fire and food rule cites a governing source URL", () => {
+    for (const [id, c] of Object.entries(CAMPING)) {
+      expect(c.fire_rules.source_url, `${id} fire_rules missing source`).toMatch(/^https:\/\//);
+      expect(c.food_storage.source_url, `${id} food_storage missing source`).toMatch(/^https:\/\//);
+      expect(c.food_storage.cross_ref).toMatch(/get_safety_brief/);
+      expect(c.permits_pointer).toMatch(/get_permit/);
+    }
+  });
+});

--- a/apps/trip-mcp/src/tools/camp_water.ts
+++ b/apps/trip-mcp/src/tools/camp_water.ts
@@ -1,0 +1,100 @@
+/**
+ * get_camp_water_beta: overnight camp + water beta. Two layers —
+ * curated registry data (regulation model, named camps, sourced fire/
+ * food rules, late-season water reliability) and a live OSM campsite
+ * query. References get_safety_brief (bear practice) and get_permits
+ * rather than duplicating them.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Env } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById } from "../areas.js";
+import { CAMPING, type Camping } from "../camping.js";
+import { findCampsites, type OsmCampsite } from "../sources/osm.js";
+import { bboxAroundPoint } from "../polyline.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+const OSM_CAVEAT =
+  "mapped_sites comes from OpenStreetMap and is incomplete AND unofficial: many legal dispersed sites are unmapped, and many mapped pitches are unofficial or closed — the curated regulation model governs what's legal.";
+
+interface CampWaterData {
+  area_id: string;
+  area_name: string;
+  camping: Camping | null;
+  mapped_sites: OsmCampsite[];
+}
+
+export function registerCampWaterTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_camp_water_beta",
+    "Checking camp and water beta…",
+    "Overnight camp + water beta for a registry area. Curated layer: regulation_model (designated_sites_only | zone_quota | dispersed_with_rules) with detail, named_camps for designated-site areas, fire_rules and food_storage each citing the governing source URL (never bare fact), and late-season water_reliability notes (LOW confidence — verify against recent trip reports). Live layer: `mapped_sites` from OSM (tourism=camp_site/camp_pitch, backcountry flag) — incomplete and unofficial; the regulation model governs legality. Cross-references by design: bear/wildlife practice lives in get_safety_brief, permits in get_permits/get_permit_strategy. Day-hike parity: nothing here is assumed by other tools.",
+    {
+      area_id: z.string().describe("Registry area id (e.g. 'enchantments')."),
+      radius_km: z
+        .number()
+        .min(1)
+        .max(30)
+        .default(15)
+        .describe("OSM campsite search radius around the area centroid. Default 15."),
+    },
+    async ({ area_id, radius_km }) => {
+      const area = findAreaById(area_id);
+      if (!area) {
+        return payloadResponse(
+          empty<CampWaterData>([
+            `Unknown area_id: ${area_id}. Camp/water beta is registry-curated — for off-registry trails use get_route_info's water layer + recent trip reports.`,
+          ]),
+        );
+      }
+
+      const caveats: string[] = [OSM_CAVEAT];
+      const sources = [
+        makeSource(
+          "https://github.com/tusensii/mcp-stack/blob/main/apps/trip-mcp/src/camping.ts",
+          "trip-mcp curated camping registry",
+          { confidence: "medium" },
+        ),
+      ];
+
+      const camping = CAMPING[area_id] ?? null;
+      if (!camping) {
+        caveats.push(`No curated camping data for ${area_id} yet — explicit empty status; the OSM layer below is all that's available.`);
+      } else {
+        caveats.push(
+          "water_reliability notes are curated and LOW confidence — verify against recent trip reports (get_trip_reports with extract_conditions).",
+        );
+        sources.push(
+          makeSource(camping.fire_rules.source_url, "Governing fire/food-storage regulations", {
+            confidence: "medium",
+          }),
+        );
+      }
+
+      let mappedSites: OsmCampsite[] = [];
+      try {
+        const bbox = bboxAroundPoint(area.centroid.lat, area.centroid.lon, radius_km);
+        mappedSites = (await findCampsites(env, bbox)).slice(0, 50);
+        sources.push(
+          makeSource("https://overpass-api.de/api/interpreter", "OpenStreetMap (Overpass API) — mapped campsites", {
+            license: "ODbL",
+            confidence: "low",
+          }),
+        );
+      } catch (e) {
+        caveats.push(`osm_campsites: ${e instanceof Error ? e.message : String(e)} — mapped_sites empty.`);
+      }
+
+      const data: CampWaterData = {
+        area_id,
+        area_name: area.name,
+        camping,
+        mapped_sites: mappedSites,
+      };
+      return payloadResponse(ok(data, sources, camping ? "medium" : "low", caveats));
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/conditions.ts
+++ b/apps/trip-mcp/src/tools/conditions.ts
@@ -231,9 +231,10 @@ export function registerConditionsTools(server: McpServer, env: Env): void {
       );
       if (!inciwebRes.ok && inciwebRes.error) caveats.push(inciwebRes.error);
 
-      // Always-on caveat for deferred USFS alerts.
+      // usfs_alerts remains [] here by design — the road-status slice is
+      // superseded by get_access_status (forest alerts-page mention scan).
       caveats.push(
-        "USFS forest-page scraping not yet implemented; check fs.usda.gov manually for forest-specific alerts.",
+        "usfs_alerts is not populated here — use get_access_status for USFS road status (forest alerts-page scan); check fs.usda.gov for other forest-specific alerts.",
       );
 
       const failures = [npsRes, wsdotRes, perimRes, incRes, inciwebRes].filter((r) => !r.ok).length;

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -10,6 +10,7 @@ import { registerElevationProfileTools } from "./elevation_profile.js";
 import { registerTrailWeatherProfileTools } from "./trail_weather_profile.js";
 import { registerRiverConditionsTools } from "./river_conditions.js";
 import { registerAvalancheTools } from "./avalanche.js";
+import { registerSeasonalTimingTools } from "./seasonal_timing.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -25,6 +26,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerTrailWeatherProfileTools(server, env);
   registerRiverConditionsTools(server, env);
   registerAvalancheTools(server, env);
+  registerSeasonalTimingTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerTrailWeatherProfileTools } from "./trail_weather_profile.js";
 import { registerRiverConditionsTools } from "./river_conditions.js";
 import { registerAvalancheTools } from "./avalanche.js";
 import { registerSeasonalTimingTools } from "./seasonal_timing.js";
+import { registerApproachInfoTools } from "./approach_info.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -27,6 +28,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerRiverConditionsTools(server, env);
   registerAvalancheTools(server, env);
   registerSeasonalTimingTools(server, env);
+  registerApproachInfoTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -12,6 +12,7 @@ import { registerRiverConditionsTools } from "./river_conditions.js";
 import { registerAvalancheTools } from "./avalanche.js";
 import { registerSeasonalTimingTools } from "./seasonal_timing.js";
 import { registerApproachInfoTools } from "./approach_info.js";
+import { registerPermitStrategyTools } from "./permit_strategy.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -29,6 +30,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerAvalancheTools(server, env);
   registerSeasonalTimingTools(server, env);
   registerApproachInfoTools(server, env);
+  registerPermitStrategyTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -8,6 +8,7 @@ import { registerTripReportTools } from "./trip_reports.js";
 import { registerRouteInfoTools } from "./route_info.js";
 import { registerElevationProfileTools } from "./elevation_profile.js";
 import { registerTrailWeatherProfileTools } from "./trail_weather_profile.js";
+import { registerRiverConditionsTools } from "./river_conditions.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -21,6 +22,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerRouteInfoTools(server, env);
   registerElevationProfileTools(server, env);
   registerTrailWeatherProfileTools(server, env);
+  registerRiverConditionsTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -14,6 +14,7 @@ import { registerSeasonalTimingTools } from "./seasonal_timing.js";
 import { registerApproachInfoTools } from "./approach_info.js";
 import { registerPermitStrategyTools } from "./permit_strategy.js";
 import { registerCampWaterTools } from "./camp_water.js";
+import { registerAccessStatusTools } from "./access_status.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -33,6 +34,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerApproachInfoTools(server, env);
   registerPermitStrategyTools(server, env);
   registerCampWaterTools(server, env);
+  registerAccessStatusTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerRouteInfoTools } from "./route_info.js";
 import { registerElevationProfileTools } from "./elevation_profile.js";
 import { registerTrailWeatherProfileTools } from "./trail_weather_profile.js";
 import { registerRiverConditionsTools } from "./river_conditions.js";
+import { registerAvalancheTools } from "./avalanche.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -23,6 +24,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerElevationProfileTools(server, env);
   registerTrailWeatherProfileTools(server, env);
   registerRiverConditionsTools(server, env);
+  registerAvalancheTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/index.ts
+++ b/apps/trip-mcp/src/tools/index.ts
@@ -13,6 +13,7 @@ import { registerAvalancheTools } from "./avalanche.js";
 import { registerSeasonalTimingTools } from "./seasonal_timing.js";
 import { registerApproachInfoTools } from "./approach_info.js";
 import { registerPermitStrategyTools } from "./permit_strategy.js";
+import { registerCampWaterTools } from "./camp_water.js";
 import { registerSafetyTools } from "./safety.js";
 import { registerWebResearchTools } from "./web_research.js";
 import { registerResearchTripTool } from "./research_trip.js";
@@ -31,6 +32,7 @@ export function registerAllTools(server: McpServer, env: Env): void {
   registerSeasonalTimingTools(server, env);
   registerApproachInfoTools(server, env);
   registerPermitStrategyTools(server, env);
+  registerCampWaterTools(server, env);
   registerSafetyTools(server, env);
   registerWebResearchTools(server, env);
   registerResearchTripTool(server, env);

--- a/apps/trip-mcp/src/tools/permit_strategy.test.ts
+++ b/apps/trip-mcp/src/tools/permit_strategy.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { summarizeAvailability } from "./permit_strategy.js";
+import { PERMIT_STRATEGIES } from "../permit_strategy.js";
+import { AREAS } from "../areas.js";
+
+describe("PERMIT_STRATEGIES coverage (#83 acceptance)", () => {
+  it("Enchantments has at least 3 distinct acquisition paths with windows and odds", () => {
+    const s = PERMIT_STRATEGIES["enchantments"]!;
+    expect(s.paths.length).toBeGreaterThanOrEqual(3);
+    for (const p of s.paths) {
+      expect(p.window).toBeTruthy();
+      expect(p.odds_context).toBeTruthy();
+    }
+  });
+
+  it("self-issued areas state the simple truth without padding", () => {
+    const s = PERMIT_STRATEGIES["glacier_peak"]!;
+    expect(s.paths).toHaveLength(1);
+    expect(s.paths[0]!.method).toMatch(/self-issued/);
+  });
+
+  it("every rec_gov registry area has curated paths", () => {
+    for (const area of AREAS) {
+      if (area.permit_system.startsWith("rec_gov")) {
+        const s = PERMIT_STRATEGIES[area.id];
+        expect(s, `missing strategy for ${area.id}`).toBeDefined();
+        expect(s!.paths.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("walk-up beta exists for areas with real walk-up quotas", () => {
+    expect(PERMIT_STRATEGIES["mt_rainier"]!.walk_up_beta).toBeTruthy();
+    expect(PERMIT_STRATEGIES["north_cascades"]!.walk_up_beta).toBeTruthy();
+  });
+});
+
+describe("summarizeAvailability", () => {
+  it("counts dates with remaining capacity across nested grids", () => {
+    const raw = {
+      payload: {
+        availability: {
+          "233273_1": {
+            date_availability: {
+              "2026-09-01T00:00:00Z": { remaining: 0, total: 10 },
+              "2026-09-02T00:00:00Z": { remaining: 3, total: 10 },
+            },
+          },
+          "233273_2": {
+            date_availability: {
+              "2026-09-01T00:00:00Z": { remaining: 2, total: 4 },
+            },
+          },
+        },
+      },
+    };
+    const s = summarizeAvailability(raw, "2026-09");
+    expect(s).toEqual({ available_days: 2, days_seen: 2 });
+  });
+
+  it("returns null on unrecognizable shapes instead of guessing", () => {
+    expect(summarizeAvailability({ weird: [1, 2, 3] }, "2026-09")).toBeNull();
+    expect(summarizeAvailability(null, "2026-09")).toBeNull();
+  });
+});

--- a/apps/trip-mcp/src/tools/permit_strategy.ts
+++ b/apps/trip-mcp/src/tools/permit_strategy.ts
@@ -1,0 +1,181 @@
+/**
+ * get_permit_strategy: the strategic layer over get_permits — realistic
+ * acquisition paths, walk-up beta, cancellation patterns, plus an
+ * optional live availability probe for reservation-system areas.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Env } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById, type RangerStation } from "../areas.js";
+import { PERMIT_STRATEGIES, type PermitStrategy } from "../permit_strategy.js";
+import { getPermitAvailability } from "../sources/ridb.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+const ODDS_CAVEAT =
+  "Odds and windows are historical/approximate (year noted where known) and shift yearly — recreation.gov and the ranger station are authoritative.";
+
+interface LiveAvailability {
+  attempted: boolean;
+  permit_id?: string;
+  month?: string;
+  available_days?: number;
+  days_seen?: number;
+  source_url?: string;
+  note: string;
+}
+
+/**
+ * Generic month summary over recreation.gov/RIDB availability grids.
+ * Shapes vary by permit; walk the object tree for date-keyed entries
+ * carrying a numeric `remaining`. Returns null when nothing matched —
+ * callers degrade to the check_availability pointer, never guess.
+ */
+export function summarizeAvailability(
+  raw: unknown,
+  monthPrefix: string,
+): { available_days: number; days_seen: number } | null {
+  const perDate = new Map<string, number>();
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      const dateM = key.match(/^(\d{4}-\d{2}-\d{2})/);
+      if (dateM && dateM[1]!.startsWith(monthPrefix) && value && typeof value === "object") {
+        const rec = value as Record<string, unknown>;
+        const remaining =
+          typeof rec.remaining === "number"
+            ? rec.remaining
+            : typeof rec.quota_usage_by_member_daily === "number"
+              ? rec.quota_usage_by_member_daily
+              : null;
+        if (remaining !== null) {
+          const date = dateM[1]!;
+          perDate.set(date, Math.max(perDate.get(date) ?? 0, remaining));
+          continue;
+        }
+      }
+      visit(value);
+    }
+  };
+  visit(raw);
+  if (perDate.size === 0) return null;
+  let available = 0;
+  for (const remaining of perDate.values()) {
+    if (remaining > 0) available++;
+  }
+  return { available_days: available, days_seen: perDate.size };
+}
+
+function lastDayOfMonth(yyyyMm: string): string {
+  const [y, m] = yyyyMm.split("-").map((s) => Number.parseInt(s, 10));
+  const last = new Date(Date.UTC(y ?? 2026, m ?? 1, 0)).getUTCDate();
+  return `${yyyyMm}-${String(last).padStart(2, "0")}`;
+}
+
+interface PermitStrategyData {
+  area_id: string;
+  area_name: string;
+  permit_system: string;
+  strategy: PermitStrategy | null;
+  live_availability?: LiveAvailability;
+  ranger_stations: RangerStation[];
+}
+
+export function registerPermitStrategyTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_permit_strategy",
+    "Working out permit strategy…",
+    "The strategic layer over get_permits: ordered, realistic acquisition paths per area ({method, window, odds_context, effort, notes}) — lotteries, unclaimed-date releases, continuation lotteries, walk-up hold-backs, day-use workarounds, off-season windows — plus walk_up_beta (which ranger stations issue, when lines form), cancellation_beta, and zone_notes. Self-issued areas return the simple truth (kiosk permit, no strategy needed) rather than padding. All odds are historical/approximate and shift yearly — recreation.gov + ranger stations are authoritative (contacts included). With `target_month` (YYYY-MM) on a reservation-system area, a live recreation.gov availability probe summarizes how many days currently show openings (degrades to a check_availability pointer when the grid shape is unreadable).",
+    {
+      area_id: z.string().describe("Registry area id (e.g. 'enchantments')."),
+      target_month: z
+        .string()
+        .regex(/^\d{4}-\d{2}$/)
+        .optional()
+        .describe("YYYY-MM — adds a live availability summary for reservation-system areas."),
+    },
+    async ({ area_id, target_month }) => {
+      const area = findAreaById(area_id);
+      if (!area) {
+        return payloadResponse(empty<PermitStrategyData>([`Unknown area_id: ${area_id}`]));
+      }
+
+      const sources = [
+        makeSource(
+          "https://github.com/tusensii/mcp-stack/blob/main/apps/trip-mcp/src/permit_strategy.ts",
+          "trip-mcp curated permit-strategy registry",
+          { confidence: "medium" },
+        ),
+      ];
+      const caveats = [ODDS_CAVEAT];
+      const strategy = PERMIT_STRATEGIES[area_id] ?? null;
+      if (!strategy) {
+        caveats.push(`No curated strategy for ${area_id} yet — explicit empty status; see get_permits for the raw permit records.`);
+      }
+
+      let live: LiveAvailability | undefined;
+      if (target_month && area.permit_system.startsWith("rec_gov")) {
+        const permitId = area.rec_gov_permit_ids?.[0];
+        if (!permitId) {
+          live = { attempted: false, note: "No rec.gov permit id in the registry for this area." };
+        } else {
+          try {
+            const res = await getPermitAvailability(
+              env,
+              permitId,
+              `${target_month}-01`,
+              lastDayOfMonth(target_month),
+            );
+            if (res.ok && res.data) {
+              const summary = summarizeAvailability(res.data.raw, target_month);
+              live = {
+                attempted: true,
+                permit_id: permitId,
+                month: target_month,
+                source_url: res.data.source_url,
+                ...(summary
+                  ? {
+                      available_days: summary.available_days,
+                      days_seen: summary.days_seen,
+                      note: `${summary.available_days} of ${summary.days_seen} ${target_month} days currently show availability (any division/site; shapes vary — use check_availability for the full grid).`,
+                    }
+                  : {
+                      note: "Availability grid fetched but its shape wasn't summarizable — use check_availability for the raw grid rather than trusting a guessed count.",
+                    }),
+              };
+            } else {
+              live = { attempted: true, permit_id: permitId, month: target_month, note: `availability probe failed: ${res.error ?? "unknown"}` };
+              caveats.push(`live_availability: ${res.error ?? "upstream failure"} — strategy data unaffected.`);
+            }
+          } catch (e) {
+            live = { attempted: true, permit_id: permitId, month: target_month, note: `availability probe failed: ${e instanceof Error ? e.message : String(e)}` };
+            caveats.push("live_availability probe failed — strategy data unaffected.");
+          }
+          sources.push(
+            makeSource("https://www.recreation.gov/", "Recreation.gov availability", {
+              license: "public",
+              confidence: "medium",
+            }),
+          );
+        }
+      } else if (target_month) {
+        live = {
+          attempted: false,
+          note: `${area_id} is ${area.permit_system} — no reservation grid to probe.`,
+        };
+      }
+
+      const data: PermitStrategyData = {
+        area_id,
+        area_name: area.name,
+        permit_system: area.permit_system,
+        strategy,
+        ...(live ? { live_availability: live } : {}),
+        ranger_stations: area.ranger_stations,
+      };
+      return payloadResponse(ok(data, sources, strategy ? "medium" : "low", caveats));
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/profile_shared.ts
+++ b/apps/trip-mcp/src/tools/profile_shared.ts
@@ -10,8 +10,35 @@
 
 import { z } from "zod";
 import type { Env } from "../types.js";
-import { findTrailGeometryByName, getOsmGeometry } from "../sources/osm.js";
+import {
+  findTrailGeometryByName,
+  getOsmGeometry,
+  type OsmGeometryAssembly,
+} from "../sources/osm.js";
 import { bboxAroundPoint, type PolyPoint } from "../polyline.js";
+
+/** Caveats distinguishing clean chains, bridged gaps, and truncation. */
+function assemblyCaveats(assembly: OsmGeometryAssembly | undefined): string[] {
+  if (!assembly || assembly.segments_used <= 1) return [];
+  const out: string[] = [];
+  const from = assembly.assembled_from === "relation" ? "route relation members" : "connected OSM ways";
+  if (assembly.bridged_gaps_m.length === 0) {
+    out.push(`Full chain assembled from ${assembly.segments_used} ${from}.`);
+  } else {
+    out.push(
+      `Chain assembled from ${assembly.segments_used} ${from} with ${assembly.bridged_gaps_m.length} bridged gap(s) (max ${Math.max(...assembly.bridged_gaps_m)} m straight-line) — mileage across gaps is approximate.`,
+    );
+  }
+  if (assembly.leftover_segments > 0) {
+    out.push(
+      `${assembly.leftover_segments} name-matching segment(s) could not be connected to the chain (disjoint or >50 m away) and were excluded.`,
+    );
+  }
+  if (assembly.capped) {
+    out.push("Chain stopped at the 30 mi assembly cap — the matched route continues beyond it.");
+  }
+  return out;
+}
 
 export const profileInputSchema = {
   points: z
@@ -90,9 +117,7 @@ export async function resolvePolyline(
       points: geom.points,
       resolved_from: "osm_id",
       osm_id: geom.id,
-      caveats: geom.id.startsWith("relation/")
-        ? ["Relation geometry concatenated in member order; OSM does not guarantee ordering — mileage may be off if members are unsorted."]
-        : [],
+      caveats: assemblyCaveats(geom.assembly),
     };
     if (geom.name) out.matched_name = geom.name;
     return out;
@@ -103,7 +128,10 @@ export async function resolvePolyline(
       return { error: "trail_name resolution requires both lat and lon as a location hint." };
     }
     const bbox = bboxAroundPoint(args.lat, args.lon, args.radius_km);
-    const geom = await findTrailGeometryByName(env, bbox, args.trail_name);
+    const geom = await findTrailGeometryByName(env, bbox, args.trail_name, {
+      lat: args.lat,
+      lon: args.lon,
+    });
     if (!geom) {
       return {
         error:
@@ -116,7 +144,8 @@ export async function resolvePolyline(
       resolved_from: "trail_name",
       osm_id: geom.id,
       caveats: [
-        "Trail resolved to the single longest matching OSM way — long trails split across several ways may be truncated; pass osm_id or points for the full line.",
+        ...assemblyCaveats(geom.assembly),
+        "Full mapped line assembled from OSM — OSM coverage may end before the on-the-ground destination (upper-basin routes are often unmapped user tracks).",
       ],
     };
     if (geom.name) out.matched_name = geom.name;

--- a/apps/trip-mcp/src/tools/river_conditions.ts
+++ b/apps/trip-mcp/src/tools/river_conditions.ts
@@ -1,0 +1,235 @@
+/**
+ * get_river_conditions: USGS gauge data for crossing assessment.
+ *
+ * Registry areas carry curated crossing→gauge mappings; anything else
+ * falls back to bbox gauge discovery with an explicit relevance caveat.
+ * Gauges indicate TREND, not crossability — output never judges a
+ * crossing "safe", and the ranger-station pointer rides along per the
+ * app's safety convention.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Confidence, Env, Source, ToolPayload } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById, type RangerStation } from "../areas.js";
+import {
+  discoverGauges,
+  flowContext,
+  getDailyStats,
+  getGauges,
+  type FlowContext,
+  type GaugeSeriesPoint,
+} from "../sources/usgs_water.js";
+import { bboxAroundPoint } from "../polyline.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+interface GaugeReport {
+  site_id: string;
+  site_name: string;
+  lat: number | null;
+  lon: number | null;
+  crossing?: string;
+  crossing_note?: string;
+  discharge_cfs: number | null;
+  gage_height_ft: number | null;
+  reading_time: string | null;
+  flow_context: FlowContext;
+  flow_context_detail: string | null;
+  /** 7-day chart-ready series {time_iso, discharge_cfs}. */
+  series: GaugeSeriesPoint[];
+}
+
+interface RiverConditionsData {
+  area_id: string | null;
+  gauges: GaugeReport[];
+  gauge_relevance: "curated" | "discovered";
+  ranger_stations: RangerStation[];
+  provenance: {
+    discharge: string;
+    flow_context: string;
+  };
+}
+
+const SAFETY_CAVEATS = [
+  "Gauges indicate flow TREND, not crossability — no reading makes a specific crossing safe. Glacial streams pulse in the afternoon; cross in the morning.",
+  "Call the ranger station for current crossing conditions before committing to a route with major fords.",
+];
+
+export function registerRiverConditionsTools(server: McpServer, env: Env): void {
+  titledTool(
+    server,
+    "get_river_conditions",
+    "Reading river gauges…",
+    "USGS stream-gauge data for river-crossing assessment. Pass `area_id` for curated crossing→gauge mappings (Glacier Peak's Sauk/Suiattle corridors, Olympic's Elwha/Quinault, Enchantments' Icicle, etc.), or lat/lon + radius_km for nearest-gauge discovery — discovered gauges carry a caveat that gauge-to-crossing relevance is UNVERIFIED (a downstream gauge may not represent the crossing). Per gauge: current discharge (cfs) + gage height (ft), a 7-day chart-ready `series` of {time_iso, discharge_cfs}, and `flow_context` (low/normal/elevated/high) from historical percentiles for this date when USGS statistics exist. Rising limb + elevated/high context = postpone fords. This tool NEVER judges a crossing safe — surface the flow context and trend, then point at the ranger station (included in the response for registry areas).",
+    {
+      area_id: z.string().optional().describe("Registry area id (e.g. 'glacier_peak') — uses curated crossing→gauge mappings."),
+      lat: z.number().min(-90).max(90).optional().describe("Latitude for gauge discovery when area_id is absent."),
+      lon: z.number().min(-180).max(180).optional().describe("Longitude for gauge discovery when area_id is absent."),
+      radius_km: z.number().min(1).max(50).default(25).describe("Discovery radius (km). Default 25."),
+      max_gauges: z.number().int().min(1).max(10).default(5).describe("Max gauges returned in discovery mode. Default 5."),
+    },
+    async ({ area_id, lat, lon, radius_km, max_gauges }) => {
+      const fetchedAt = new Date().toISOString();
+      const caveats: string[] = [...SAFETY_CAVEATS];
+      const sources: Source[] = [
+        makeSource(
+          "https://waterservices.usgs.gov/nwis/iv/",
+          "USGS NWIS Instantaneous Values",
+          { license: "public domain (US Govt)", confidence: "high", fetched_at: fetchedAt },
+        ),
+      ];
+
+      let curated: Array<{ site: string; crossing: string; note?: string }> = [];
+      let rangerStations: RangerStation[] = [];
+      let relevance: "curated" | "discovered" = "discovered";
+      let centerLat = lat;
+      let centerLon = lon;
+
+      if (area_id) {
+        const area = findAreaById(area_id);
+        if (!area) {
+          return payloadResponse(empty<RiverConditionsData>([`Unknown area_id: ${area_id}`]));
+        }
+        rangerStations = area.ranger_stations;
+        centerLat = area.centroid.lat;
+        centerLon = area.centroid.lon;
+        if (area.crossings && area.crossings.length > 0) {
+          relevance = "curated";
+          curated = area.crossings.map((c) => ({
+            site: c.gauge_site_id,
+            crossing: c.name,
+            ...(c.note ? { note: c.note } : {}),
+          }));
+        } else {
+          caveats.push(
+            `No curated crossing→gauge mappings for ${area_id} yet — falling back to nearest-gauge discovery; gauge-to-crossing relevance is UNVERIFIED.`,
+          );
+        }
+      }
+
+      if (curated.length === 0) {
+        if (typeof centerLat !== "number" || typeof centerLon !== "number") {
+          return payloadResponse(
+            empty<RiverConditionsData>(["Provide area_id or both lat and lon."]),
+          );
+        }
+        if (!area_id) {
+          caveats.push(
+            "Discovered gauges are nearest-by-bbox; gauge-to-crossing relevance is UNVERIFIED — a downstream gauge may not represent conditions at your crossing.",
+          );
+        }
+      }
+
+      // Resolve site list: curated ids, or discovery.
+      let siteIds: string[];
+      const crossingBySite = new Map<string, { crossing: string; note?: string }>();
+      if (curated.length > 0) {
+        siteIds = curated.map((c) => c.site);
+        for (const c of curated) {
+          crossingBySite.set(c.site, { crossing: c.crossing, ...(c.note ? { note: c.note } : {}) });
+        }
+      } else {
+        try {
+          const bbox = bboxAroundPoint(centerLat!, centerLon!, radius_km);
+          const found = await discoverGauges(env, bbox);
+          siteIds = found.slice(0, max_gauges).map((g) => g.site_id);
+          if (siteIds.length === 0) {
+            return payloadResponse(
+              empty<RiverConditionsData>(
+                [`No active USGS discharge gauges within ${radius_km} km.`, ...caveats],
+                sources,
+              ),
+            );
+          }
+        } catch (e) {
+          return payloadResponse(
+            empty<RiverConditionsData>(
+              [`usgs_discovery: ${e instanceof Error ? e.message : String(e)}`, ...caveats],
+              sources,
+            ),
+          );
+        }
+      }
+
+      // Fetch gauge data, then per-gauge percentile context (isolated).
+      let gauges: GaugeReport[];
+      try {
+        const data = await getGauges(env, siteIds);
+        gauges = await Promise.all(
+          data.map(async (g): Promise<GaugeReport> => {
+            let context: FlowContext = "unknown";
+            let detail: string | null = null;
+            try {
+              const stats = await getDailyStats(env, g.site_id);
+              const now = new Date(
+                new Date().toLocaleString("en-US", { timeZone: "America/Los_Angeles" }),
+              );
+              const stat = stats.get(`${now.getMonth() + 1}-${now.getDate()}`);
+              const fc = flowContext(g.discharge_cfs, stat);
+              context = fc.context;
+              detail = fc.detail;
+              if (context === "unknown") {
+                caveats.push(
+                  `flow_context unavailable for ${g.site_id} — no historical statistics for this site/date.`,
+                );
+              }
+            } catch (e) {
+              caveats.push(
+                `usgs_stats (${g.site_id}): ${e instanceof Error ? e.message : String(e)} — flow_context unknown.`,
+              );
+            }
+            const curatedInfo = crossingBySite.get(g.site_id);
+            return {
+              site_id: g.site_id,
+              site_name: g.site_name,
+              lat: g.lat,
+              lon: g.lon,
+              ...(curatedInfo ? { crossing: curatedInfo.crossing } : {}),
+              ...(curatedInfo?.note ? { crossing_note: curatedInfo.note } : {}),
+              discharge_cfs: g.discharge_cfs,
+              gage_height_ft: g.gage_height_ft,
+              reading_time: g.reading_time,
+              flow_context: context,
+              flow_context_detail: detail,
+              series: g.series,
+            };
+          }),
+        );
+      } catch (e) {
+        return payloadResponse(
+          empty<RiverConditionsData>(
+            [`usgs_iv: ${e instanceof Error ? e.message : String(e)}`, ...caveats],
+            sources,
+          ),
+        );
+      }
+
+      const missing = siteIds.filter((s) => !gauges.some((g) => g.site_id === s));
+      for (const m of missing) {
+        caveats.push(`Gauge ${m} returned no data (inactive or ice-affected) — omitted.`);
+      }
+
+      sources.push(
+        makeSource(
+          "https://waterservices.usgs.gov/nwis/stat/",
+          "USGS NWIS Daily Statistics (historical percentiles)",
+          { license: "public domain (US Govt)", confidence: "high", fetched_at: fetchedAt },
+        ),
+      );
+
+      const data: RiverConditionsData = {
+        area_id: area_id ?? null,
+        gauges,
+        gauge_relevance: relevance,
+        ranger_stations: rangerStations,
+        provenance: {
+          discharge: "USGS real-time gauge observation (provisional data, subject to revision)",
+          flow_context: "derived from USGS daily statistics percentiles for this calendar date",
+        },
+      };
+      const confidence: Confidence = gauges.length > 0 ? "high" : "low";
+      return payloadResponse(ok(data, sources, confidence, caveats));
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/seasonal_timing.test.ts
+++ b/apps/trip-mcp/src/tools/seasonal_timing.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { dayOfYear, windowRelevantToMonth } from "./seasonal_timing.js";
+import { SEASONAL } from "../seasonal.js";
+import { AREAS } from "../areas.js";
+
+describe("dayOfYear", () => {
+  it("maps MM-DD to day numbers", () => {
+    expect(dayOfYear("01-01")).toBe(1);
+    expect(dayOfYear("07-15")).toBe(196);
+    expect(dayOfYear("12-31")).toBe(365);
+  });
+});
+
+describe("windowRelevantToMonth", () => {
+  const larch = { start: "09-25", end: "10-15" };
+
+  it("keeps windows active in the month", () => {
+    expect(windowRelevantToMonth(larch, 10)).toBe(true);
+  });
+
+  it("keeps windows starting within the ~6-week lookahead", () => {
+    expect(windowRelevantToMonth(larch, 8)).toBe(true);
+  });
+
+  it("drops windows far outside the interest period", () => {
+    expect(windowRelevantToMonth(larch, 2)).toBe(false);
+    expect(windowRelevantToMonth({ start: "05-15", end: "06-30" }, 10)).toBe(false);
+  });
+});
+
+describe("SEASONAL registry coverage (#80 acceptance)", () => {
+  it("seeds all 12 areas with snow_free_typical and bug_pressure", () => {
+    for (const area of AREAS) {
+      const s = SEASONAL[area.id];
+      expect(s, `missing seasonal data for ${area.id}`).toBeDefined();
+      expect(s!.snow_free_typical, `missing snow_free_typical for ${area.id}`).toBeDefined();
+      expect(s!.bug_pressure.length, `missing bug_pressure for ${area.id}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("has larch windows for the 3 larch areas", () => {
+    for (const id of ["enchantments", "north_cascades", "pasayten"]) {
+      expect(SEASONAL[id]?.larch_window, `missing larch window for ${id}`).toBeDefined();
+    }
+  });
+});

--- a/apps/trip-mcp/src/tools/seasonal_timing.ts
+++ b/apps/trip-mcp/src/tools/seasonal_timing.ts
@@ -1,0 +1,132 @@
+/**
+ * get_seasonal_timing: curated typical-year windows (melt-out, larches,
+ * wildflowers, bugs, crossing peak, crowds) per registry area. Pure
+ * curation — no upstream calls; confidence capped at medium with a
+ * standing typical-year caveat.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Env, ToolPayload } from "../types.js";
+import { empty, makeSource, ok } from "../types.js";
+import { findAreaById } from "../areas.js";
+import { SEASONAL, type Seasonal, type SeasonalWindow } from "../seasonal.js";
+import { payloadResponse, titledTool } from "./utils.js";
+
+const TYPICAL_YEAR_CAVEAT =
+  "Typical-year windows — actual timing swings ±2–3 weeks with snowpack. Verify against current snow levels (get_weather freezing levels) and recent trip reports before planning around any window.";
+
+/** Day-of-year (1-366) for an "MM-DD" string; non-leap calendar. */
+export function dayOfYear(mmdd: string): number {
+  const [mm, dd] = mmdd.split("-").map((s) => Number.parseInt(s, 10));
+  const cumDays = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+  return (cumDays[(mm ?? 1) - 1] ?? 0) + (dd ?? 1);
+}
+
+/**
+ * Does a window overlap the interest period for `month` — that month
+ * plus a ~6-week lookahead? Used by the optional month filter.
+ */
+export function windowRelevantToMonth(window: SeasonalWindow, month: number): boolean {
+  const interestStart = dayOfYear(`${String(month).padStart(2, "0")}-01`);
+  const interestEnd = interestStart + 72; // month (~31d) + ~6 weeks
+  const s = dayOfYear(window.start);
+  const e = dayOfYear(window.end);
+  const overlaps = (from: number, to: number) => s <= to && e >= from;
+  // Handle lookahead wrapping past year end by also testing shifted +365.
+  return overlaps(interestStart, interestEnd) || overlaps(interestStart - 365, interestEnd - 365);
+}
+
+function filterByMonth(seasonal: Seasonal, month: number): Seasonal {
+  const keepWindow = (w: SeasonalWindow | undefined) =>
+    w && windowRelevantToMonth(w, month) ? w : undefined;
+  const out: Seasonal = {
+    bug_pressure: seasonal.bug_pressure,
+    ...(seasonal.crowds ? { crowds: seasonal.crowds } : {}),
+    ...(seasonal.notes ? { notes: seasonal.notes } : {}),
+  };
+  const snowFree = keepWindow(seasonal.snow_free_typical);
+  if (snowFree) out.snow_free_typical = snowFree;
+  const larch = keepWindow(seasonal.larch_window);
+  if (larch) out.larch_window = larch;
+  const flowers = keepWindow(seasonal.wildflower_peak);
+  if (flowers) out.wildflower_peak = flowers;
+  const crossings = keepWindow(seasonal.stream_crossing_peak);
+  if (crossings) out.stream_crossing_peak = crossings;
+  return out;
+}
+
+interface SeasonalTimingData {
+  area_id: string;
+  area_name: string;
+  month_filter: number | null;
+  seasonal: Seasonal | null;
+  framing: string;
+}
+
+export function registerSeasonalTimingTools(server: McpServer, env: Env): void {
+  void env;
+  titledTool(
+    server,
+    "get_seasonal_timing",
+    "Checking seasonal windows…",
+    "Curated typical-year timing windows for a registry area: snow_free_typical (melt-out → first persistent snow), larch_window (areas where larches are a real draw: Enchantments, North Cascades, Pasayten), wildflower_peak, bug_pressure by month, stream_crossing_peak (snowmelt high water — pairs with get_river_conditions), and crowds. Windows are MM-DD ranges for a TYPICAL year and swing ±2–3 weeks with snowpack — never present one as a guarantee; cross-check recent trip reports. Optional `month` (1–12) filters to windows active that month or starting within ~6 weeks. Areas without curated data return an explicit empty status. Registry-curated data (low-to-medium confidence) — WTA-fallback areas are not covered.",
+    {
+      area_id: z.string().describe("Registry area id (e.g. 'enchantments')."),
+      month: z
+        .number()
+        .int()
+        .min(1)
+        .max(12)
+        .optional()
+        .describe("Filter to windows active this month or starting within ~6 weeks."),
+    },
+    async ({ area_id, month }) => {
+      const area = findAreaById(area_id);
+      if (!area) {
+        return payloadResponse(
+          empty<SeasonalTimingData>([
+            `Unknown area_id: ${area_id}. Seasonal timing is registry-curated — WTA-fallback areas are not covered; try recent trip reports via get_trip_reports instead.`,
+          ]),
+        );
+      }
+
+      const seasonal = SEASONAL[area_id];
+      const sources = [
+        makeSource(
+          "https://github.com/tusensii/mcp-stack/blob/main/apps/trip-mcp/src/seasonal.ts",
+          "trip-mcp curated seasonal registry (WTA seasonal guidance + guidebook consensus)",
+          { confidence: "low" },
+        ),
+      ];
+
+      if (!seasonal) {
+        const data: SeasonalTimingData = {
+          area_id,
+          area_name: area.name,
+          month_filter: month ?? null,
+          seasonal: null,
+          framing: "no curated seasonal data for this area yet",
+        };
+        return payloadResponse(
+          ok(data, sources, "low", [
+            `No curated seasonal data for ${area_id} yet — an explicit empty status, not an error. Use get_trip_reports for current conditions.`,
+            TYPICAL_YEAR_CAVEAT,
+          ]),
+        );
+      }
+
+      const filtered = typeof month === "number" ? filterByMonth(seasonal, month) : seasonal;
+      const data: SeasonalTimingData = {
+        area_id,
+        area_name: area.name,
+        month_filter: month ?? null,
+        seasonal: filtered,
+        framing: "typical-year windows (curated); confidence medium at best",
+      };
+      return payloadResponse(
+        ok<SeasonalTimingData>(data, sources, "medium", [TYPICAL_YEAR_CAVEAT]) as ToolPayload<SeasonalTimingData>,
+      );
+    },
+  );
+}

--- a/apps/trip-mcp/src/tools/trail_weather_profile.test.ts
+++ b/apps/trip-mcp/src/tools/trail_weather_profile.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { interpolateByMile, sampleIndices } from "./trail_weather_profile.js";
+import {
+  computeGearFlags,
+  etaHourForMile,
+  interpolateByMile,
+  sampleIndices,
+} from "./trail_weather_profile.js";
 
 describe("sampleIndices", () => {
   it("caps at maxSamples with endpoints included", () => {
@@ -30,5 +35,107 @@ describe("interpolateByMile", () => {
   it("returns all nulls when no sample succeeded", () => {
     const out = interpolateByMile([0, 1], [0, 1], [null, null]);
     expect(out).toEqual([null, null]);
+  });
+});
+
+describe("etaHourForMile", () => {
+  it("computes linear arrival hours from start time and pace", () => {
+    expect(etaHourForMile(0, "08:00", 2)).toBeCloseTo(8, 5);
+    expect(etaHourForMile(4, "08:00", 2)).toBeCloseTo(10, 5);
+    expect(etaHourForMile(3, "06:30", 1.5)).toBeCloseTo(8.5, 5);
+  });
+
+  it("clamps past-midnight arrivals to end of day", () => {
+    expect(etaHourForMile(40, "18:00", 2)).toBeCloseTo(23.99, 2);
+  });
+});
+
+describe("computeGearFlags", () => {
+  const sample = (over: Record<string, unknown>) => ({
+    mile: 0,
+    ok: true,
+    dayHours: [],
+    temp_window_mean_f: 50,
+    precip_window_max_pct: 0,
+    precip_window_sum_in: 0,
+    wind_window_max_mph: 5,
+    cloud_window_mean_pct: 80,
+    uv_window_max: 2,
+    freezing_level_window_min_ft: 12000,
+    ...over,
+  });
+  const warmPoints = [
+    { mile: 0, elevation_ft: 2000, temp_f: 55 },
+    { mile: 4, elevation_ft: 5000, temp_f: 48 },
+  ];
+
+  it("returns no flags in benign conditions", () => {
+    const flags = computeGearFlags({
+      points: warmPoints,
+      samples: [sample({})] as never,
+      maxElevationFt: 5000,
+    });
+    expect(flags).toEqual([]);
+  });
+
+  it("escalates rain_shell by precip probability", () => {
+    const rec = computeGearFlags({
+      points: warmPoints,
+      samples: [sample({ precip_window_max_pct: 35 })] as never,
+      maxElevationFt: 5000,
+    });
+    expect(rec.find((f) => f.item === "rain_shell")?.level).toBe("recommended");
+    const strong = computeGearFlags({
+      points: warmPoints,
+      samples: [sample({ precip_window_max_pct: 70 })] as never,
+      maxElevationFt: 5000,
+    });
+    expect(strong.find((f) => f.item === "rain_shell")?.level).toBe("strongly_recommended");
+  });
+
+  it("flags insulation and freezing risk with mile ranges", () => {
+    const flags = computeGearFlags({
+      points: [
+        { mile: 0, elevation_ft: 2000, temp_f: 44 },
+        { mile: 3, elevation_ft: 5000, temp_f: 30 },
+        { mile: 4, elevation_ft: 5200, temp_f: 31 },
+      ],
+      samples: [sample({})] as never,
+      maxElevationFt: 5200,
+    });
+    expect(flags.find((f) => f.item === "insulation")?.level).toBe("strongly_recommended");
+    const freeze = flags.find((f) => f.item === "freezing_risk");
+    expect(freeze?.affected_miles).toEqual([3, 4]);
+  });
+
+  it("flags traction when freezing level dips below route max elevation", () => {
+    const flags = computeGearFlags({
+      points: warmPoints,
+      samples: [sample({ freezing_level_window_min_ft: 4500 })] as never,
+      maxElevationFt: 5000,
+    });
+    expect(flags.some((f) => f.item === "traction")).toBe(true);
+  });
+
+  it("flags sun on clear high-UV days and wind with affected range", () => {
+    const flags = computeGearFlags({
+      points: warmPoints,
+      samples: [
+        sample({ cloud_window_mean_pct: 10, uv_window_max: 8 }),
+        sample({ mile: 4, wind_window_max_mph: 26, cloud_window_mean_pct: 20, uv_window_max: 7 }),
+      ] as never,
+      maxElevationFt: 5000,
+    });
+    expect(flags.some((f) => f.item === "sun_protection")).toBe(true);
+    expect(flags.find((f) => f.item === "wind_shell")?.affected_miles).toEqual([4, 4]);
+  });
+
+  it("returns nothing when no samples resolved", () => {
+    const flags = computeGearFlags({
+      points: warmPoints,
+      samples: [sample({ ok: false })] as never,
+      maxElevationFt: 5000,
+    });
+    expect(flags).toEqual([]);
   });
 });

--- a/apps/trip-mcp/src/tools/trail_weather_profile.ts
+++ b/apps/trip-mcp/src/tools/trail_weather_profile.ts
@@ -1,17 +1,21 @@
 /**
  * get_trail_weather_profile: one chart-ready series merging mileage,
- * elevation, temperature, and precipitation along a trail.
+ * elevation, temperature, and precipitation along a trail — plus, on
+ * request, a time axis (hourly conditions per sample point), ETA-based
+ * evaluation ("what will it feel like when I'm actually there"), and
+ * rule-based gear flags.
  *
  * Pipeline: resolve polyline (same inputs as get_elevation_profile) →
  * resample → one Open-Meteo elevation batch → ≤5 elevation-corrected
  * weather samples along the route (parallel, one day window each) →
- * interpolate temperature between samples per profile point.
+ * interpolate temperature between samples.
  *
  * Honesty contract (carried from doing this by hand): precipitation does
- * NOT vary meaningfully in the source model at trail scale, and the
- * temperature correction is a model adjustment, not a mountain-station
- * observation. Per-field provenance is part of the payload so downstream
- * consumers label charts accordingly.
+ * NOT vary meaningfully in the source model at trail scale, the
+ * temperature correction is a model adjustment (not a mountain-station
+ * observation), and gear flags are deterministic heuristics — the
+ * consuming LLM narrates; this tool never freeforms advice. Per-field
+ * provenance is part of the payload.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -22,6 +26,7 @@ import {
   OPEN_METEO_ATTRIBUTION,
   getElevationsMeters,
   getPointForecast,
+  type OpenMeteoHourly,
 } from "../sources/openmeteo.js";
 import { resamplePolyline } from "../polyline.js";
 import { payloadResponse, titledTool } from "./utils.js";
@@ -31,11 +36,38 @@ import { buildProfileEntries, profileStats } from "./elevation_profile.js";
 const MAX_WEATHER_SAMPLES = 5;
 const PROFILE_POINTS = 50;
 
+const GEAR_DISCLAIMER =
+  "Gear flags are model-derived heuristics from forecast data — not a substitute for judgment, current conditions, or ranger information. get_safety_brief remains the authority for safety gear.";
+
 interface TrailWeatherPoint {
   mile: number;
   elevation_ft: number | null;
   temp_f: number | null;
   precip_pct: number | null;
+  /** Present in ETA mode: estimated arrival clock time (HH:MM local). */
+  eta?: string;
+}
+
+export interface TimeSeriesHour {
+  time_iso: string;
+  temp_f: number | null;
+  precip_pct: number | null;
+  precip_in: number | null;
+  wind_mph: number | null;
+  freezing_level_ft: number | null;
+}
+
+interface SampleTimeSeries {
+  mile: number;
+  hours: TimeSeriesHour[];
+}
+
+export interface GearFlag {
+  item: string;
+  level: "consider" | "recommended" | "strongly_recommended";
+  reason: string;
+  /** Mile range affected, or null when route-wide. */
+  affected_miles: [number, number] | null;
 }
 
 interface TrailWeatherData {
@@ -44,7 +76,12 @@ interface TrailWeatherData {
   matched_name?: string;
   date: string;
   window: { start_hour: number; end_hour: number };
+  /** How temp_f/precip_pct in `series` were evaluated. */
+  evaluation: "window_mean" | "eta";
+  eta_params?: { start_time: string; pace_mph: number };
   series: TrailWeatherPoint[];
+  time_series?: SampleTimeSeries[];
+  gear_flags?: { flags: GearFlag[]; disclaimer: string };
   summary: {
     total_distance_mi: number;
     total_gain_ft: number | null;
@@ -59,6 +96,7 @@ interface TrailWeatherData {
     elevation: string;
     temp: string;
     precip: string;
+    gear_flags?: string;
   };
 }
 
@@ -106,8 +144,55 @@ export function interpolateByMile(
   });
 }
 
-function round1(n: number): number {
-  return Math.round(n * 10) / 10;
+/**
+ * Estimated arrival hour (fractional, 24h clock) for a route point.
+ * Linear pace; clamped to 23.99 with the clamp reported by callers.
+ */
+export function etaHourForMile(mile: number, startTime: string, paceMph: number): number {
+  const [hh, mm] = startTime.split(":");
+  const startHours = Number.parseInt(hh ?? "8", 10) + Number.parseInt(mm ?? "0", 10) / 60;
+  return Math.min(startHours + mile / Math.max(paceMph, 0.1), 23.99);
+}
+
+function fmtClock(hourFloat: number): string {
+  const h = Math.floor(hourFloat);
+  const m = Math.round((hourFloat - h) * 60);
+  return `${String(h).padStart(2, "0")}:${String(m % 60).padStart(2, "0")}`;
+}
+
+function hourOf(h: OpenMeteoHourly): number {
+  return Number.parseInt(h.time.slice(11, 13), 10);
+}
+
+interface SampleData {
+  mile: number;
+  ok: boolean;
+  error?: string;
+  /** Hourly entries for the requested date (whole day). */
+  dayHours: OpenMeteoHourly[];
+  /** Window aggregates (static mode). */
+  temp_window_mean_f: number | null;
+  precip_window_max_pct: number | null;
+  precip_window_sum_in: number | null;
+  wind_window_max_mph: number | null;
+  cloud_window_mean_pct: number | null;
+  uv_window_max: number | null;
+  freezing_level_window_min_ft: number | null;
+}
+
+/** Nearest-hour lookup within a sample's day. */
+function sampleAtHour(s: SampleData, hourFloat: number): OpenMeteoHourly | null {
+  if (s.dayHours.length === 0) return null;
+  let best: OpenMeteoHourly | null = null;
+  let bestDist = Infinity;
+  for (const h of s.dayHours) {
+    const d = Math.abs(hourOf(h) - hourFloat);
+    if (d < bestDist) {
+      bestDist = d;
+      best = h;
+    }
+  }
+  return best;
 }
 
 function mean(values: number[]): number | null {
@@ -115,12 +200,136 @@ function mean(values: number[]): number | null {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
 
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function mileRange(miles: number[]): [number, number] | null {
+  if (miles.length === 0) return null;
+  return [Math.min(...miles), Math.max(...miles)];
+}
+
+/**
+ * Rule-based gear flags. Thresholds (documented in the tool description):
+ * rain_shell ≥30% precip prob or >0.01 in (strongly ≥60%); insulation
+ * route min ≤45°F (strongly ≤35°F); freezing_risk any point ≤32°F;
+ * traction freezing level below route max elevation; sun mean cloud <30%
+ * and UV ≥6; wind max ≥20 mph.
+ */
+export function computeGearFlags(input: {
+  points: Array<{ mile: number; elevation_ft: number | null; temp_f: number | null }>;
+  samples: SampleData[];
+  maxElevationFt: number | null;
+}): GearFlag[] {
+  const flags: GearFlag[] = [];
+  const okSamples = input.samples.filter((s) => s.ok);
+  if (okSamples.length === 0) return flags;
+
+  const maxPrecipPct = Math.max(
+    ...okSamples.map((s) => s.precip_window_max_pct ?? -1).filter((v) => v >= 0),
+    -1,
+  );
+  const anyPrecipIn = okSamples.some((s) => (s.precip_window_sum_in ?? 0) > 0.01);
+  if (maxPrecipPct >= 60) {
+    flags.push({
+      item: "rain_shell",
+      level: "strongly_recommended",
+      reason: `max precipitation probability ${Math.round(maxPrecipPct)}% in window`,
+      affected_miles: null,
+    });
+  } else if (maxPrecipPct >= 30 || anyPrecipIn) {
+    flags.push({
+      item: "rain_shell",
+      level: "recommended",
+      reason: anyPrecipIn
+        ? "measurable precipitation forecast in window"
+        : `max precipitation probability ${Math.round(maxPrecipPct)}% in window`,
+      affected_miles: null,
+    });
+  }
+
+  const temps = input.points.map((p) => p.temp_f).filter((v): v is number => v !== null);
+  if (temps.length > 0) {
+    const minTemp = Math.min(...temps);
+    if (minTemp <= 35) {
+      flags.push({
+        item: "insulation",
+        level: "strongly_recommended",
+        reason: `route minimum temperature ${round1(minTemp)}°F`,
+        affected_miles: null,
+      });
+    } else if (minTemp <= 45) {
+      flags.push({
+        item: "insulation",
+        level: "recommended",
+        reason: `route minimum temperature ${round1(minTemp)}°F`,
+        affected_miles: null,
+      });
+    }
+    const freezingMiles = input.points
+      .filter((p) => p.temp_f !== null && p.temp_f <= 32)
+      .map((p) => p.mile);
+    if (freezingMiles.length > 0) {
+      flags.push({
+        item: "freezing_risk",
+        level: "strongly_recommended",
+        reason: "modeled temperature at or below 32°F at evaluation time",
+        affected_miles: mileRange(freezingMiles),
+      });
+    }
+  }
+
+  if (input.maxElevationFt !== null) {
+    const minFreezing = okSamples
+      .map((s) => s.freezing_level_window_min_ft)
+      .filter((v): v is number => v !== null);
+    if (minFreezing.length > 0 && Math.min(...minFreezing) < input.maxElevationFt) {
+      flags.push({
+        item: "traction",
+        level: "consider",
+        reason: `freezing level (${Math.round(Math.min(...minFreezing))} ft) drops below route max elevation (${Math.round(input.maxElevationFt)} ft) — snow/ice possible at elevation`,
+        affected_miles: null,
+      });
+    }
+  }
+
+  const cloudMeans = okSamples
+    .map((s) => s.cloud_window_mean_pct)
+    .filter((v): v is number => v !== null);
+  const uvMaxes = okSamples.map((s) => s.uv_window_max).filter((v): v is number => v !== null);
+  if (
+    cloudMeans.length > 0 &&
+    (mean(cloudMeans) ?? 100) < 30 &&
+    uvMaxes.length > 0 &&
+    Math.max(...uvMaxes) >= 6
+  ) {
+    flags.push({
+      item: "sun_protection",
+      level: "recommended",
+      reason: `mostly clear (mean cloud cover ${Math.round(mean(cloudMeans)!)}%) with UV index up to ${round1(Math.max(...uvMaxes))}`,
+      affected_miles: null,
+    });
+  }
+
+  const windySamples = okSamples.filter((s) => (s.wind_window_max_mph ?? 0) >= 20);
+  if (windySamples.length > 0) {
+    flags.push({
+      item: "wind_shell",
+      level: "recommended",
+      reason: `max wind ${Math.round(Math.max(...windySamples.map((s) => s.wind_window_max_mph!)))} mph in window`,
+      affected_miles: mileRange(windySamples.map((s) => s.mile)),
+    });
+  }
+
+  return flags;
+}
+
 export function registerTrailWeatherProfileTools(server: McpServer, env: Env): void {
   titledTool(
     server,
     "get_trail_weather_profile",
     "Modeling weather along the trail…",
-    "One merged, chart-ready series along a trail: {mile, elevation_ft, temp_f, precip_pct}[] — built for \"graph mileage, elevation, temperature and rain in one visual\" asks. Accepts the same polyline inputs as get_elevation_profile (`points` > `osm_id` > `trail_name`+lat/lon), plus optional `date` (YYYY-MM-DD, default today Pacific, up to ~16 days out) and an hour window (default 8–18). Internally: elevation from one Open-Meteo DEM batch, then at most 5 elevation-corrected weather samples along the route, temperatures interpolated between samples. READ THE PROVENANCE LABELS before charting: elevation is DEM-sampled (90 m Copernicus GLO-90); temp_f is a model elevation-correction (Open-Meteo hypsometric adjustment), not a mountain-station observation; precip_pct is GRID-SCALE — it does not vary meaningfully at trail scale, so never imply per-point precipitation precision. Partial failure degrades per-field: series returns with null temp/precip (or null elevation) and a named caveat.",
+    "One merged, chart-ready series along a trail: {mile, elevation_ft, temp_f, precip_pct}[] — built for \"graph mileage, elevation, temperature and rain in one visual\" asks. Accepts the same polyline inputs as get_elevation_profile (`points` > `osm_id` > `trail_name`+lat/lon), plus optional `date` (YYYY-MM-DD, default today Pacific, up to ~16 days out) and an hour window (default 8–18). MODES: (1) default — temp_f is the window mean at each point; (2) `eta_mode: true` with optional `start_time` (default 08:00) and `pace_mph` (default 2, linear) — each point is evaluated at its ESTIMATED ARRIVAL TIME, the answer to \"what will it feel like when I'm actually there\", with per-point `eta` clock times; (3) `time_series: true` — adds per-sample hourly arrays {time_iso, temp_f, precip_pct, precip_in, wind_mph, freezing_level_ft} (≤5 samples × ≤24 h, optionally filtered by `hours: [8,12,16]`) for mile×time charting from ONE call. GEAR FLAGS: a rule-based `gear_flags` block (thresholds: rain_shell ≥30% precip prob or >0.01 in, strongly ≥60%; insulation route-min ≤45°F, strongly ≤35°F; freezing_risk any point ≤32°F with mile range; traction when freezing level < route max elevation; sun_protection mean cloud <30% and UV ≥6; wind_shell ≥20 mph) — heuristics for the consuming LLM to narrate, never safety authority (that's get_safety_brief). READ THE PROVENANCE LABELS before charting: elevation is DEM-sampled (90 m); temp_f is a model elevation-correction, not a station observation; precip_pct is GRID-SCALE — never imply per-point precipitation precision. Partial failure degrades per-field with named caveats.",
     {
       ...profileInputSchema,
       date: z
@@ -130,12 +339,37 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
         .describe("Forecast date YYYY-MM-DD (default: today, America/Los_Angeles)."),
       start_hour: z.number().int().min(0).max(23).default(8).describe("Window start hour, local (default 8)."),
       end_hour: z.number().int().min(1).max(24).default(18).describe("Window end hour, local, exclusive (default 18)."),
+      eta_mode: z
+        .boolean()
+        .default(false)
+        .describe("Evaluate each point at its estimated arrival time (start_time + mile/pace_mph) instead of the window mean."),
+      start_time: z
+        .string()
+        .regex(/^\d{2}:\d{2}$/)
+        .optional()
+        .describe("ETA mode: departure clock time HH:MM local (default 08:00)."),
+      pace_mph: z
+        .number()
+        .min(0.5)
+        .max(6)
+        .default(2)
+        .describe("ETA mode: linear pace in mph (default 2; no uphill adjustment — pick a conservative value)."),
+      time_series: z
+        .boolean()
+        .default(false)
+        .describe("Include per-sample hourly arrays for the date (≤5 samples × ≤24 h)."),
+      hours: z
+        .array(z.number().int().min(0).max(23))
+        .max(24)
+        .optional()
+        .describe("time_series: restrict hourly arrays to these hours (default: all 24)."),
     },
     async (args) => {
       const date = args.date ?? todayInPacific();
       if (args.end_hour <= args.start_hour) {
         return payloadResponse(empty<TrailWeatherData>(["end_hour must be after start_hour."]));
       }
+      const startTime = args.start_time ?? "08:00";
 
       const resolved = await resolvePolyline(env, args);
       if ("error" in resolved) {
@@ -171,10 +405,22 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
       // ≤5 weather samples along the route, fetched in parallel for the
       // one-day window; each is elevation-corrected when a DEM value exists.
       const indices = sampleIndices(profile.length, MAX_WEATHER_SAMPLES);
-      const sampleResults = await Promise.all(
-        indices.map(async (idx) => {
+      const samples: SampleData[] = await Promise.all(
+        indices.map(async (idx): Promise<SampleData> => {
           const p = sampled[idx]!;
           const elevM = elevationsM[idx];
+          const base: SampleData = {
+            mile: profile[idx]!.mile,
+            ok: false,
+            dayHours: [],
+            temp_window_mean_f: null,
+            precip_window_max_pct: null,
+            precip_window_sum_in: null,
+            wind_window_max_mph: null,
+            cloud_window_mean_pct: null,
+            uv_window_max: null,
+            freezing_level_window_min_ft: null,
+          };
           try {
             const fc = await getPointForecast(env, {
               lat: p.lat,
@@ -183,70 +429,100 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
               startDate: date,
               endDate: date,
             });
-            const windowHours = fc.hourly.filter((h) => {
-              if (!h.time.startsWith(date)) return false;
-              const hour = Number.parseInt(h.time.slice(11, 13), 10);
+            const dayHours = fc.hourly.filter((h) => h.time.startsWith(date));
+            const windowHours = dayHours.filter((h) => {
+              const hour = hourOf(h);
               return hour >= args.start_hour && hour < args.end_hour;
             });
-            const temps = windowHours
-              .map((h) => h.temp_f)
-              .filter((v): v is number => v !== null);
-            const precips = windowHours
-              .map((h) => h.precip_probability_pct)
-              .filter((v): v is number => v !== null);
+            const nums = (get: (h: OpenMeteoHourly) => number | null) =>
+              windowHours.map(get).filter((v): v is number => v !== null);
+            const temps = nums((h) => h.temp_f);
+            const precipPcts = nums((h) => h.precip_probability_pct);
+            const precipIns = nums((h) => h.precip_in);
+            const winds = nums((h) => h.wind_speed_mph);
+            const clouds = nums((h) => h.cloud_cover_pct);
+            const uvs = nums((h) => h.uv_index);
+            const freezing = nums((h) => h.freezing_level_ft);
             return {
-              mile: profile[idx]!.mile,
-              temp_f: mean(temps),
-              precip_pct: precips.length > 0 ? Math.max(...precips) : null,
+              ...base,
               ok: true,
+              dayHours,
+              temp_window_mean_f: mean(temps),
+              precip_window_max_pct: precipPcts.length > 0 ? Math.max(...precipPcts) : null,
+              precip_window_sum_in:
+                precipIns.length > 0 ? precipIns.reduce((a, b) => a + b, 0) : null,
+              wind_window_max_mph: winds.length > 0 ? Math.max(...winds) : null,
+              cloud_window_mean_pct: mean(clouds),
+              uv_window_max: uvs.length > 0 ? Math.max(...uvs) : null,
+              freezing_level_window_min_ft: freezing.length > 0 ? Math.min(...freezing) : null,
             };
           } catch (e) {
-            return {
-              mile: profile[idx]!.mile,
-              temp_f: null,
-              precip_pct: null,
-              ok: false,
-              error: e instanceof Error ? e.message : String(e),
-            };
+            return { ...base, error: e instanceof Error ? e.message : String(e) };
           }
         }),
       );
 
-      const failed = sampleResults.filter((r) => !r.ok);
-      if (failed.length === sampleResults.length) {
+      const failed = samples.filter((s) => !s.ok);
+      if (failed.length === samples.length) {
         caveats.push(
-          `open_meteo_forecast: all ${sampleResults.length} weather samples failed (${failed[0] && "error" in failed[0] ? failed[0].error : "unknown"}) — temp_f/precip_pct are null.`,
+          `open_meteo_forecast: all ${samples.length} weather samples failed (${failed[0]?.error ?? "unknown"}) — temp_f/precip_pct are null.`,
         );
       } else if (failed.length > 0) {
         caveats.push(
-          `open_meteo_forecast: ${failed.length}/${sampleResults.length} weather samples failed; temperatures interpolated from the remaining samples.`,
+          `open_meteo_forecast: ${failed.length}/${samples.length} weather samples failed; temperatures interpolated from the remaining samples.`,
         );
       }
-      if (sampleResults.some((r) => r.ok && r.temp_f === null)) {
+      if (samples.some((s) => s.ok && s.dayHours.length === 0)) {
         caveats.push(
-          `No forecast hours in the ${args.start_hour}:00–${args.end_hour}:00 window for ${date} — date may be out of the ~16-day forecast range.`,
+          `No forecast hours for ${date} — date may be out of the ~16-day forecast range.`,
         );
       }
 
       const miles = profile.map((p) => p.mile);
-      const temps = interpolateByMile(
-        miles,
-        sampleResults.map((r) => r.mile),
-        sampleResults.map((r) => r.temp_f),
-      );
-      const precipSampleValues = sampleResults.map((r) => r.precip_pct);
-      const maxPrecip = precipSampleValues.filter((v): v is number => v !== null);
+      let temps: Array<number | null>;
+      let etas: string[] | null = null;
+      if (args.eta_mode) {
+        // Evaluate bracketing samples at each point's arrival hour, then
+        // interpolate by mile between those time-specific values.
+        etas = miles.map((m) => fmtClock(etaHourForMile(m, startTime, args.pace_mph)));
+        temps = miles.map((m) => {
+          const hour = etaHourForMile(m, startTime, args.pace_mph);
+          const values = samples.map((s) => {
+            const h = s.ok ? sampleAtHour(s, hour) : null;
+            return h ? h.temp_f : null;
+          });
+          const interp = interpolateByMile(
+            [m],
+            samples.map((s) => s.mile),
+            values,
+          );
+          return interp[0] ?? null;
+        });
+        const lastEta = etaHourForMile(miles[miles.length - 1] ?? 0, startTime, args.pace_mph);
+        if (lastEta >= 23.98) {
+          caveats.push(
+            "ETA evaluation clamped at end of day (23:59) — route end arrival passes midnight at the given pace; conditions past midnight are not evaluated.",
+          );
+        }
+      } else {
+        temps = interpolateByMile(
+          miles,
+          samples.map((s) => s.mile),
+          samples.map((s) => s.temp_window_mean_f),
+        );
+      }
+
       // Precip is grid-scale: apply the nearest sample's value rather than
       // pretending it varies per point.
       const precips = miles.map((m) => {
         let nearest: number | null = null;
         let nearestDist = Infinity;
-        for (const r of sampleResults) {
-          if (r.precip_pct === null) continue;
-          const d = Math.abs(r.mile - m);
+        for (const s of samples) {
+          if (s.precip_window_max_pct === null) continue;
+          const d = Math.abs(s.mile - m);
           if (d < nearestDist) {
             nearestDist = d;
-            nearest = r.precip_pct;
+            nearest = s.precip_window_max_pct;
           }
         }
         return nearest;
@@ -257,7 +533,30 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
         elevation_ft: p.elevation_ft,
         temp_f: temps[i] ?? null,
         precip_pct: precips[i] ?? null,
+        ...(etas ? { eta: etas[i]! } : {}),
       }));
+
+      // Optional time-series block: per-sample hourly arrays, bounded.
+      let timeSeries: SampleTimeSeries[] | undefined;
+      if (args.time_series) {
+        const hourFilter = args.hours ? new Set(args.hours) : null;
+        timeSeries = samples
+          .filter((s) => s.ok)
+          .map((s) => ({
+            mile: s.mile,
+            hours: s.dayHours
+              .filter((h) => !hourFilter || hourFilter.has(hourOf(h)))
+              .slice(0, 24)
+              .map((h) => ({
+                time_iso: h.time,
+                temp_f: h.temp_f,
+                precip_pct: h.precip_probability_pct,
+                precip_in: h.precip_in,
+                wind_mph: h.wind_speed_mph,
+                freezing_level_ft: h.freezing_level_ft,
+              })),
+          }));
+      }
 
       sources.push(
         makeSource("https://open-meteo.com/en/docs", OPEN_METEO_ATTRIBUTION, {
@@ -267,14 +566,42 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
       );
 
       const validTemps = temps.filter((v): v is number => v !== null);
+      const weatherResolved = samples.some((s) => s.ok) && validTemps.length > 0;
+
+      // Gear flags only when weather data actually resolved.
+      let gearFlags: { flags: GearFlag[]; disclaimer: string } | undefined;
+      if (weatherResolved) {
+        gearFlags = {
+          flags: computeGearFlags({
+            points: profile.map((p, i) => ({
+              mile: p.mile,
+              elevation_ft: p.elevation_ft,
+              temp_f: temps[i] ?? null,
+            })),
+            samples,
+            maxElevationFt: stats.max_elevation_ft,
+          }),
+          disclaimer: GEAR_DISCLAIMER,
+        };
+      } else {
+        caveats.push("gear_flags omitted — weather data did not resolve.");
+      }
+
       const lastPoint = profile[profile.length - 1];
+      const maxPrecip = samples
+        .map((s) => s.precip_window_max_pct)
+        .filter((v): v is number => v !== null);
       const data: TrailWeatherData = {
         resolved_from: resolved.resolved_from,
         ...(resolved.osm_id ? { osm_id: resolved.osm_id } : {}),
         ...(resolved.matched_name ? { matched_name: resolved.matched_name } : {}),
         date,
         window: { start_hour: args.start_hour, end_hour: args.end_hour },
+        evaluation: args.eta_mode ? "eta" : "window_mean",
+        ...(args.eta_mode ? { eta_params: { start_time: startTime, pace_mph: args.pace_mph } } : {}),
         series,
+        ...(timeSeries ? { time_series: timeSeries } : {}),
+        ...(gearFlags ? { gear_flags: gearFlags } : {}),
         summary: {
           total_distance_mi: lastPoint ? lastPoint.mile : 0,
           total_gain_ft: stats.total_gain_ft,
@@ -288,13 +615,16 @@ export function registerTrailWeatherProfileTools(server: McpServer, env: Env): v
         },
         provenance: {
           elevation: "DEM-sampled (Copernicus GLO-90, 90 m resolution)",
-          temp: "model elevation-corrected (Open-Meteo hypsometric adjustment) — not a station observation",
+          temp: args.eta_mode
+            ? "model elevation-corrected (Open-Meteo), evaluated at estimated arrival time — not a station observation"
+            : "model elevation-corrected (Open-Meteo hypsometric adjustment) — not a station observation",
           precip: "grid-scale — weakest field; does not vary meaningfully at trail scale",
+          ...(gearFlags ? { gear_flags: "rule-based heuristic over forecast fields" } : {}),
         },
       };
 
       const confidence: Confidence =
-        validTemps.length > 0 && stats.min_elevation_ft !== null ? "medium" : "low";
+        weatherResolved && stats.min_elevation_ft !== null ? "medium" : "low";
       const payload: ToolPayload<TrailWeatherData> = ok(data, sources, confidence, caveats);
       return payloadResponse(payload);
     },

--- a/apps/trip-mcp/src/tools/trip_reports.ts
+++ b/apps/trip-mcp/src/tools/trip_reports.ts
@@ -9,8 +9,23 @@ import { z } from "zod";
 import type { Env } from "../types.js";
 import { empty, makeSource, ok } from "../types.js";
 import { findAreaById } from "../areas.js";
-import { searchTripReports, type TripReportSummary } from "../sources/wta.js";
+import { getTripReport, searchTripReports, type TripReportSummary } from "../sources/wta.js";
+import {
+  extractConditions,
+  rollupConditions,
+  type ExtractedConditions,
+  type ReportExtraction,
+} from "../extraction.js";
 import { payloadResponse, titledTool } from "./utils.js";
+
+/** Detail pages fetched per call in extraction mode (throttled scrape). */
+const DETAIL_FETCH_LIMIT = 5;
+
+interface ReportWithConditions extends TripReportSummary {
+  conditions?: ExtractedConditions;
+  /** "detail" = full report page + WTA conditions table; "blurb" = listing snippet only. */
+  extraction_source?: "detail" | "blurb";
+}
 
 const argsShape = {
   area_id: z
@@ -39,6 +54,12 @@ const argsShape = {
     .max(50)
     .optional()
     .describe("Max reports to return. Default 15."),
+  extract_conditions: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Attach a structured conditions block (snow/snow line, blowdowns, road, bugs, water, crowding) per report plus a cross-report rollup. Heuristic keyword extraction (low confidence) — absent fields are null, never inferred. Fetches up to 5 full report pages (slower on cold cache).",
+    ),
 };
 
 export function registerTripReportTools(server: McpServer, env: Env): void {
@@ -48,7 +69,7 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
     "Reading recent trip reports…",
     "Returns recent Washington Trails Association (WTA) trip reports for a PNW area or trail. Trip reports are user-submitted observations of actual conditions (snow level, water sources, blowdowns, road status, bug pressure) and are the single best source of recent ground-truth for WA hikes — better than AllTrails for this use case. Scraped from wta.org with attribution; cache may be up to 24h stale (medium confidence). Use `area_id` from `find_areas` when available; if no reports come back for the area name, the orchestrator will retry with the most distinctive alias (e.g., \"Image Lake\" instead of \"Glacier Peak Wilderness\"). PNW only — for non-WA trips this tool will return empty; fall back to `web_research`. If a report mentions a road closure, blowdown, or condition that contradicts an official source (e.g., USFS says trail open, report says blocked), surface BOTH to the user and recommend they call the ranger station to resolve.",
     argsShape,
-    async ({ area_id, area_name, trail_name, since_days, limit }) => {
+    async ({ area_id, area_name, trail_name, since_days, limit, extract_conditions }) => {
       const sinceDays = since_days ?? 60;
       const max = limit ?? 15;
 
@@ -102,15 +123,67 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
         );
       }
 
+      const caveats = [
+        "WTA data is scraped (no SLA); fields may be missing if site markup changed.",
+        "Reports without a parseable hike date are kept in results.",
+      ];
+
+      if (!extract_conditions) {
+        return payloadResponse(
+          ok({ reports: filtered, query_used: query }, [source], "medium", caveats),
+        );
+      }
+
+      // Extraction mode: fetch full pages for the first few reports (the
+      // WTA conditions table + body are far higher-signal than the
+      // listing blurb); the rest extract from title+blurb only.
+      const withConditions: ReportWithConditions[] = await Promise.all(
+        filtered.map(async (r, i): Promise<ReportWithConditions> => {
+          let text = [r.title, r.conditions_blurb].filter(Boolean).join("\n");
+          let extractionSource: "detail" | "blurb" = "blurb";
+          if (i < DETAIL_FETCH_LIMIT) {
+            try {
+              const detail = await getTripReport(env, r.url);
+              if (detail) {
+                extractionSource = "detail";
+                const condTable = Object.entries(detail.conditions)
+                  .map(([k, v]) => `${k}: ${v}`)
+                  .join("\n");
+                text = [r.title, condTable, detail.body, r.conditions_blurb]
+                  .filter(Boolean)
+                  .join("\n");
+              }
+            } catch {
+              // fall back to blurb extraction
+            }
+          }
+          return { ...r, conditions: extractConditions(text), extraction_source: extractionSource };
+        }),
+      );
+
+      const extractions: ReportExtraction[] = withConditions.map((r) => ({
+        url: r.url,
+        title: r.title,
+        date_hiked: r.date_hiked,
+        conditions: r.conditions!,
+      }));
+
+      caveats.push(
+        "Condition extraction is heuristic keyword matching (low confidence): absent fields mean the report didn't clearly mention them, not that conditions are absent. Read the cited reports before relying on a specific claim.",
+        `Full-page extraction covers the first ${Math.min(DETAIL_FETCH_LIMIT, withConditions.length)} reports; the rest are extracted from listing blurbs only (see per-report extraction_source).`,
+      );
+
       return payloadResponse(
         ok(
-          { reports: filtered, query_used: query },
+          {
+            reports: withConditions,
+            query_used: query,
+            conditions_rollup: rollupConditions(extractions),
+            extraction: { method: "heuristic", confidence: "low" as const },
+          },
           [source],
           "medium",
-          [
-            "WTA data is scraped (no SLA); fields may be missing if site markup changed.",
-            "Reports without a parseable hike date are kept in results.",
-          ],
+          caveats,
         ),
       );
     },

--- a/apps/trip-mcp/src/tools/trip_reports.ts
+++ b/apps/trip-mcp/src/tools/trip_reports.ts
@@ -10,6 +10,8 @@ import type { Env } from "../types.js";
 import { empty, makeSource, ok } from "../types.js";
 import { findAreaById } from "../areas.js";
 import { getTripReport, searchTripReports, type TripReportSummary } from "../sources/wta.js";
+import { searchRedditReports } from "../sources/reddit.js";
+import { searchNwhikersReports } from "../sources/nwhikers.js";
 import {
   extractConditions,
   rollupConditions,
@@ -20,8 +22,13 @@ import { payloadResponse, titledTool } from "./utils.js";
 
 /** Detail pages fetched per call in extraction mode (throttled scrape). */
 const DETAIL_FETCH_LIMIT = 5;
+/** Cap per secondary source — lower-signal than WTA by design. */
+const SECONDARY_SOURCE_CAP = 5;
 
-interface ReportWithConditions extends TripReportSummary {
+type ReportSource = "wta" | "nwhikers" | "reddit";
+
+interface MergedReport extends TripReportSummary {
+  source: ReportSource;
   conditions?: ExtractedConditions;
   /** "detail" = full report page + WTA conditions table; "blurb" = listing snippet only. */
   extraction_source?: "detail" | "blurb";
@@ -60,6 +67,12 @@ const argsShape = {
     .describe(
       "Attach a structured conditions block (snow/snow line, blowdowns, road, bugs, water, crowding) per report plus a cross-report rollup. Heuristic keyword extraction (low confidence) — absent fields are null, never inferred. Fetches up to 5 full report pages (slower on cold cache).",
     ),
+  include_secondary_sources: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Also query NWHikers and Reddit (r/WashingtonHikers, r/PNWhiking) as lower-signal secondary sources — capped at 5 each, ranked after WTA, labeled per-report via `source`. Both are best-effort: either may be unreachable from server-side clients (named caveat when so).",
+    ),
 };
 
 export function registerTripReportTools(server: McpServer, env: Env): void {
@@ -69,7 +82,15 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
     "Reading recent trip reports…",
     "Returns recent Washington Trails Association (WTA) trip reports for a PNW area or trail. Trip reports are user-submitted observations of actual conditions (snow level, water sources, blowdowns, road status, bug pressure) and are the single best source of recent ground-truth for WA hikes — better than AllTrails for this use case. Scraped from wta.org with attribution; cache may be up to 24h stale (medium confidence). Use `area_id` from `find_areas` when available; if no reports come back for the area name, the orchestrator will retry with the most distinctive alias (e.g., \"Image Lake\" instead of \"Glacier Peak Wilderness\"). PNW only — for non-WA trips this tool will return empty; fall back to `web_research`. If a report mentions a road closure, blowdown, or condition that contradicts an official source (e.g., USFS says trail open, report says blocked), surface BOTH to the user and recommend they call the ranger station to resolve.",
     argsShape,
-    async ({ area_id, area_name, trail_name, since_days, limit, extract_conditions }) => {
+    async ({
+      area_id,
+      area_name,
+      trail_name,
+      since_days,
+      limit,
+      extract_conditions,
+      include_secondary_sources,
+    }) => {
       const sinceDays = since_days ?? 60;
       const max = limit ?? 15;
 
@@ -97,28 +118,87 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
         );
       }
 
-      const source = makeSource("https://wta.org", "Washington Trails Association", {
-        license: "Washington Trails Association — content used with attribution",
-        confidence: "medium",
-      });
+      const sources = [
+        makeSource("https://wta.org", "Washington Trails Association", {
+          license: "Washington Trails Association — content used with attribution",
+          confidence: "medium",
+        }),
+      ];
+      const secondaryCaveats: string[] = [];
 
-      const reports = await searchTripReports(env, query, max);
+      const [wtaReports, redditRes, nwhikersRes] = await Promise.all([
+        searchTripReports(env, query, max),
+        include_secondary_sources
+          ? searchRedditReports(env, query, SECONDARY_SOURCE_CAP)
+          : Promise.resolve({ reports: [], errors: [] }),
+        include_secondary_sources
+          ? searchNwhikersReports(env, query, SECONDARY_SOURCE_CAP)
+          : Promise.resolve({ reports: [], errors: [] }),
+      ]);
+      secondaryCaveats.push(...redditRes.errors, ...nwhikersRes.errors);
 
-      // Filter by since_days when we have a parseable date_hiked.
+      // Filter by since_days when we have a parseable date.
       const cutoffMs = Date.now() - sinceDays * 86_400_000;
-      const filtered = reports.filter((r) => {
-        if (!r.date_hiked) return true; // keep undated rather than drop silently
-        const t = Date.parse(r.date_hiked);
+      const withinWindow = (dateStr: string | null) => {
+        if (!dateStr) return true; // keep undated rather than drop silently
+        const t = Date.parse(dateStr);
         return Number.isNaN(t) ? true : t >= cutoffMs;
-      });
+      };
+
+      // WTA always ranks first; secondary sources are capped and labeled.
+      const filtered: MergedReport[] = wtaReports
+        .filter((r) => withinWindow(r.date_hiked))
+        .map((r) => ({ ...r, source: "wta" as const }));
+      if (include_secondary_sources) {
+        for (const r of nwhikersRes.reports.filter((n) => withinWindow(n.date_posted))) {
+          filtered.push({
+            source: "nwhikers",
+            title: r.title,
+            url: r.url,
+            author: null,
+            hike_name: null,
+            date_hiked: r.date_posted,
+            conditions_blurb: null,
+          });
+        }
+        for (const r of redditRes.reports.filter((p) => withinWindow(p.date_posted))) {
+          filtered.push({
+            source: "reddit",
+            title: `[r/${r.subreddit}] ${r.title}`,
+            url: r.url,
+            author: r.author,
+            hike_name: null,
+            date_hiked: r.date_posted,
+            conditions_blurb: r.blurb,
+          });
+        }
+        if (nwhikersRes.reports.length > 0) {
+          sources.push(
+            makeSource("https://www.nwhikers.net/forums/", "NWHikers.net forums", {
+              license: "NWHikers.net — content used with attribution",
+              confidence: "low",
+            }),
+          );
+        }
+        if (redditRes.reports.length > 0) {
+          sources.push(
+            makeSource(
+              "https://www.reddit.com/r/WashingtonHikers/",
+              "Reddit (r/WashingtonHikers, r/PNWhiking)",
+              { license: "user-generated content, linked with attribution", confidence: "low" },
+            ),
+          );
+        }
+      }
 
       if (filtered.length === 0) {
         return payloadResponse(
-          empty<{ reports: TripReportSummary[]; query_used: string }>(
+          empty<{ reports: MergedReport[]; query_used: string }>(
             [
               `No PNW trip reports found in the last ${sinceDays} days for this query — try a broader area or check WTA directly`,
+              ...secondaryCaveats,
             ],
-            [source],
+            sources,
           ),
         );
       }
@@ -126,22 +206,30 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
       const caveats = [
         "WTA data is scraped (no SLA); fields may be missing if site markup changed.",
         "Reports without a parseable hike date are kept in results.",
+        ...secondaryCaveats,
       ];
-
-      if (!extract_conditions) {
-        return payloadResponse(
-          ok({ reports: filtered, query_used: query }, [source], "medium", caveats),
+      if (include_secondary_sources) {
+        caveats.push(
+          "NWHikers/Reddit results are lower-signal than WTA (no structured conditions, looser topicality) — treat as leads to read, not extracted fact.",
         );
       }
 
-      // Extraction mode: fetch full pages for the first few reports (the
-      // WTA conditions table + body are far higher-signal than the
-      // listing blurb); the rest extract from title+blurb only.
-      const withConditions: ReportWithConditions[] = await Promise.all(
-        filtered.map(async (r, i): Promise<ReportWithConditions> => {
+      if (!extract_conditions) {
+        return payloadResponse(
+          ok({ reports: filtered, query_used: query }, sources, "medium", caveats),
+        );
+      }
+
+      // Extraction mode: fetch full pages for the first few WTA reports
+      // (the WTA conditions table + body are far higher-signal than the
+      // listing blurb); everything else extracts from title+blurb only.
+      let wtaDetailBudget = DETAIL_FETCH_LIMIT;
+      const withConditions: MergedReport[] = await Promise.all(
+        filtered.map(async (r): Promise<MergedReport> => {
           let text = [r.title, r.conditions_blurb].filter(Boolean).join("\n");
           let extractionSource: "detail" | "blurb" = "blurb";
-          if (i < DETAIL_FETCH_LIMIT) {
+          if (r.source === "wta" && wtaDetailBudget > 0) {
+            wtaDetailBudget--;
             try {
               const detail = await getTripReport(env, r.url);
               if (detail) {
@@ -181,7 +269,7 @@ export function registerTripReportTools(server: McpServer, env: Env): void {
             conditions_rollup: rollupConditions(extractions),
             extraction: { method: "heuristic", confidence: "low" as const },
           },
-          [source],
+          sources,
           "medium",
           caveats,
         ),


### PR DESCRIPTION
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80
Closes #81
Closes #82
Closes #83
Closes #84
Closes #85

One commit per issue (twelve commits; #81 lands as two per its own sequencing note):

**Conventions & plumbing**
- **#77** — `DESIGN.md` records the Aug 2026 design-interview principles; audit filed follow-up #86 (get_weather NWS periods aren't chart-ready).
- **#75** — Full multi-way/relation trail geometry: deterministic endpoint-proximity chaining (30 m joins, ≤50 m recorded gap bridges, 30 mi cap), relation-first with shortest-complete-relation selection, caveats distinguishing clean chain / bridged gaps / OSM-coverage-may-end. Cache keys versioned.
- **#76** — `get_trail_weather_profile` gains `time_series` (per-sample hourly arrays from data already being fetched), `eta_mode` (evaluate each point at estimated arrival time; per-point `eta` clocks), and rule-based `gear_flags` with documented thresholds and a heuristics disclaimer. Backward compatible.

**New API-backed tools**
- **#78** — `get_river_conditions`: USGS NWIS current + 7-day chart-ready discharge series + percentile `flow_context`; curated crossing→gauge maps for 8 areas (all 10 gauge ids verified live); bbox discovery fallback with unverified-relevance caveat; never judges a crossing safe.
- **#79** — `get_avalanche_forecast`: NWAC via avalanche.org v2 (danger by elevation band as chart rows, problems, discussion); name-based zone mapping for all 12 areas + polygon point lookup; explicit off-season status (verified against current August state).

**New curated tools** (data-only registries, low/medium confidence, staleness caveats)
- **#80** — `get_seasonal_timing`: melt-out/larch/wildflower/bug/crossing-peak/crowd windows, all 12 areas seeded, month filter.
- **#82** — `get_approach_info`: last gas/real-gear/supplies/food, cell coverage, road notes per corridor; Mountain Loop entry encodes the Everett-last-gear + hardware-store-rain-gear lessons.
- **#83** — `get_permit_strategy`: ordered acquisition paths (Enchantments: 5 paths incl. day-use and off-season), walk-up/cancellation beta, optional live recreation.gov availability probe with defensive grid summarization.
- **#84** — `get_camp_water_beta`: regulation models, named camps, sourced fire/food rules (URL-cited, test-enforced), late-season water reliability; OSM campsite layer.
- **#85** — `get_access_status`: per-road status via WSDOT feed / NPS alerts / USFS alerts-page mention scan ("unknown" explicitly ≠ open), static or OSRM-live drive times with impersonal origin param; supersedes get_conditions' usfs_alerts stub.

**Trip-report intelligence**
- **#81A** — opt-in heuristic condition extraction (snow+snow line, blowdowns, road, bugs+severity, water, crowding) with per-claim-attributed rollups; never fabricates (tested); first 5 WTA reports extract from full pages.
- **#81B** — NWHikers + Reddit as capped, labeled secondary sources. Honest note: live probes show Reddit 403s datacenter IPs and NWHikers fronts a JS challenge — both degrade to named caveats; if production confirms permanent blocks, the fix is a Reddit OAuth app (interface already shaped for it).

Gate: `pnpm -r type-check` + `pnpm -r test` pass (36 new unit tests, incl. registry-coverage acceptance tests for all curated datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq

---
_Generated by [Claude Code](https://claude.ai/code/session_011aiNtKkBqgBcow92Z2AShq)_